### PR TITLE
Query execution timeout

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,14 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+#### Added
+
+- Query timeout protection to prevent runaway queries
+  - 30-second timeout applied to all database operations by default
+  - Both client-side and server-side timeout enforcement where supported (PostgreSQL, MySQL)
+  - Per-query timeout override parameter for edge cases
+  - Automatic rollback of transactions when queries timeout
+
 ### v0.21.0 - 2025-09-15
 
 #### Changed

--- a/tests/test_database/test_timeout.py
+++ b/tests/test_database/test_timeout.py
@@ -1,0 +1,124 @@
+"""Tests for query timeout functionality."""
+
+import asyncio
+
+import pytest
+
+from sqlsaber.database.connection import (
+    DEFAULT_QUERY_TIMEOUT,
+    DatabaseConnection,
+    QueryTimeoutError,
+    SQLiteConnection,
+)
+
+
+class TestQueryTimeout:
+    """Test query timeout functionality."""
+
+    def test_default_query_timeout_constant(self):
+        """Test that the default query timeout constant is defined."""
+        assert DEFAULT_QUERY_TIMEOUT == 30.0
+
+    @pytest.mark.asyncio
+    async def test_database_connection_creation(self):
+        """Test that DatabaseConnection can be created."""
+        connection_string = "sqlite:///:memory:"
+
+        conn = DatabaseConnection(connection_string)
+        assert conn.connection_string == connection_string
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_timeout_fallback_logic(self):
+        """Test timeout fallback: per-query > hardcoded default."""
+        connection_string = "sqlite:///:memory:"
+
+        # Test with no timeout - should use hardcoded default
+        conn1 = SQLiteConnection(connection_string)
+        result1 = await conn1.execute_query("SELECT 1 as test")
+        assert len(result1) == 1
+        await conn1.close()
+
+        # Test with per-query timeout override
+        conn2 = SQLiteConnection(connection_string)
+        result2 = await conn2.execute_query("SELECT 2 as test", timeout=60.0)
+        assert len(result2) == 1
+        await conn2.close()
+
+    @pytest.mark.asyncio
+    async def test_sqlite_timeout_functionality(self):
+        """Test timeout functionality with SQLite in-memory database."""
+        connection_string = "sqlite:///:memory:"
+        timeout = 1.0  # 1 second timeout
+
+        conn = SQLiteConnection(connection_string)
+
+        try:
+            # This query should complete quickly
+            result = await conn.execute_query("SELECT 1 as test", timeout=timeout)
+            assert len(result) == 1
+            assert result[0]["test"] == 1
+
+            # Test with no explicit timeout (uses default)
+            result2 = await conn.execute_query("SELECT 2 as test")
+            assert len(result2) == 1
+            assert result2[0]["test"] == 2
+
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_handling(self):
+        """Test that timeout errors are properly raised with asyncio.TimeoutError."""
+        connection_string = "sqlite:///:memory:"
+
+        conn = SQLiteConnection(connection_string)
+
+        try:
+            # Create a mock query that artificially delays to trigger timeout
+            async def mock_slow_execute_query(query, *args, timeout=None):
+                # Simulate a slow query by sleeping longer than timeout
+                await asyncio.sleep(0.1)  # 100ms, longer than 1ms timeout
+                return [{"result": "should not reach here"}]
+
+            # Replace the execute_query method temporarily
+            conn.execute_query = mock_slow_execute_query
+
+            # This should raise an asyncio.TimeoutError which gets converted to QueryTimeoutError
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(conn.execute_query("SELECT 1"), timeout=0.001)
+
+        finally:
+            await conn.close()
+
+    def test_query_timeout_error_message(self):
+        """Test QueryTimeoutError message formatting."""
+        timeout = 30.5
+        error = QueryTimeoutError(timeout)
+
+        assert str(error) == "Query exceeded timeout of 30.5s"
+        assert error.timeout == 30.5
+
+    @pytest.mark.asyncio
+    async def test_timeout_precedence(self):
+        """Test that query-level timeout overrides hardcoded default."""
+        connection_string = "sqlite:///:memory:"
+        query_timeout = 45.0
+
+        conn = SQLiteConnection(connection_string)
+
+        try:
+            # The query should use the query-specific timeout
+            # We can't easily test the actual timeout without creating a slow query,
+            # but we can verify the parameter is accepted
+            result = await conn.execute_query("SELECT 1 as test", timeout=query_timeout)
+            assert len(result) == 1
+            assert result[0]["test"] == 1
+
+        finally:
+            await conn.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
- Query timeout protection to prevent runaway queries
  - 30-second timeout applied to all database operations by default
  - Both client-side and server-side timeout enforcement where supported (PostgreSQL, MySQL)
  - Per-query timeout override parameter for edge cases
  - Automatic rollback of transactions when queries timeout