### PR TITLE
fix: make final thinking blocks render Markdown

### DIFF
--- a/src/sqlsaber/cli/display.py
+++ b/src/sqlsaber/cli/display.py
@@ -109,7 +109,7 @@ class LiveMarkdownRenderer:
         # Print the complete markdown to scroll-back for permanent reference
         if buf:
             if kind == ThinkingPart:
-                self.console.print(Text(buf, style="dim"))
+                self.console.print(Markdown(buf, style="dim"))
             else:
                 self.console.print(Markdown(buf))
 


### PR DESCRIPTION
Changed line 112 to use Markdown() instead of Text() for consistency
with live thinking block rendering (line 93).

Fixes #47

Generated with [Claude Code](https://claude.ai/code)