### PR TITLE
[fix] Subcomand help visibility for nested apps

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,10 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+#### Fixed
+
+- Subcommand help visibility for nested apps
+
 ---
 
 ### v0.19.0 - 2025-09-09

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -7,6 +7,12 @@ from typing import Annotated
 import cyclopts
 from rich.console import Console
 
+from sqlsaber.cli.auth import create_auth_app
+from sqlsaber.cli.database import create_db_app
+from sqlsaber.cli.memory import create_memory_app
+from sqlsaber.cli.models import create_models_app
+from sqlsaber.cli.threads import create_threads_app
+
 # Lazy imports - only import what's needed for CLI parsing
 from sqlsaber.config.database import DatabaseConfigManager
 
@@ -24,6 +30,11 @@ app = cyclopts.App(
     help="SQLsaber - Open-source agentic SQL assistant for your database",
 )
 
+app.command(create_auth_app(), name="auth")
+app.command(create_db_app(), name="db")
+app.command(create_memory_app(), name="memory")
+app.command(create_models_app(), name="models")
+app.command(create_threads_app(), name="threads")
 
 console = Console()
 config_manager = DatabaseConfigManager()
@@ -193,47 +204,6 @@ def query(
     except CLIError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         sys.exit(e.exit_code)
-
-
-# Use lazy imports for fast CLI startup time
-@app.command(name="auth")
-def auth(*args, **kwargs):
-    """Manage authentication configuration."""
-    from sqlsaber.cli.auth import create_auth_app
-
-    return create_auth_app()(*args, **kwargs)
-
-
-@app.command(name="db")
-def db(*args, **kwargs):
-    """Manage database connections."""
-    from sqlsaber.cli.database import create_db_app
-
-    return create_db_app()(*args, **kwargs)
-
-
-@app.command(name="memory")
-def memory(*args, **kwargs):
-    """Manage database-specific memories."""
-    from sqlsaber.cli.memory import create_memory_app
-
-    return create_memory_app()(*args, **kwargs)
-
-
-@app.command(name="models")
-def models(*args, **kwargs):
-    """Select and manage models."""
-    from sqlsaber.cli.models import create_models_app
-
-    return create_models_app()(*args, **kwargs)
-
-
-@app.command(name="threads")
-def threads(*args, **kwargs):
-    """Manage SQLsaber threads."""
-    from sqlsaber.cli.threads import create_threads_app
-
-    return create_threads_app()(*args, **kwargs)
 
 
 def main():

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from rich.table import Table
 
 from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
-from sqlsaber.database.connection import DatabaseConnection
 
 # Global instances for CLI commands
 console = Console()
@@ -343,6 +342,9 @@ def test(
     """Test a database connection."""
 
     async def test_connection():
+        # Lazy import to keep CLI startup fast
+        from sqlsaber.database.connection import DatabaseConnection
+
         if name:
             db_config = config_manager.get_database(name)
             if not db_config:

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -17,9 +17,9 @@ from rich.console import Console
 from sqlsaber.cli.threads import (
     _human_readable,
     _render_transcript,
-    config_manager,
     create_threads_app,
 )
+from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.threads.storage import Thread, ThreadStorage
 
 
@@ -220,7 +220,7 @@ class TestThreadsCLI:
             ),
         ]
 
-        with patch("sqlsaber.cli.threads.DisplayManager") as mock_dm_class:
+        with patch("sqlsaber.cli.display.DisplayManager") as mock_dm_class:
             mock_dm = MagicMock()
             mock_dm_class.return_value = mock_dm
 
@@ -253,7 +253,7 @@ class TestThreadsCLI:
             ),
         ]
 
-        with patch("sqlsaber.cli.threads.DisplayManager") as mock_dm_class:
+        with patch("sqlsaber.cli.display.DisplayManager") as mock_dm_class:
             mock_dm = MagicMock()
             mock_dm_class.return_value = mock_dm
 
@@ -307,10 +307,14 @@ class TestThreadsCLI:
 
             with (
                 patch("sqlsaber.cli.threads.ThreadStorage", return_value=store),
-                patch("sqlsaber.cli.threads.resolve_database") as mock_resolve,
-                patch("sqlsaber.cli.threads.DatabaseConnection") as mock_db_conn_class,
-                patch("sqlsaber.cli.threads.build_sqlsaber_agent") as mock_build_agent,
-                patch("sqlsaber.cli.threads.InteractiveSession") as mock_session_class,
+                patch("sqlsaber.database.resolver") as mock_resolve,
+                patch("sqlsaber.database.DatabaseConnection") as mock_db_conn_class,
+                patch(
+                    "sqlsaber.agents.pydantic_ai_agent.build_sqlsaber_agent"
+                ) as mock_build_agent,
+                patch(
+                    "sqlsaber.cli.interactive.InteractiveSession"
+                ) as mock_session_class,
             ):
                 # Mock database resolution
                 mock_resolved = MagicMock()
@@ -333,7 +337,7 @@ class TestThreadsCLI:
                 assert resolved_thread == thread
 
                 db_selector = resolved_thread.database_name
-                resolved = mock_resolve(db_selector, config_manager)
+                resolved = mock_resolve(db_selector, DatabaseConfigManager())
                 assert resolved.name == "prod_db"
 
         await mock_resume_run()


### PR DESCRIPTION
- Subcommand help visibility for nested apps: `saber db --help` (and other subcommands) now shows their commands again by registering sub-apps directly with Cyclopts while keeping fast startup via lazy imports.
