### PR TITLE
[use-connection-string] Extend `-d` flag and unified connection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to SQLSaber will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2025-07-26
+
+### Added
+
+- Database resolver abstraction for unified connection handling
+  - Extended `-d` flag to accept PostgreSQL and MySQL connection strings (e.g., `postgresql://user:pass@host:5432/db`)
+  - Support for direct connection strings alongside existing file path and configured database support
+  - Examples: `saber -d "postgresql://user:pass@host:5432/db" "show users"`
+
+## [0.12.0] - 2025-07-23
+
+### Added
+
+- Add support for ad-hoc SQLite files via `--database`/`-d` flag
+
 ## [0.11.0] - 2025-07-09
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlsaber"
-version = "0.12.0"
+version = "0.13.0"
 description = "SQLSaber - Agentic SQL assistant like Claude Code"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/sqlsaber/database/resolver.py
+++ b/src/sqlsaber/database/resolver.py
@@ -1,0 +1,96 @@
+"""Database connection resolution from CLI input."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
+
+
+class DatabaseResolutionError(Exception):
+    """Exception raised when database resolution fails."""
+
+    pass
+
+
+@dataclass
+class ResolvedDatabase:
+    """Result of database resolution containing canonical connection info."""
+
+    name: str  # Human-readable name for display/logging
+    connection_string: str  # Canonical connection string for DatabaseConnection factory
+
+
+SUPPORTED_SCHEMES = {"postgresql", "mysql", "sqlite", "csv"}
+
+
+def _is_connection_string(s: str) -> bool:
+    """Check if string looks like a connection string with supported scheme."""
+    try:
+        scheme = urlparse(s).scheme
+        return scheme in SUPPORTED_SCHEMES
+    except Exception:
+        return False
+
+
+def resolve_database(
+    spec: str | None, config_mgr: DatabaseConfigManager
+) -> ResolvedDatabase:
+    """Turn user CLI input into resolved database connection info.
+
+    Args:
+        spec: User input - None (default), configured name, connection string, or file path
+        config_mgr: Database configuration manager for looking up configured connections
+
+    Returns:
+        ResolvedDatabase with name and canonical connection string
+
+    Raises:
+        DatabaseResolutionError: If the spec cannot be resolved to a valid database connection
+    """
+    if spec is None:
+        db_cfg = config_mgr.get_default_database()
+        if not db_cfg:
+            raise DatabaseResolutionError(
+                "No database connections configured. "
+                "Use 'sqlsaber db add <name>' to add one."
+            )
+        return ResolvedDatabase(
+            name=db_cfg.name,
+            connection_string=db_cfg.to_connection_string(),
+        )
+
+    # 1. Connection string?
+    if _is_connection_string(spec):
+        scheme = urlparse(spec).scheme
+        if scheme in {"postgresql", "mysql"}:
+            db_name = urlparse(spec).path.lstrip("/") or "database"
+        elif scheme in {"sqlite", "csv"}:
+            db_name = Path(urlparse(spec).path).stem
+        else:  # should not happen because of SUPPORTED_SCHEMES
+            db_name = "database"
+        return ResolvedDatabase(name=db_name, connection_string=spec)
+
+    # 2. Raw file path?
+    path = Path(spec).expanduser().resolve()
+    if path.suffix.lower() == ".csv":
+        if not path.exists():
+            raise DatabaseResolutionError(f"CSV file '{spec}' not found.")
+        return ResolvedDatabase(name=path.stem, connection_string=f"csv:///{path}")
+    if path.suffix.lower() in {".db", ".sqlite", ".sqlite3"}:
+        if not path.exists():
+            raise DatabaseResolutionError(f"SQLite file '{spec}' not found.")
+        return ResolvedDatabase(name=path.stem, connection_string=f"sqlite:///{path}")
+
+    # 3. Must be a configured name
+    db_cfg: DatabaseConfig | None = config_mgr.get_database(spec)
+    if not db_cfg:
+        raise DatabaseResolutionError(
+            f"Database connection '{spec}' not found. "
+            "Use 'sqlsaber db list' to see available connections."
+        )
+    return ResolvedDatabase(
+        name=db_cfg.name, connection_string=db_cfg.to_connection_string()
+    )

--- a/tests/test_database_resolver.py
+++ b/tests/test_database_resolver.py
@@ -1,0 +1,126 @@
+"""Tests for database resolver functionality."""
+
+import pytest
+from unittest.mock import Mock, patch
+from sqlsaber.database.resolver import resolve_database, DatabaseResolutionError
+from sqlsaber.config.database import DatabaseConfig
+
+
+class TestDatabaseResolver:
+    """Test cases for database resolution logic."""
+
+    def test_resolve_connection_strings(self):
+        """Test that connection strings are handled correctly."""
+        config_mgr = Mock()
+
+        # PostgreSQL connection string
+        result = resolve_database("postgresql://user:pass@host:5432/testdb", config_mgr)
+        assert result.name == "testdb"
+        assert result.connection_string == "postgresql://user:pass@host:5432/testdb"
+
+        # MySQL connection string
+        result = resolve_database("mysql://user:pass@host:3306/mydb", config_mgr)
+        assert result.name == "mydb"
+        assert result.connection_string == "mysql://user:pass@host:3306/mydb"
+
+        # SQLite connection string
+        result = resolve_database("sqlite:///test.db", config_mgr)
+        assert result.name == "test"
+        assert result.connection_string == "sqlite:///test.db"
+
+        # CSV connection string
+        result = resolve_database("csv:///data.csv", config_mgr)
+        assert result.name == "data"
+        assert result.connection_string == "csv:///data.csv"
+
+    @patch("pathlib.Path.exists")
+    def test_resolve_file_paths(self, mock_exists):
+        """Test that file paths are resolved correctly."""
+        mock_exists.return_value = True
+        config_mgr = Mock()
+
+        # CSV file
+        result = resolve_database("data.csv", config_mgr)
+        assert result.name == "data"
+        assert result.connection_string.startswith("csv:///")
+        assert result.connection_string.endswith("data.csv")
+
+        # SQLite file
+        result = resolve_database("test.db", config_mgr)
+        assert result.name == "test"
+        assert result.connection_string.startswith("sqlite:///")
+        assert result.connection_string.endswith("test.db")
+
+    @patch("pathlib.Path.exists")
+    def test_file_not_found_error(self, mock_exists):
+        """Test that missing files raise appropriate errors."""
+        mock_exists.return_value = False
+        config_mgr = Mock()
+
+        with pytest.raises(
+            DatabaseResolutionError, match="CSV file 'missing.csv' not found"
+        ):
+            resolve_database("missing.csv", config_mgr)
+
+        with pytest.raises(
+            DatabaseResolutionError, match="SQLite file 'missing.db' not found"
+        ):
+            resolve_database("missing.db", config_mgr)
+
+    def test_resolve_configured_database(self):
+        """Test that configured database names are resolved."""
+        config_mgr = Mock()
+        db_config = Mock(spec=DatabaseConfig)
+        db_config.name = "mydb"
+        db_config.to_connection_string.return_value = "postgresql://localhost:5432/mydb"
+        config_mgr.get_database.return_value = db_config
+
+        result = resolve_database("mydb", config_mgr)
+        assert result.name == "mydb"
+        assert result.connection_string == "postgresql://localhost:5432/mydb"
+
+    def test_configured_database_not_found(self):
+        """Test error when configured database doesn't exist."""
+        config_mgr = Mock()
+        config_mgr.get_database.return_value = None
+
+        with pytest.raises(
+            DatabaseResolutionError, match="Database connection 'unknown' not found"
+        ):
+            resolve_database("unknown", config_mgr)
+
+    def test_resolve_default_database(self):
+        """Test that None resolves to default database."""
+        config_mgr = Mock()
+        db_config = Mock(spec=DatabaseConfig)
+        db_config.name = "default"
+        db_config.to_connection_string.return_value = (
+            "postgresql://localhost:5432/default"
+        )
+        config_mgr.get_default_database.return_value = db_config
+
+        result = resolve_database(None, config_mgr)
+        assert result.name == "default"
+        assert result.connection_string == "postgresql://localhost:5432/default"
+
+    def test_no_default_database_error(self):
+        """Test error when no default database is configured."""
+        config_mgr = Mock()
+        config_mgr.get_default_database.return_value = None
+
+        with pytest.raises(
+            DatabaseResolutionError, match="No database connections configured"
+        ):
+            resolve_database(None, config_mgr)
+
+    def test_connection_string_edge_cases(self):
+        """Test edge cases in connection string parsing."""
+        config_mgr = Mock()
+
+        # PostgreSQL without database name
+        result = resolve_database("postgresql://user:pass@host:5432/", config_mgr)
+        assert result.name == "database"  # fallback name
+
+        # PostgreSQL with no path at all
+        result = resolve_database("postgresql://user:pass@host:5432", config_mgr)
+        assert result.name == "database"  # fallback name

--- a/uv.lock
+++ b/uv.lock
@@ -918,7 +918,7 @@ wheels = [
 
 [[package]]
 name = "sqlsaber"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomysql" },


### PR DESCRIPTION
- Database resolver abstraction for unified connection handling
  - Extended `-d` flag to accept PostgreSQL and MySQL connection strings (e.g., `postgresql://user:pass@host:5432/db`)
  - Support for direct connection strings alongside existing file path and configured database support
  - Examples: `saber -d "postgresql://user:pass@host:5432/db" "show users"`
