### PR TITLE
Fix broken /docs link

### DIFF
--- a/docs/src/components/Hero.svelte
+++ b/docs/src/components/Hero.svelte
@@ -28,7 +28,7 @@
       <Button
         size="lg"
         class="bg-black text-white hover:bg-gray-800 px-8 py-4 text-lg font-medium"
-        href="/docs"
+        href="https://github.com/SarthakJariwala/sqlsaber?tab=readme-ov-file#configuration"
       >
         Get started
       </Button>


### PR DESCRIPTION
Fixes # 18

Updated the `/docs` link in the Hero component to point directly to the GitHub README configuration section.

🤖 Generated with [Claude Code](https://claude.ai/code)