### PR TITLE
Enhanced read-only query validation using sqlglot's SQL AST analysis

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -15,6 +15,15 @@ All notable changes to SQLsaber will be documented here.
     - Light themes: `solarized-light`, `vs`
   - Easy theme switching via `SQLSABER_THEME` environment variable or config file
 
+#### Changed
+
+- Enhanced read-only query validation using `sqlglot` AST analysis
+  - Improved security with comprehensive AST-based detection of write operations
+  - Blocks dangerous operations in nested queries, CTEs, and subqueries
+  - Detects dialect-specific dangerous functions (pg_read_file, LOAD_FILE, readfile, etc.)
+  - Prevents SELECT INTO, SELECT FOR UPDATE/SHARE, and multi-statement queries
+  - Dialect-aware LIMIT clause injection for Postgres, MySQL, SQLite, and DuckDB
+
 ### v0.27.0 - 2025-10-01
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "fastmcp>=2.9.0",
     "cyclopts>=3.22.1",
     "prompt-toolkit>3.0.51",
+    "sqlglot[rs]>=27.20.0",
 ]
 
 [tool.uv]

--- a/src/sqlsaber/database/base.py
+++ b/src/sqlsaber/database/base.py
@@ -61,6 +61,12 @@ class BaseDatabaseConnection(ABC):
         self.connection_string = connection_string
         self._pool = None
 
+    @property
+    @abstractmethod
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name for this database."""
+        pass
+
     @abstractmethod
     async def get_pool(self):
         """Get or create connection pool."""

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -58,6 +58,11 @@ class CSVConnection(BaseDatabaseConnection):
 
         self.table_name = Path(self.csv_path).stem or "csv_table"
 
+    @property
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name."""
+        return "duckdb"
+
     async def get_pool(self):
         """CSV connections do not maintain a pool."""
         return None

--- a/src/sqlsaber/database/duckdb.py
+++ b/src/sqlsaber/database/duckdb.py
@@ -52,6 +52,11 @@ class DuckDBConnection(BaseDatabaseConnection):
 
         self.database_path = db_path or ":memory:"
 
+    @property
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name."""
+        return "duckdb"
+
     async def get_pool(self):
         """DuckDB creates connections per query, return database path."""
         return self.database_path

--- a/src/sqlsaber/database/mysql.py
+++ b/src/sqlsaber/database/mysql.py
@@ -23,6 +23,11 @@ class MySQLConnection(BaseDatabaseConnection):
         self._pool: aiomysql.Pool | None = None
         self._parse_connection_string()
 
+    @property
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name."""
+        return "mysql"
+
     def _parse_connection_string(self):
         """Parse MySQL connection string into components."""
         parsed = urlparse(self.connection_string)

--- a/src/sqlsaber/database/postgresql.py
+++ b/src/sqlsaber/database/postgresql.py
@@ -23,6 +23,11 @@ class PostgreSQLConnection(BaseDatabaseConnection):
         self._pool: asyncpg.Pool | None = None
         self._ssl_context = self._create_ssl_context()
 
+    @property
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name."""
+        return "postgres"
+
     def _create_ssl_context(self) -> ssl.SSLContext | None:
         """Create SSL context from connection string parameters."""
         parsed = urlparse(self.connection_string)

--- a/src/sqlsaber/database/sqlite.py
+++ b/src/sqlsaber/database/sqlite.py
@@ -21,6 +21,11 @@ class SQLiteConnection(BaseDatabaseConnection):
         # Extract database path from sqlite:///path format
         self.database_path = connection_string.replace("sqlite:///", "")
 
+    @property
+    def sqlglot_dialect(self) -> str:
+        """Return the sqlglot dialect name."""
+        return "sqlite"
+
     async def get_pool(self):
         """SQLite doesn't use connection pooling, return database path."""
         return self.database_path

--- a/src/sqlsaber/tools/sql_guard.py
+++ b/src/sqlsaber/tools/sql_guard.py
@@ -1,0 +1,225 @@
+"""SQL query validation and security using sqlglot AST analysis."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import ParseError
+
+# Prohibited AST node types that indicate write/mutation operations
+# Only include expression types that exist in sqlglot
+PROHIBITED_NODES = {
+    # DML operations
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Merge,
+    # DDL operations
+    exp.Create,
+    exp.Drop,
+    exp.Alter,
+    exp.TruncateTable,
+    exp.AlterRename,
+    # MySQL specific
+    exp.Replace,
+    # Transaction control
+    exp.Transaction,
+    # Analysis and maintenance
+    exp.Analyze,
+    # Data loading/copying
+    exp.Copy,
+    exp.LoadData,
+    # Session and configuration
+    exp.Set,
+    exp.Use,
+    exp.Pragma,
+    # Security
+    exp.Grant,
+    exp.Revoke,
+    # Database operations
+    exp.Attach,
+    exp.Detach,
+    # Locking and process control
+    exp.Lock,
+    exp.Kill,
+    # Commands
+    exp.Command,
+}
+
+try:
+    # Add optional types that may not exist in all sqlglot versions
+    PROHIBITED_NODES.add(exp.Vacuum)
+except AttributeError:
+    pass
+
+# Dangerous functions by dialect that can read files or execute commands
+DANGEROUS_FUNCTIONS_BY_DIALECT = {
+    "postgres": {
+        "pg_read_file",
+        "pg_read_binary_file",
+        "pg_ls_dir",
+        "pg_stat_file",
+        "pg_logdir_ls",
+        "dblink",
+        "dblink_exec",
+    },
+    "mysql": {
+        "load_file",
+        "sys_eval",
+        "sys_exec",
+    },
+    "sqlite": {
+        "readfile",
+        "writefile",
+    },
+    "tsql": {
+        "xp_cmdshell",
+    },
+}
+
+
+@dataclass
+class GuardResult:
+    """Result of SQL query validation."""
+
+    allowed: bool
+    reason: Optional[str] = None
+    is_select: bool = False
+
+
+def is_select_like(stmt: exp.Expression) -> bool:
+    """Check if statement is a SELECT-like query.
+
+    Handles CTEs (WITH) and set operations (UNION/INTERSECT/EXCEPT).
+    """
+    root = stmt
+    # WITH wraps another statement
+    if isinstance(root, exp.With):
+        root = root.this
+    return isinstance(root, (exp.Select, exp.Union, exp.Except, exp.Intersect))
+
+
+def has_prohibited_nodes(stmt: exp.Expression) -> Optional[str]:
+    """Walk AST to find any prohibited operations.
+
+    Checks for:
+    - Write operations (INSERT/UPDATE/DELETE/etc)
+    - DDL operations (CREATE/DROP/ALTER/etc)
+    - SELECT INTO
+    - Locking clauses (FOR UPDATE/FOR SHARE)
+    """
+    for node in stmt.walk():
+        # Check prohibited node types
+        if isinstance(node, tuple(PROHIBITED_NODES)):
+            return f"Prohibited operation: {type(node).__name__}"
+
+        # Block SELECT INTO (Postgres-style table creation)
+        if isinstance(node, exp.Select) and node.args.get("into"):
+            return "SELECT INTO is not allowed"
+
+        # Block locking clauses (FOR UPDATE/FOR SHARE)
+        if isinstance(node, exp.Select):
+            locks = node.args.get("locks")
+            if locks:
+                return "SELECT with locking clause (FOR UPDATE/SHARE) is not allowed"
+
+    return None
+
+
+def has_dangerous_functions(stmt: exp.Expression, dialect: str) -> Optional[str]:
+    """Check for dangerous functions that can read files or execute commands."""
+    deny_set = DANGEROUS_FUNCTIONS_BY_DIALECT.get(dialect, set())
+    if not deny_set:
+        return None
+
+    deny_lower = {f.lower() for f in deny_set}
+
+    for fn in stmt.find_all(exp.Func):
+        name = fn.name
+        if name and name.lower() in deny_lower:
+            return f"Use of dangerous function '{name}' is not allowed"
+
+    return None
+
+
+def validate_read_only(sql: str, dialect: str = "ansi") -> GuardResult:
+    """Validate that SQL query is read-only using AST analysis.
+
+    Args:
+        sql: SQL query to validate
+        dialect: SQL dialect (postgres, mysql, sqlite, tsql, etc.)
+
+    Returns:
+        GuardResult with validation outcome
+    """
+    try:
+        statements = sqlglot.parse(sql, read=dialect)
+    except ParseError as e:
+        return GuardResult(False, f"Unable to parse query safely: {e}")
+    except Exception as e:
+        return GuardResult(False, f"Error parsing query: {e}")
+
+    # Only allow single statements
+    if len(statements) != 1:
+        return GuardResult(
+            False,
+            f"Only single SELECT statements are allowed (got {len(statements)} statements)",
+        )
+
+    stmt = statements[0]
+
+    # Must be a SELECT-like statement
+    if not is_select_like(stmt):
+        return GuardResult(False, "Only SELECT-like statements are allowed")
+
+    # Check for prohibited operations in the AST
+    reason = has_prohibited_nodes(stmt)
+    if reason:
+        return GuardResult(False, reason)
+
+    # Check for dangerous functions
+    reason = has_dangerous_functions(stmt, dialect)
+    if reason:
+        return GuardResult(False, reason)
+
+    return GuardResult(True, None, is_select=True)
+
+
+def add_limit(sql: str, dialect: str = "ansi", limit: int = 100) -> str:
+    """Add LIMIT clause to query if not already present.
+
+    Args:
+        sql: SQL query
+        dialect: SQL dialect for proper rendering
+        limit: Maximum number of rows to return
+
+    Returns:
+        SQL with LIMIT clause added (or original if LIMIT already exists)
+    """
+    try:
+        statements = sqlglot.parse(sql, read=dialect)
+        if len(statements) != 1:
+            return sql
+
+        stmt = statements[0]
+
+        # Check if LIMIT/TOP/FETCH already exists
+        has_limit = any(
+            isinstance(n, (exp.Limit, exp.Top, exp.Fetch)) for n in stmt.walk()
+        )
+        if has_limit:
+            return stmt.sql(dialect=dialect)
+
+        # Add LIMIT - sqlglot will render appropriately for dialect
+        # (LIMIT for most, TOP for SQL Server, FETCH FIRST for Oracle)
+        stmt = stmt.limit(limit)
+        return stmt.sql(dialect=dialect)
+
+    except Exception:
+        # If parsing/transformation fails, fall back to simple string append
+        # This maintains backward compatibility
+        sql_upper = sql.strip().upper()
+        if "LIMIT" not in sql_upper:
+            return f"{sql.rstrip(';')} LIMIT {limit};"
+        return sql

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -154,7 +154,7 @@ class TestThreadsCLI:
                     show("nonexistent-thread")
 
                 mock_console.print.assert_called_with(
-                "[error]Thread not found:[/error] nonexistent-thread"
+                    "[error]Thread not found:[/error] nonexistent-thread"
                 )
 
     def test_show_thread_found(self, sample_threads, sample_messages):

--- a/tests/test_tools/test_sql_guard.py
+++ b/tests/test_tools/test_sql_guard.py
@@ -1,0 +1,314 @@
+"""Tests for SQL query validation and security."""
+
+from sqlsaber.tools.sql_guard import add_limit, validate_read_only
+
+
+class TestValidateReadOnly:
+    """Tests for read-only query validation."""
+
+    def test_simple_select_allowed(self):
+        """Simple SELECT queries should be allowed."""
+        result = validate_read_only("SELECT * FROM users", "postgres")
+        assert result.allowed
+        assert result.is_select
+
+    def test_select_with_where_allowed(self):
+        """SELECT with WHERE clause should be allowed."""
+        result = validate_read_only(
+            "SELECT id, name FROM users WHERE age > 18", "postgres"
+        )
+        assert result.allowed
+        assert result.is_select
+
+    def test_select_with_joins_allowed(self):
+        """SELECT with JOINs should be allowed."""
+        query = """
+        SELECT u.id, u.name, o.total
+        FROM users u
+        JOIN orders o ON u.id = o.user_id
+        WHERE o.status = 'completed'
+        """
+        result = validate_read_only(query, "postgres")
+        assert result.allowed
+        assert result.is_select
+
+    def test_select_with_subquery_allowed(self):
+        """SELECT with subqueries should be allowed."""
+        query = """
+        SELECT * FROM users
+        WHERE id IN (SELECT user_id FROM orders WHERE total > 100)
+        """
+        result = validate_read_only(query, "postgres")
+        assert result.allowed
+        assert result.is_select
+
+    def test_select_with_cte_allowed(self):
+        """SELECT with CTEs should be allowed."""
+        query = """
+        WITH high_value_users AS (
+            SELECT user_id FROM orders GROUP BY user_id HAVING SUM(total) > 1000
+        )
+        SELECT * FROM users WHERE id IN (SELECT user_id FROM high_value_users)
+        """
+        result = validate_read_only(query, "postgres")
+        assert result.allowed
+        assert result.is_select
+
+    def test_union_queries_allowed(self):
+        """UNION queries should be allowed."""
+        query = """
+        SELECT name FROM users WHERE active = true
+        UNION
+        SELECT name FROM archived_users WHERE archived_date > '2024-01-01'
+        """
+        result = validate_read_only(query, "postgres")
+        assert result.allowed
+
+    def test_insert_blocked(self):
+        """INSERT queries should be blocked."""
+        result = validate_read_only(
+            "INSERT INTO users (name, email) VALUES ('John', 'john@example.com')",
+            "postgres",
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_update_blocked(self):
+        """UPDATE queries should be blocked."""
+        result = validate_read_only(
+            "UPDATE users SET name = 'Jane' WHERE id = 1", "postgres"
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_delete_blocked(self):
+        """DELETE queries should be blocked."""
+        result = validate_read_only("DELETE FROM users WHERE id = 1", "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_drop_blocked(self):
+        """DROP queries should be blocked."""
+        result = validate_read_only("DROP TABLE users", "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_create_table_blocked(self):
+        """CREATE TABLE queries should be blocked."""
+        result = validate_read_only(
+            "CREATE TABLE new_users (id INT, name VARCHAR(100))", "postgres"
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_alter_table_blocked(self):
+        """ALTER TABLE queries should be blocked."""
+        result = validate_read_only(
+            "ALTER TABLE users ADD COLUMN phone VARCHAR(20)", "postgres"
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_truncate_blocked(self):
+        """TRUNCATE queries should be blocked."""
+        result = validate_read_only("TRUNCATE TABLE users", "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_cte_with_insert_blocked(self):
+        """CTEs with INSERT should be blocked."""
+        query = """
+        WITH new_users AS (
+            INSERT INTO users (name) VALUES ('John') RETURNING id
+        )
+        SELECT * FROM new_users
+        """
+        result = validate_read_only(query, "postgres")
+        assert not result.allowed
+        assert "Prohibited operation" in result.reason
+
+    def test_cte_with_update_blocked(self):
+        """CTEs with UPDATE should be blocked."""
+        query = """
+        WITH updated AS (
+            UPDATE users SET active = false WHERE id = 1 RETURNING id
+        )
+        SELECT * FROM updated
+        """
+        result = validate_read_only(query, "postgres")
+        assert not result.allowed
+        assert "Prohibited operation" in result.reason
+
+    def test_cte_with_delete_blocked(self):
+        """CTEs with DELETE should be blocked."""
+        query = """
+        WITH deleted AS (
+            DELETE FROM users WHERE id = 1 RETURNING id
+        )
+        SELECT * FROM deleted
+        """
+        result = validate_read_only(query, "postgres")
+        assert not result.allowed
+        assert "Prohibited operation" in result.reason
+
+    def test_select_into_blocked(self):
+        """SELECT INTO should be blocked (Postgres)."""
+        result = validate_read_only("SELECT * INTO new_table FROM users", "postgres")
+        assert not result.allowed
+        assert "SELECT INTO" in result.reason
+
+    def test_select_for_update_blocked(self):
+        """SELECT FOR UPDATE should be blocked."""
+        result = validate_read_only(
+            "SELECT * FROM users WHERE id = 1 FOR UPDATE", "postgres"
+        )
+        assert not result.allowed
+        assert "locking clause" in result.reason
+
+    def test_select_for_share_blocked(self):
+        """SELECT FOR SHARE should be blocked."""
+        result = validate_read_only(
+            "SELECT * FROM users WHERE id = 1 FOR SHARE", "postgres"
+        )
+        assert not result.allowed
+        assert "locking clause" in result.reason
+
+    def test_multi_statement_blocked(self):
+        """Multiple statements should be blocked."""
+        result = validate_read_only(
+            "SELECT * FROM users; SELECT * FROM orders;", "postgres"
+        )
+        assert not result.allowed
+        assert "single SELECT" in result.reason
+
+    def test_multi_statement_with_drop_blocked(self):
+        """Multiple statements with DROP should be blocked."""
+        result = validate_read_only(
+            "SELECT * FROM users; DROP TABLE users;", "postgres"
+        )
+        assert not result.allowed
+        assert "single SELECT" in result.reason
+
+    def test_copy_blocked_postgres(self):
+        """COPY should be blocked (Postgres)."""
+        result = validate_read_only("COPY users TO '/tmp/users.csv'", "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_explain_blocked(self):
+        """EXPLAIN should be blocked for simplicity."""
+        result = validate_read_only("EXPLAIN SELECT * FROM users", "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_postgres_dangerous_function_pg_read_file(self):
+        """Postgres dangerous functions should be blocked."""
+        result = validate_read_only("SELECT pg_read_file('/etc/passwd')", "postgres")
+        assert not result.allowed
+        assert "dangerous function" in result.reason.lower()
+
+    def test_mysql_dangerous_function_load_file(self):
+        """MySQL dangerous functions should be blocked."""
+        result = validate_read_only("SELECT LOAD_FILE('/etc/passwd')", "mysql")
+        assert not result.allowed
+        assert "dangerous function" in result.reason.lower()
+
+    def test_sqlite_dangerous_function_readfile(self):
+        """SQLite dangerous functions should be blocked."""
+        result = validate_read_only("SELECT readfile('/etc/passwd')", "sqlite")
+        assert not result.allowed
+        assert "dangerous function" in result.reason.lower()
+
+    def test_parse_error_blocked(self):
+        """Unparseable queries should be blocked."""
+        result = validate_read_only("SELECT FROM WHERE", "postgres")
+        assert not result.allowed
+        assert "parse" in result.reason.lower()
+
+    def test_create_table_as_select_blocked(self):
+        """CREATE TABLE AS SELECT should be blocked."""
+        result = validate_read_only(
+            "CREATE TABLE new_users AS SELECT * FROM users", "postgres"
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_insert_into_select_blocked(self):
+        """INSERT INTO ... SELECT should be blocked."""
+        result = validate_read_only(
+            "INSERT INTO backup_users SELECT * FROM users", "postgres"
+        )
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+    def test_merge_blocked(self):
+        """MERGE should be blocked."""
+        query = """
+        MERGE INTO target t
+        USING source s ON t.id = s.id
+        WHEN MATCHED THEN UPDATE SET t.value = s.value
+        WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.value)
+        """
+        result = validate_read_only(query, "postgres")
+        assert not result.allowed
+        assert "Only SELECT" in result.reason
+
+
+class TestAddLimit:
+    """Tests for adding LIMIT clauses."""
+
+    def test_add_limit_to_simple_select(self):
+        """Should add LIMIT to simple SELECT."""
+        query = "SELECT * FROM users"
+        result = add_limit(query, "postgres", 100)
+        assert "LIMIT" in result.upper()
+        assert "100" in result
+
+    def test_preserve_existing_limit(self):
+        """Should preserve existing LIMIT."""
+        query = "SELECT * FROM users LIMIT 50"
+        result = add_limit(query, "postgres", 100)
+        assert "50" in result
+        assert "100" not in result
+
+    def test_add_limit_to_query_with_where(self):
+        """Should add LIMIT to query with WHERE."""
+        query = "SELECT * FROM users WHERE age > 18"
+        result = add_limit(query, "postgres", 100)
+        assert "LIMIT" in result.upper()
+        assert "WHERE age > 18" in result
+
+    def test_add_limit_to_union(self):
+        """Should add LIMIT to UNION queries."""
+        query = "SELECT name FROM users UNION SELECT name FROM archived_users"
+        result = add_limit(query, "postgres", 100)
+        assert "LIMIT" in result.upper()
+
+    def test_add_limit_with_existing_offset(self):
+        """Should work with existing OFFSET."""
+        query = "SELECT * FROM users OFFSET 10"
+        result = add_limit(query, "postgres", 100)
+        # Should add LIMIT
+        assert "LIMIT" in result.upper()
+
+    def test_mysql_limit_syntax(self):
+        """MySQL should use LIMIT syntax."""
+        query = "SELECT * FROM users"
+        result = add_limit(query, "mysql", 100)
+        assert "LIMIT" in result.upper()
+        assert "100" in result
+
+    def test_sqlite_limit_syntax(self):
+        """SQLite should use LIMIT syntax."""
+        query = "SELECT * FROM users"
+        result = add_limit(query, "sqlite", 100)
+        assert "LIMIT" in result.upper()
+        assert "100" in result
+
+    def test_fallback_on_parse_error(self):
+        """Should fall back to simple append on parse errors."""
+        # Even invalid SQL should get LIMIT appended as a fallback
+        query = "SELECT FROM WHERE"
+        result = add_limit(query, "postgres", 100)
+        # Fallback should still try to add LIMIT
+        assert "LIMIT" in result.upper()

--- a/tests/test_tools/test_sql_tools.py
+++ b/tests/test_tools/test_sql_tools.py
@@ -195,7 +195,7 @@ class TestExecuteSQLTool:
             result = await tool.execute(query=query)
             data = json.loads(result)
             assert "error" in data
-            assert "write operations are not allowed" in data["error"].lower()
+            assert "only select" in data["error"].lower()
 
     @pytest.mark.asyncio
     async def test_error_handling(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1845,6 +1845,48 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlglot"
+version = "27.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/9d/31eac378d98b5d7f945981dc27bc34a3959a60c09ed9ca78cf9c9f95fe52/sqlglot-27.20.0.tar.gz", hash = "sha256:92e7a93200eb588eb17cf19c813103160bd6c9b261ffd295eea79633657569d9", size = 5480742 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/53/4c87ef36f743d7b2a414839677f08ea0904400afd376b3785b6ed1593d0b/sqlglot-27.20.0-py3-none-any.whl", hash = "sha256:9c0b67bbb8e0a9300e34eb2984bf825bca6356cf3cdcc7637658058f2afe41ca", size = 520739 },
+]
+
+[package.optional-dependencies]
+rs = [
+    { name = "sqlglotrs" },
+]
+
+[[package]]
+name = "sqlglotrs"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/de/0d42a6a0f8ee3129beb45f5b8e367667a43597adf459f2192f5d2346e379/sqlglotrs-0.6.2.tar.gz", hash = "sha256:7ed668215bdcea6f69dc9a29c9ea26ed39216ab330f357289a5ec95138c40482", size = 15600 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/9e/d73880ebb0e2d2dfbd65222c72bb6f9ea5ed765d7e5da7307d52319f3dbe/sqlglotrs-0.6.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a12fa4230b170b8f94c3ba459d5983f64acc92e690f7d406e4d690577efdc126", size = 311422 },
+    { url = "https://files.pythonhosted.org/packages/26/d2/f9bdc858af62780fb64dd409670809278d3b3c4e836cd695ea8c1415947f/sqlglotrs-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb93868dd14762a8c1e89c549db9a56d327026e69c7a6aaffaf86a6d3c872b68", size = 297448 },
+    { url = "https://files.pythonhosted.org/packages/b1/11/8de1140dd88c6424d011f880447a7d90dd53881b1aa264ca5caa9f03011b/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9667fdd0b5e35e2e2c4f40227f800c615c7796c9259807e2e87ab55d2c505e6", size = 332485 },
+    { url = "https://files.pythonhosted.org/packages/3b/3d/0dd81a5b2e66e57b610fa375c4c19c7b5f440d0c8f3b2fdfd78a4844fd4c/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ffd2819f98c6a939555749bf155214f1f14cf1e9e5164bbfab3d5960a939f3", size = 341281 },
+    { url = "https://files.pythonhosted.org/packages/03/9b/6de3930e8f01bcf18469f6f8d9cb03e1fc82baaa76bb0a24a2b053ee0749/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f69c4d0d1286a1ac8a66c825decbbcaddb03599bf1452697f2ffc338d5e5d48", size = 486820 },
+    { url = "https://files.pythonhosted.org/packages/89/6a/babb32e867f48c0d2c60614e5aa1dede0751788b92b5d91aab3bc50f5ca4/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c62a60610aa5ce5b931dd0ca5ffcc010766a29b62f6e30f2700f105aa458c4", size = 366763 },
+    { url = "https://files.pythonhosted.org/packages/ca/49/85b338783e04d831efb1dee7b0a05d31b0f7bf56c9a33cafd8b713295387/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c5da9552ac32560e93e5cced87ee64afae405f8e79bb42840fdf7d573396a4d", size = 338305 },
+    { url = "https://files.pythonhosted.org/packages/41/af/9230f9915503526c7fa804d54665fba83eb8e748bba01820c543d78cbad7/sqlglotrs-0.6.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:70d26179e0dab0f810ec47950592bac7b83e3681d3c151fc1c2feec064af7460", size = 363539 },
+    { url = "https://files.pythonhosted.org/packages/c1/c4/98b660338b8c51ed853d5ea8698f99de1848016e576f2c0d9b1842cef5e8/sqlglotrs-0.6.2-cp312-cp312-win32.whl", hash = "sha256:33470906c51636c2c08303bf68fb5430690eec2271fe33b41c2a2ff6a36ee321", size = 183693 },
+    { url = "https://files.pythonhosted.org/packages/b1/41/e5e32894c9e92dcb56df74e76d3f79972f608ca699eefbee01ffeb09df5e/sqlglotrs-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:4fb23a9a9dfb621fc99d29dbeb366b45e875ee51a2e6e16778c5f76febff37d0", size = 196041 },
+    { url = "https://files.pythonhosted.org/packages/d8/d6/1cea2a171265486a94d2e2aab3a97a26a6ac82c0f7aed750c7db90ce680a/sqlglotrs-0.6.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5b15920dbd6ccdf7045dd3fcbf98a0e40e62b7642c2f694d8dea9e74c94f01df", size = 311335 },
+    { url = "https://files.pythonhosted.org/packages/ef/af/8dd8a2bb72fa9b8413493fbd707a94f34c72ef82c745bd3477ac6792b06d/sqlglotrs-0.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:566ac0eb312440339469924924b973e85d98899bd05ccca6da9f4a95eb842603", size = 297384 },
+    { url = "https://files.pythonhosted.org/packages/7d/ab/ec947c148a589a322b5091d9d03139d361d9e7f9485995738e6d4ce690bd/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f99df4940a11d190105089faf9ae7fc0844090017d0a0734f78df709ed939fe", size = 332209 },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/f108b5fca05b53c57dcf65077cf746cb49d30db3cf0dd134e2d2c28326fb/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1e39821bb3e4630d408963d42503ad1efd959d55dca9a16f1a864867367cd2e", size = 340656 },
+    { url = "https://files.pythonhosted.org/packages/4b/05/39d21b4d914c0ad8f8f24bbad58c5cb808560b5830f501a63a73dfab0e50/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49841d4f97e1a35ddde4bb0160f92ed53d167d1dfedf7ad4d398acf6cfcbf85a", size = 486243 },
+    { url = "https://files.pythonhosted.org/packages/8e/ed/8b69319edf0d3146ad789b84e635c7a39aca38cf4a2e9347a4c8e89f6cc1/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bdaaac3e98afddb2020f880af56c47ead2afc8c6dd6eebbf84f503255a88d75", size = 366392 },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/80b9b00943fb8c2960f8d39ea6bd5e3d37c227dd34c4be564da9fedc173e/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9f2006d70521c1641cfe9d85ef34f95714d70dbce18115ce58ec144e4e6069b", size = 338079 },
+    { url = "https://files.pythonhosted.org/packages/f3/7f/62e27243b014cb5cf116653b0122902b1a6f44af7d9d0094b366a5a846f2/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:014887e055ec0fdf0186446885be09cd0c6a48fbf604b58abaa9abd8e8f11f5a", size = 362053 },
+    { url = "https://files.pythonhosted.org/packages/55/80/678cd8bbf49fa9c5523adac1ca1815f84e1a1ebb52cf3dc9812c808ac375/sqlglotrs-0.6.2-cp313-cp313-win32.whl", hash = "sha256:12438b306bcc56e160f5562c1f96abbba0b1c923d7425fbda1bcbfa40116f3e4", size = 183754 },
+    { url = "https://files.pythonhosted.org/packages/cc/ca/46dad4f7c4d94a7a627add1f4b6ac8d4a6b248b20f54461339767b313afa/sqlglotrs-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:40c7cf78ae2a9a5dcf8f18ed7e17947817f0c0e0b82c8cd9339613c746b90280", size = 195711 },
+]
+
+[[package]]
 name = "sqlsaber"
 version = "0.27.0"
 source = { editable = "." }
@@ -1862,6 +1904,7 @@ dependencies = [
     { name = "pydantic-ai" },
     { name = "questionary" },
     { name = "rich" },
+    { name = "sqlglot", extra = ["rs"] },
 ]
 
 [package.dev-dependencies]
@@ -1886,6 +1929,7 @@ requires-dist = [
     { name = "pydantic-ai" },
     { name = "questionary", specifier = ">=2.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
+    { name = "sqlglot", extras = ["rs"], specifier = ">=27.20.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- Enhanced read-only query validation using `sqlglot` AST analysis
  - Improved security with comprehensive AST-based detection of write operations
  - Blocks dangerous operations in nested queries, CTEs, and subqueries
  - Detects dialect-specific dangerous functions (pg_read_file, LOAD_FILE, readfile, etc.)
  - Prevents SELECT INTO, SELECT FOR UPDATE/SHARE, and multi-statement queries
  - Dialect-aware LIMIT clause injection for Postgres, MySQL, SQLite, and DuckDB