### PR TITLE
[display-sql-error] SQL execution errors now display in interactive sessions instead of being silently dropped

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -12,6 +12,7 @@ All notable changes to SQLsaber will be documented here.
 #### Added
 
 - Smoother markdown streaming and prevent duplicate messages
+- SQL execution errors now display in interactive sessions instead of being silently dropped
 
 ### v0.22.0 - 2025-09-15
 

--- a/src/sqlsaber/cli/display.py
+++ b/src/sqlsaber/cli/display.py
@@ -256,6 +256,15 @@ class DisplayManager:
         """Display error message."""
         self.console.print(f"\n[bold red]Error:[/bold red] {error_message}")
 
+    def show_sql_error(self, error_message: str, suggestions: list[str] | None = None):
+        """Display SQL-specific error with optional suggestions."""
+        self.show_newline()
+        self.console.print(f"[bold red]SQL error:[/bold red] {error_message}")
+        if suggestions:
+            self.console.print("[yellow]Hints:[/yellow]")
+            for suggestion in suggestions:
+                self.console.print(f"  • {suggestion}")
+
     def show_processing(self, message: str):
         """Display processing message."""
         self.console.print()  # Add newline

--- a/src/sqlsaber/cli/streaming.py
+++ b/src/sqlsaber/cli/streaming.py
@@ -114,8 +114,14 @@ class StreamingQueryHandler:
                         pass
             elif isinstance(content, dict):
                 data = content
-            if isinstance(data, dict) and data.get("success") and data.get("results"):
-                self.display.show_query_results(data["results"])  # type: ignore[arg-type]
+
+            if isinstance(data, dict):
+                if data.get("success") and data.get("results"):
+                    self.display.show_query_results(data["results"])  # type: ignore[arg-type]
+                elif "error" in data:
+                    self.display.show_sql_error(
+                        data.get("error"), data.get("suggestions")
+                    )
         # Add a blank line after tool output to separate from next segment
         self.display.show_newline()
         # Show status while agent sends a follow-up request to the model

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -131,6 +131,10 @@ def _render_transcript(
                             and data.get("results")
                         ):
                             dm.show_query_results(data["results"])  # type: ignore[arg-type]
+                        elif isinstance(data, dict) and "error" in data:
+                            dm.show_sql_error(
+                                data.get("error"), data.get("suggestions")
+                            )
                         else:
                             console.print(
                                 Panel.fit(


### PR DESCRIPTION
SQL execution errors now display in interactive sessions instead of being silently dropped