### PR TITLE
[use-cyclopts] Use cyclopts instead of typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ saber memory list
 Start an interactive session:
 
 ```bash
-saber query
+saber
 ```
 
 > You can also add memories in an interactive session by starting your message with the `#` sign
@@ -115,7 +115,7 @@ saber query
 Execute a single natural language query:
 
 ```bash
-saber query "show me all users created this month"
+saber "show me all users created this month"
 ```
 
 ### Database Selection
@@ -123,33 +123,39 @@ saber query "show me all users created this month"
 Use a specific database connection:
 
 ```bash
-# Use named database from config
-saber query -d mydb "count all orders"
+# Interactive mode with specific database
+saber -d mydb
+
+# Single query with specific database
+saber -d mydb "count all orders"
 ```
 
 ## Examples
 
 ```bash
 # Show database schema
-saber query "what tables are in my database?"
+saber "what tables are in my database?"
 
 # Count records
-saber query "how many active users do we have?"
+saber "how many active users do we have?"
 
 # Complex queries with joins
-saber query "show me orders with customer details for this week"
+saber "show me orders with customer details for this week"
 
 # Aggregations
-saber query "what's the total revenue by product category?"
+saber "what's the total revenue by product category?"
 
 # Date filtering
-saber query "list users who haven't logged in for 30 days"
+saber "list users who haven't logged in for 30 days"
 
 # Data exploration
-saber query "show me the distribution of customer ages"
+saber "show me the distribution of customer ages"
 
 # Business analytics
-saber query "which products had the highest sales growth last quarter?"
+saber "which products had the highest sales growth last quarter?"
+
+# Start interactive mode
+saber
 ```
 
 ## MCP Server Integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,5 @@ packages = ["src/sqlsaber"]
 [project.scripts]
 sqlsaber = "sqlsaber.cli.commands:main"
 saber = "sqlsaber.cli.commands:main"
-sql = "sqlsaber.cli.commands:main"
 sqlsaber-mcp = "sqlsaber.mcp.mcp:main"
 saber-mcp = "sqlsaber.mcp.mcp:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "asyncpg>=0.30.0",
-    "typer>=0.16.0",
     "rich>=13.7.0",
     "anthropic>=0.54.0",
     "keyring>=25.6.0",
@@ -18,6 +17,7 @@ dependencies = [
     "pandas>=2.0.0",
     "fastmcp>=2.9.0",
     "uniplot>=0.21.2",
+    "cyclopts>=3.22.1",
 ]
 
 [tool.uv]

--- a/src/sqlsaber/cli/auth.py
+++ b/src/sqlsaber/cli/auth.py
@@ -1,7 +1,7 @@
 """Authentication CLI commands."""
 
 import questionary
-import typer
+import cyclopts
 from rich.console import Console
 
 from sqlsaber.config.auth import AuthConfigManager, AuthMethod
@@ -12,15 +12,14 @@ console = Console()
 config_manager = AuthConfigManager()
 
 # Create the authentication management CLI app
-auth_app = typer.Typer(
+auth_app = cyclopts.App(
     name="auth",
     help="Manage authentication configuration",
-    add_completion=True,
 )
 
 
-@auth_app.command("setup")
-def setup_auth():
+@auth_app.command
+def setup():
     """Configure authentication method for SQLSaber."""
     console.print("\n[bold]SQLSaber Authentication Setup[/bold]\n")
 
@@ -79,8 +78,8 @@ def setup_auth():
     )
 
 
-@auth_app.command("status")
-def show_auth_status():
+@auth_app.command
+def status():
     """Show current authentication configuration."""
     auth_method = config_manager.get_auth_method()
 
@@ -104,8 +103,8 @@ def show_auth_status():
                 console.print("[yellow]OAuth token missing or expired[/yellow]")
 
 
-@auth_app.command("reset")
-def reset_auth():
+@auth_app.command
+def reset():
     """Reset authentication configuration."""
     if not config_manager.has_auth_configured():
         console.print("[yellow]No authentication configuration to reset.[/yellow]")
@@ -137,6 +136,6 @@ def reset_auth():
         console.print("Reset cancelled.")
 
 
-def create_auth_app() -> typer.Typer:
+def create_auth_app() -> cyclopts.App:
     """Return the authentication management CLI app."""
     return auth_app

--- a/src/sqlsaber/cli/models.py
+++ b/src/sqlsaber/cli/models.py
@@ -1,10 +1,11 @@
 """Model management CLI commands."""
 
 import asyncio
+import sys
 
 import httpx
 import questionary
-import typer
+import cyclopts
 from rich.console import Console
 from rich.table import Table
 
@@ -14,10 +15,9 @@ from sqlsaber.config.settings import Config
 console = Console()
 
 # Create the model management CLI app
-models_app = typer.Typer(
+models_app = cyclopts.App(
     name="models",
     help="Select and manage models",
-    add_completion=True,
 )
 
 
@@ -96,8 +96,8 @@ class ModelManager:
 model_manager = ModelManager()
 
 
-@models_app.command("list")
-def list_models():
+@models_app.command
+def list():
     """List available AI models."""
 
     async def fetch_and_display():
@@ -146,8 +146,8 @@ def list_models():
     asyncio.run(fetch_and_display())
 
 
-@models_app.command("set")
-def set_model():
+@models_app.command
+def set():
     """Set the AI model to use."""
 
     async def interactive_set():
@@ -156,7 +156,7 @@ def set_model():
 
         if not models:
             console.print("[red]Failed to fetch models. Cannot set model.[/red]")
-            raise typer.Exit(1)
+            sys.exit(1)
 
         # Create choices for questionary
         choices = []
@@ -190,22 +190,22 @@ def set_model():
                 console.print(f"[green]✓ Model set to: {selected_model}[/green]")
             else:
                 console.print("[red]✗ Failed to set model[/red]")
-                raise typer.Exit(1)
+                sys.exit(1)
         else:
             console.print("[yellow]Operation cancelled[/yellow]")
 
     asyncio.run(interactive_set())
 
 
-@models_app.command("current")
-def current_model():
+@models_app.command
+def current():
     """Show the currently configured model."""
     current = model_manager.get_current_model()
     console.print(f"Current model: [cyan]{current}[/cyan]")
 
 
-@models_app.command("reset")
-def reset_model():
+@models_app.command
+def reset():
     """Reset to the default model."""
 
     async def interactive_reset():
@@ -218,13 +218,13 @@ def reset_model():
                 )
             else:
                 console.print("[red]✗ Failed to reset model[/red]")
-                raise typer.Exit(1)
+                sys.exit(1)
         else:
             console.print("[yellow]Operation cancelled[/yellow]")
 
     asyncio.run(interactive_reset())
 
 
-def create_models_app() -> typer.Typer:
+def create_models_app() -> cyclopts.App:
     """Return the model management CLI app."""
     return models_app

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815 },
+]
+
+[[package]]
 name = "authlib"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -202,12 +211,45 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "3.22.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/d2/3f81aa0852d0a71b8d7614f355cf72655ea26f33dd1ddc01e01ddb41a0d0/cyclopts-3.22.1.tar.gz", hash = "sha256:4f42c9427f1e31f598c8416d88e37040ad783a177fa496541e53a8650bed1261", size = 74470 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/f2/0155fe8b06890aec0493ee5862aef2635729997da470d2fe0fb18951131e/cyclopts-3.22.1-py3-none-any.whl", hash = "sha256:1ce307fd835f93dcd5dd5e77fff1d91c9a092bc0126f846b24e9e4740b6ea3c3", size = 84534 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/12/9c22a58c0b1e29271051222d8906257616da84135af9ed167c9e28f85cb3/docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e", size = 26565 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637", size = 36533 },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408 },
 ]
 
 [[package]]
@@ -797,6 +839,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/69/5514c3a87b5f10f09a34bb011bc0927bc12c596c8dae5915604e71abc386/rich_rst-1.3.1.tar.gz", hash = "sha256:fad46e3ba42785ea8c1785e2ceaa56e0ffa32dbe5410dec432f37e4107c4f383", size = 13839 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/bc/cc4e3dbc5e7992398dcb7a8eda0cbcf4fb792a0cdb93f857b478bf3cf884/rich_rst-1.3.1-py3-none-any.whl", hash = "sha256:498a74e3896507ab04492d326e794c3ef76e7cda078703aa592d1853d91098c1", size = 11621 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -870,6 +925,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anthropic" },
     { name = "asyncpg" },
+    { name = "cyclopts" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "keyring" },
@@ -877,7 +933,6 @@ dependencies = [
     { name = "platformdirs" },
     { name = "questionary" },
     { name = "rich" },
-    { name = "typer" },
     { name = "uniplot" },
 ]
 
@@ -894,6 +949,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "anthropic", specifier = ">=0.54.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "cyclopts", specifier = ">=3.22.1" },
     { name = "fastmcp", specifier = ">=2.9.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "keyring", specifier = ">=25.6.0" },
@@ -901,7 +957,6 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "questionary", specifier = ">=2.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "typer", specifier = ">=0.16.0" },
     { name = "uniplot", specifier = ">=0.21.2" },
 ]
 


### PR DESCRIPTION
- Use cyclopts instead of typer
- make `saber` the default command to start intearctive mode instead of `saber query`
- remove `sql` as the console script: only `sqlsaber` and `saber`