### PR TITLE
Theme set/reset via cli

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,14 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+#### Added
+
+- Theme management commands
+  - `saber theme set` - Interactively select from all available Pygments themes with searchable list
+  - `saber theme reset` - Reset to default theme (nord)
+  - Theme configuration persists across sessions
+  - Environment variable `SQLSABER_THEME` can override configured theme
+
 #### Changed
 
 - Theme manager now derives semantic colors directly from selected Pygments styles, enabling out-of-the-box support for any upstream theme while retaining user overrides and fallbacks.

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -310,6 +310,39 @@ saber models reset
 
 ---
 
+### `saber theme`
+
+Manage syntax highlighting theme settings.
+
+#### `saber theme set`
+
+Interactively select a syntax highlighting theme from all available Pygments themes.
+
+**Usage:**
+
+```bash
+saber theme set
+```
+
+You can also set themes via environment variable:
+
+```bash
+export SQLSABER_THEME=dracula
+saber
+```
+
+#### `saber theme reset`
+
+Reset to the default theme (nord).
+
+**Usage:**
+
+```bash
+saber theme reset
+```
+
+---
+
 ### `saber threads`
 
 Manage conversation threads.

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -11,6 +11,7 @@ from sqlsaber.cli.database import create_db_app
 from sqlsaber.cli.memory import create_memory_app
 from sqlsaber.cli.models import create_models_app
 from sqlsaber.cli.onboarding import needs_onboarding, run_onboarding
+from sqlsaber.cli.theme import create_theme_app
 from sqlsaber.cli.threads import create_threads_app
 
 # Lazy imports - only import what's needed for CLI parsing
@@ -35,6 +36,7 @@ app.command(create_auth_app(), name="auth")
 app.command(create_db_app(), name="db")
 app.command(create_memory_app(), name="memory")
 app.command(create_models_app(), name="models")
+app.command(create_theme_app(), name="theme")
 app.command(create_threads_app(), name="threads")
 
 console = create_console()

--- a/src/sqlsaber/cli/theme.py
+++ b/src/sqlsaber/cli/theme.py
@@ -1,0 +1,146 @@
+"""Theme management CLI commands."""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import cyclopts
+import questionary
+from platformdirs import user_config_dir
+from pygments.styles import get_all_styles
+
+from sqlsaber.theme.manager import DEFAULT_THEME_NAME, create_console
+
+console = create_console()
+
+# Create the theme management CLI app
+theme_app = cyclopts.App(
+    name="theme",
+    help="Manage theme settings",
+)
+
+
+class ThemeManager:
+    """Manages theme configuration persistence."""
+
+    def __init__(self):
+        self.config_dir = Path(user_config_dir("sqlsaber"))
+        self.config_file = self.config_dir / "theme.json"
+
+    def _ensure_config_dir(self) -> None:
+        """Ensure config directory exists."""
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+
+    def _load_config(self) -> dict:
+        """Load theme configuration from file."""
+        if not self.config_file.exists():
+            return {}
+
+        try:
+            with open(self.config_file, "r") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+    def _save_config(self, config: dict) -> None:
+        """Save theme configuration to file."""
+        self._ensure_config_dir()
+
+        with open(self.config_file, "w") as f:
+            json.dump(config, f, indent=2)
+
+    def get_current_theme(self) -> str:
+        """Get the currently configured theme."""
+        config = self._load_config()
+        env_theme = os.getenv("SQLSABER_THEME")
+        if env_theme:
+            return env_theme
+        return config.get("theme", {}).get("pygments_style") or DEFAULT_THEME_NAME
+
+    def set_theme(self, theme_name: str) -> bool:
+        """Set the current theme."""
+        try:
+            config = self._load_config()
+            if "theme" not in config:
+                config["theme"] = {}
+            config["theme"]["name"] = theme_name
+            config["theme"]["pygments_style"] = theme_name
+            self._save_config(config)
+            return True
+        except Exception as e:
+            console.print(f"[error]Error setting theme: {e}[/error]")
+            return False
+
+    def reset_theme(self) -> bool:
+        """Reset to default theme."""
+        try:
+            if self.config_file.exists():
+                self.config_file.unlink()
+            return True
+        except Exception as e:
+            console.print(f"[error]Error resetting theme: {e}[/error]")
+            return False
+
+    def get_available_themes(self) -> list[str]:
+        """Get list of available Pygments themes."""
+        return sorted(get_all_styles())
+
+
+theme_manager = ThemeManager()
+
+
+@theme_app.command
+def set():
+    """Set the theme to use for syntax highlighting."""
+
+    async def interactive_set():
+        themes = theme_manager.get_available_themes()
+        current_theme = theme_manager.get_current_theme()
+
+        # Create choices with current theme highlighted
+        choices = [
+            questionary.Choice(
+                title=f"{theme} (current)" if theme == current_theme else theme,
+                value=theme,
+            )
+            for theme in themes
+        ]
+
+        selected_theme = await questionary.select(
+            "Select a theme:",
+            choices=choices,
+            default=current_theme,
+            use_search_filter=True,
+            use_jk_keys=False,
+        ).ask_async()
+
+        if selected_theme:
+            if theme_manager.set_theme(selected_theme):
+                console.print(f"[success]✓ Theme set to: {selected_theme}[/success]")
+            else:
+                console.print("[error]✗ Failed to set theme[/error]")
+                sys.exit(1)
+        else:
+            console.print("[warning]Operation cancelled[/warning]")
+
+    asyncio.run(interactive_set())
+
+
+@theme_app.command
+def reset():
+    """Reset to the default theme."""
+
+    if theme_manager.reset_theme():
+        console.print(
+            f"[success]✓ Theme reset to default: {DEFAULT_THEME_NAME}[/success]"
+        )
+    else:
+        console.print("[error]✗ Failed to reset theme[/error]")
+        sys.exit(1)
+
+
+def create_theme_app() -> cyclopts.App:
+    """Return the theme management CLI app."""
+    return theme_app

--- a/src/sqlsaber/theme/manager.py
+++ b/src/sqlsaber/theme/manager.py
@@ -1,7 +1,7 @@
 """Theme management for unified theming across Rich and prompt_toolkit."""
 
+import json
 import os
-import tomllib
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Dict
@@ -131,11 +131,11 @@ def _build_role_palette_from_style(style_name: str) -> dict[str, str]:
 def _load_user_theme_config() -> dict:
     """Load theme configuration from user config directory."""
     cfg_dir = user_config_dir("sqlsaber")
-    path = os.path.join(cfg_dir, "theme.toml")
+    path = os.path.join(cfg_dir, "theme.json")
     if not os.path.exists(path):
         return {}
-    with open(path, "rb") as f:
-        return tomllib.load(f)
+    with open(path, "r") as f:
+        return json.load(f)
 
 
 def _resolve_refs(palette: dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
Theme management commands
  - `saber theme set` - Interactively select from all available Pygments themes with searchable list
  - `saber theme reset` - Reset to default theme (nord)
  - Theme configuration persists across sessions
  - Environment variable `SQLSABER_THEME` can override configured theme