### PR TITLE
Centralized provider definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to SQLsaber will be documented in this file.
 
 - Migrated to Pydantic-AI agent runtime with model-agnostic interfaces
 - Added multi-provider model support: Anthropic, OpenAI, Google, Groq, Mistral, Cohere, Hugging Face
+- Provider registry tests to ensure invariants and alias normalization
 
 ### Changed
 
@@ -17,6 +18,8 @@ All notable changes to SQLsaber will be documented in this file.
   - Removes API keys from OS credential store for the selected provider
   - For Anthropic, also detects and removes OAuth tokens
   - Offers optional prompt to unset global auth method when Anthropic OAuth is removed
+- Centralized provider definitions in `sqlsaber.config.providers` and refactored CLI, config, and agent code to use the registry (single source of truth)
+- Normalized provider aliases (e.g., `google-gla` → `google`) for consistent behavior across modules
 
 ### Removed
 

--- a/src/sqlsaber/cli/models.py
+++ b/src/sqlsaber/cli/models.py
@@ -9,6 +9,7 @@ import questionary
 from rich.console import Console
 from rich.table import Table
 
+from sqlsaber.config import providers
 from sqlsaber.config.settings import Config
 
 # Global instances for CLI commands
@@ -26,15 +27,8 @@ class ModelManager:
 
     DEFAULT_MODEL = "anthropic:claude-sonnet-4-20250514"
     MODELS_API_URL = "https://models.dev/api.json"
-    SUPPORTED_PROVIDERS = [
-        "anthropic",
-        "openai",
-        "google",
-        "groq",
-        "mistral",
-        "cohere",
-        "huggingface",
-    ]
+    # Providers come from central registry
+    SUPPORTED_PROVIDERS = providers.all_keys()
 
     async def fetch_available_models(
         self, providers: list[str] | None = None

--- a/src/sqlsaber/config/api_keys.py
+++ b/src/sqlsaber/config/api_keys.py
@@ -6,6 +6,8 @@ import os
 import keyring
 from rich.console import Console
 
+from sqlsaber.config import providers
+
 console = Console()
 
 
@@ -41,16 +43,9 @@ class APIKeyManager:
 
     def _get_env_var_name(self, provider: str) -> str:
         """Get the expected environment variable name for a provider."""
-        mapping = {
-            "openai": "OPENAI_API_KEY",
-            "anthropic": "ANTHROPIC_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "groq": "GROQ_API_KEY",
-            "mistral": "MISTRAL_API_KEY",
-            "cohere": "COHERE_API_KEY",
-            "huggingface": "HUGGINGFACE_API_KEY",
-        }
-        return mapping.get(provider, "AI_API_KEY")
+        # Normalize aliases to canonical provider keys
+        key = providers.canonical(provider) or provider
+        return providers.env_var_name(key)
 
     def _get_service_name(self, provider: str) -> str:
         """Get the keyring service name for a provider."""

--- a/src/sqlsaber/config/providers.py
+++ b/src/sqlsaber/config/providers.py
@@ -1,0 +1,116 @@
+"""Central registry for supported AI providers.
+
+This module defines a single source of truth for providers used across the
+codebase (CLI, config, agents). Update this file to add or modify providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Specification for a provider."""
+
+    key: str
+    env_var: str
+    supports_oauth: bool = False
+    aliases: tuple[str, ...] = ()
+
+
+# Ordered definition -> used for CLI display order
+_PROVIDERS: List[ProviderSpec] = [
+    ProviderSpec(
+        key="anthropic",
+        env_var="ANTHROPIC_API_KEY",
+        supports_oauth=True,
+        aliases=(),
+    ),
+    ProviderSpec(
+        key="openai",
+        env_var="OPENAI_API_KEY",
+        aliases=(),
+    ),
+    ProviderSpec(
+        key="google",
+        env_var="GOOGLE_API_KEY",
+        # Historically some model IDs start with "google-gla"; treat as alias
+        aliases=("google-gla",),
+    ),
+    ProviderSpec(
+        key="groq",
+        env_var="GROQ_API_KEY",
+        aliases=(),
+    ),
+    ProviderSpec(
+        key="mistral",
+        env_var="MISTRAL_API_KEY",
+        aliases=(),
+    ),
+    ProviderSpec(
+        key="cohere",
+        env_var="COHERE_API_KEY",
+        aliases=(),
+    ),
+    ProviderSpec(
+        key="huggingface",
+        env_var="HUGGINGFACE_API_KEY",
+        aliases=(),
+    ),
+]
+
+
+# Fast lookup maps
+_BY_KEY: Dict[str, ProviderSpec] = {p.key: p for p in _PROVIDERS}
+_ALIAS_TO_KEY: Dict[str, str] = {
+    alias: p.key for p in _PROVIDERS for alias in p.aliases
+}
+
+
+def all_keys() -> List[str]:
+    """Return provider keys in display order."""
+    return [p.key for p in _PROVIDERS]
+
+
+def env_var_name(key: str) -> str:
+    """Return the expected environment variable for a provider.
+
+    Falls back to a generic name if the provider is unknown.
+    """
+    spec = _BY_KEY.get(key)
+    return spec.env_var if spec else "AI_API_KEY"
+
+
+def supports_oauth(key: str) -> bool:
+    """Return True if the provider supports OAuth in SQLsaber."""
+    spec = _BY_KEY.get(key)
+    return bool(spec and spec.supports_oauth)
+
+
+def canonical(key_or_alias: str) -> Optional[str]:
+    """Return the canonical provider key for a provider or alias.
+
+    Returns None if not recognized.
+    """
+    if key_or_alias in _BY_KEY:
+        return key_or_alias
+    return _ALIAS_TO_KEY.get(key_or_alias)
+
+
+def provider_from_model(model_name: str) -> Optional[str]:
+    """Infer the canonical provider key from a model identifier.
+
+    Accepts either "provider:model_id" or a bare provider string. Aliases are
+    normalized to their canonical provider key.
+    """
+    if not model_name:
+        return None
+    provider_raw = model_name.split(":", 1)[0]
+    return canonical(provider_raw)
+
+
+def specs() -> Iterable[ProviderSpec]:
+    """Iterate provider specifications (in display order)."""
+    return tuple(_PROVIDERS)

--- a/tests/test_config/test_providers.py
+++ b/tests/test_config/test_providers.py
@@ -1,0 +1,40 @@
+import pytest
+
+from sqlsaber.config import providers
+
+
+def test_all_keys_contains_expected_providers():
+    keys = providers.all_keys()
+    # Stable core set
+    for k in [
+        "anthropic",
+        "openai",
+        "google",
+        "groq",
+        "mistral",
+        "cohere",
+        "huggingface",
+    ]:
+        assert k in keys
+
+
+def test_env_var_name_mapping():
+    assert providers.env_var_name("openai") == "OPENAI_API_KEY"
+    assert providers.env_var_name("anthropic") == "ANTHROPIC_API_KEY"
+    assert providers.env_var_name("unknown") == "AI_API_KEY"
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("anthropic:claude-3", "anthropic"),
+        ("openai:gpt-4o", "openai"),
+        ("google:gemini-1.5-pro", "google"),
+        ("google-gla:gemini-1.5-pro", "google"),
+        ("mistral:large", "mistral"),
+        ("unknown:model", None),
+        ("", None),
+    ],
+)
+def test_provider_from_model(model: str, expected: str | None):
+    assert providers.provider_from_model(model) == expected


### PR DESCRIPTION
Centralized provider definitions in `sqlsaber.config.providers` and refactored CLI, config, and agent code to use the registry (single source of truth)
