### PR TITLE
Theme manager now derives semantic colors directly from selected Pygments styles

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,10 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+#### Changed
+
+- Theme manager now derives semantic colors directly from selected Pygments styles, enabling out-of-the-box support for any upstream theme while retaining user overrides and fallbacks.
+
 ### v0.28.0 - 2025-10-03
 
 #### Added

--- a/tests/test_theme/test_manager.py
+++ b/tests/test_theme/test_manager.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sqlsaber.theme import manager
+
+
+@pytest.fixture(autouse=True)
+def clear_theme_cache():
+    manager.get_theme_manager.cache_clear()
+    yield
+    manager.get_theme_manager.cache_clear()
+
+
+def test_dynamic_palette_uses_pygments_colors(monkeypatch):
+    monkeypatch.setenv("SQLSABER_THEME", "zenburn")
+
+    tm = manager.get_theme_manager()
+
+    assert tm.pygments_style_name == "zenburn"
+    assert tm.style("primary") == "#efdcbc"
+    assert tm.style("accent") == "#e89393"
+    assert tm.style("success") == "#cc9393"
+    assert tm.style("error") == "#e37170"
+    assert tm.style("info") == "#efef8f"
+    assert tm.style("muted") == "#7f9f7f"
+
+    monkeypatch.delenv("SQLSABER_THEME", raising=False)
+
+
+def test_unknown_theme_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setenv("SQLSABER_THEME", "does-not-exist")
+
+    tm = manager.get_theme_manager()
+
+    assert tm.pygments_style_name == "does-not-exist"
+    assert tm.style("primary") == manager.DEFAULT_ROLE_PALETTE["primary"]
+    assert tm.style("accent") == manager.DEFAULT_ROLE_PALETTE["accent"]
+
+    monkeypatch.delenv("SQLSABER_THEME", raising=False)


### PR DESCRIPTION
Theme manager now derives semantic colors directly from selected Pygments styles, enabling out-of-the-box support for any upstream theme while retaining user overrides and fallbacks.