### PR TITLE
Add multi-database SQLSaber sessions

### DIFF
--- a/src/sqlsaber/agents/multi_database_agent.py
+++ b/src/sqlsaber/agents/multi_database_agent.py
@@ -133,7 +133,9 @@ class MultiDatabaseCoordinator:
         typed_agent = cast(Agent[MultiDatabaseDeps, Any], agent)
 
         @typed_agent.system_prompt(dynamic=True)
-        async def multi_database_system_prompt(ctx: RunContext[MultiDatabaseDeps]) -> str:
+        async def multi_database_system_prompt(
+            ctx: RunContext[MultiDatabaseDeps],
+        ) -> str:
             _ = ctx
             return self.system_prompt_text()
 

--- a/src/sqlsaber/agents/multi_database_agent.py
+++ b/src/sqlsaber/agents/multi_database_agent.py
@@ -1,0 +1,335 @@
+"""Coordinator agent for routing questions across multiple database agents."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import AsyncIterable, Awaitable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Callable, cast
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import AgentStreamEvent, ModelMessage
+
+from sqlsaber.agents.provider_factory import ProviderFactory
+from sqlsaber.config import providers
+from sqlsaber.config.settings import Config, ThinkingLevel
+from sqlsaber.threads.manager import ThreadManager
+
+
+class DatabaseDescriptor(BaseModel):
+    """Database metadata available to the coordinator."""
+
+    id: str
+    name: str
+    type: str
+    description: str | None = None
+    summary: str | None = None
+    thread_id: str | None = None
+
+
+class DatabaseAnswer(BaseModel):
+    """Answer returned by a child database agent."""
+
+    database_id: str
+    database_name: str
+    thread_id: str | None = None
+    summary: str
+    evidence: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+class ChildAnswerPayload(BaseModel):
+    """Structured output contract for SQLSaber child agents."""
+
+    summary: str
+    evidence: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+@dataclass
+class DatabaseChild:
+    """Runtime state for one child SQLSaber agent."""
+
+    descriptor: DatabaseDescriptor
+    agent: Any
+    thread_manager: ThreadManager
+    database_name: str
+    message_history: list[ModelMessage] = field(default_factory=list)
+
+
+@dataclass
+class MultiDatabaseDeps:
+    """Dependencies injected into coordinator tools."""
+
+    children: dict[str, DatabaseChild]
+
+
+class MultiDatabaseCoordinator:
+    """Pydantic-AI coordinator that routes work to one child per database."""
+
+    def __init__(
+        self,
+        children: dict[str, DatabaseChild],
+        *,
+        database_label: str,
+        settings: Config | None = None,
+        thinking_enabled: bool | None = None,
+        thinking_level: ThinkingLevel | None = None,
+        model_name: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self.children = children
+        self.database_label = database_label
+        self.config = settings or Config.default()
+        self._model_name_override = model_name
+        self._api_key_override = api_key
+
+        self.thinking_enabled = (
+            thinking_enabled
+            if thinking_enabled is not None
+            else self.config.model.thinking_enabled
+        )
+        self.thinking_level = (
+            thinking_level
+            if thinking_level is not None
+            else self.config.model.thinking_level
+        )
+
+        self.agent = self._build_agent()
+
+    def _build_agent(self) -> Agent:
+        if self._api_key_override and not self._model_name_override:
+            raise ValueError(
+                "Model name is required when providing an api_key override."
+            )
+
+        model_name = self._model_name_override or self.config.model.name
+        model_name_only = (
+            model_name.split(":", 1)[1] if ":" in model_name else model_name
+        )
+
+        if not (self._model_name_override and self._api_key_override):
+            self.config.auth.validate(model_name)
+
+        provider = providers.provider_from_model(model_name) or ""
+        api_key = self._api_key_override or self.config.auth.get_api_key(model_name)
+
+        agent = ProviderFactory().create_agent(
+            provider=provider,
+            model_name=model_name_only,
+            full_model_str=model_name,
+            api_key=api_key,
+            thinking_enabled=self.thinking_enabled,
+            thinking_level=self.thinking_level,
+        )
+
+        self._setup_system_prompt(agent)
+        self._register_tools(agent)
+        return agent
+
+    def _setup_system_prompt(self, agent: Agent) -> None:
+        typed_agent = cast(Agent[MultiDatabaseDeps, Any], agent)
+
+        @typed_agent.system_prompt(dynamic=True)
+        async def multi_database_system_prompt(ctx: RunContext[MultiDatabaseDeps]) -> str:
+            _ = ctx
+            return self.system_prompt_text()
+
+    def _register_tools(self, agent: Agent) -> None:
+        typed_agent = cast(Agent[MultiDatabaseDeps, Any], agent)
+
+        @typed_agent.tool
+        async def list_connected_databases(
+            ctx: RunContext[MultiDatabaseDeps],
+        ) -> list[DatabaseDescriptor]:
+            _ = ctx
+            return self.descriptors()
+
+        @typed_agent.tool
+        async def ask_database(
+            ctx: RunContext[MultiDatabaseDeps],
+            database_id: str,
+            question: str,
+        ) -> DatabaseAnswer:
+            return await self.ask_database_direct(
+                database_id,
+                question,
+                usage=ctx.usage,
+            )
+
+    def descriptors(self) -> list[DatabaseDescriptor]:
+        """Return current descriptors for connected child databases."""
+        return [child.descriptor for child in self.children.values()]
+
+    def system_prompt_text(self) -> str:
+        """Return the coordinator system prompt as a single string."""
+        database_lines = "\n".join(
+            (
+                f"- {descriptor.id}: {descriptor.name} "
+                f"({descriptor.type})"
+                f"{f' - {descriptor.description}' if descriptor.description else ''}"
+                f"{f' Summary: {descriptor.summary}' if descriptor.summary else ''}"
+                f"{f' [thread ID: {descriptor.thread_id}]' if descriptor.thread_id else ''}"
+            )
+            for descriptor in self.descriptors()
+        )
+        if not database_lines:
+            database_lines = "- No databases are currently connected."
+
+        return (
+            "You are the SQLSaber multi-database coordinator for "
+            f"'{self.database_label}'. Route questions to the database-specific "
+            "child agents using the available tools.\n\n"
+            "Connected databases:\n"
+            f"{database_lines}\n\n"
+            "cross-database SQL joins cannot be executed. query databases "
+            "independently and state limitations when an answer requires comparing "
+            "or combining data across databases.\n"
+            "Thread IDs are traceability metadata. Include relevant child thread "
+            "IDs in answers, but do not treat transcript references as evidence."
+        )
+
+    async def ask_database_direct(
+        self,
+        database_id: str,
+        question: str,
+        *,
+        usage: Any | None = None,
+    ) -> DatabaseAnswer:
+        """Ask a specific child database agent and normalize its structured answer."""
+        child = self.children.get(database_id)
+        if child is None:
+            return DatabaseAnswer(
+                database_id=database_id,
+                database_name=database_id,
+                thread_id=None,
+                summary=f"Unable to answer from database '{database_id}'.",
+                evidence=[],
+                limitations=[f"Unknown database id '{database_id}'."],
+            )
+
+        model_name = self._child_model_name(child)
+        ensure_thread_kwargs: dict[str, str | None] = {
+            "database_name": child.database_name,
+        }
+        if child.thread_manager.current_thread_id is None:
+            ensure_thread_kwargs.update(
+                title=f"[{child.database_name}] {question}",
+                model_name=model_name,
+                extra_metadata=json.dumps(
+                    {
+                        "kind": "multi_database_child",
+                        "database_id": database_id,
+                    }
+                ),
+            )
+
+        thread_id = await child.thread_manager.ensure_thread(**ensure_thread_kwargs)
+        child.descriptor.thread_id = thread_id
+
+        prompt = self._child_prompt(child.descriptor, question)
+        try:
+            run_result = await child.agent.run(
+                prompt,
+                message_history=child.message_history,
+                usage=usage,
+            )
+        except Exception as exc:
+            return DatabaseAnswer(
+                database_id=child.descriptor.id,
+                database_name=child.database_name,
+                thread_id=thread_id,
+                summary=(
+                    f"Unable to answer from database '{child.descriptor.id}' because "
+                    "the child agent failed."
+                ),
+                evidence=[],
+                limitations=[f"Child agent failed: {exc}"],
+            )
+
+        output = self._run_output(run_result)
+
+        if not isinstance(output, ChildAnswerPayload):
+            return DatabaseAnswer(
+                database_id=child.descriptor.id,
+                database_name=child.database_name,
+                thread_id=thread_id,
+                summary=(
+                    f"Unable to answer from database '{child.descriptor.id}' because "
+                    "the child agent returned invalid structured output."
+                ),
+                evidence=[],
+                limitations=[
+                    "Child agent did not return ChildAnswerPayload structured output."
+                ],
+            )
+
+        child.message_history = await child.thread_manager.save_run(
+            run_result=run_result,
+            database_name=child.database_name,
+            user_query=question,
+            model_name=model_name,
+        )
+
+        return DatabaseAnswer(
+            database_id=child.descriptor.id,
+            database_name=child.database_name,
+            thread_id=thread_id,
+            summary=output.summary,
+            evidence=output.evidence,
+            limitations=output.limitations,
+        )
+
+    def _child_prompt(self, descriptor: DatabaseDescriptor, question: str) -> str:
+        return (
+            f"Answer using only database '{descriptor.name}' "
+            f"(id: {descriptor.id}, type: {descriptor.type}).\n"
+            "Return ChildAnswerPayload with summary, evidence, and limitations.\n\n"
+            f"Question: {question}"
+        )
+
+    def _run_output(self, run_result: Any) -> Any:
+        if hasattr(run_result, "output"):
+            return run_result.output
+        if hasattr(run_result, "data"):
+            return run_result.data
+        return None
+
+    def _child_model_name(self, child: DatabaseChild) -> str:
+        child_pydantic_agent = getattr(child.agent, "agent", None)
+        child_model = getattr(child_pydantic_agent, "model", None)
+        model_name = getattr(child_model, "model_name", None)
+        if isinstance(model_name, str) and model_name:
+            return model_name
+        return self.config.model.name
+
+    async def run(
+        self,
+        prompt: str,
+        message_history: Sequence[ModelMessage] | None = None,
+        event_stream_handler: Callable[
+            [RunContext[Any], AsyncIterable[AgentStreamEvent]],
+            Awaitable[None],
+        ]
+        | None = None,
+    ) -> Any:
+        """Run the coordinator agent with child-agent dependencies."""
+        run_agent = cast(Agent[MultiDatabaseDeps, Any], self.agent)
+        return await run_agent.run(
+            prompt,
+            message_history=message_history,
+            event_stream_handler=event_stream_handler,
+            deps=MultiDatabaseDeps(children=self.children),
+        )
+
+    async def close(self) -> None:
+        """Close child agents that expose an async close method."""
+        for child in self.children.values():
+            close = getattr(child.agent, "close", None)
+            if close is None:
+                continue
+            result = close()
+            if inspect.isawaitable(result):
+                await result

--- a/src/sqlsaber/agents/multi_database_agent.py
+++ b/src/sqlsaber/agents/multi_database_agent.py
@@ -162,14 +162,11 @@ class MultiDatabaseCoordinator:
             database_lines = "- No databases are currently connected."
 
         return (
-            "You are the SQLSaber multi-database coordinator for "
-            f"'{self.database_label}'. Route questions to the database-specific "
-            "child agents using the available tools.\n\n"
+            "You are a helpful multi-database SQL orchestrator and coordinator"
+            f"designed to help users query their {self.database_label} databases "
+            "using natural language.\n\n"
             "Connected databases:\n"
             f"{database_lines}\n\n"
-            "cross-database SQL joins cannot be executed. query databases "
-            "independently and state limitations when an answer requires comparing "
-            "or combining data across databases.\n"
             "Thread IDs are traceability metadata. Include relevant child thread "
             "IDs in answers, but do not treat transcript references as evidence."
         )
@@ -253,8 +250,6 @@ class MultiDatabaseCoordinator:
 
     def _child_prompt(self, descriptor: DatabaseDescriptor, question: str) -> str:
         return (
-            f"Answer using only database '{descriptor.name}' "
-            f"(id: {descriptor.id}, type: {descriptor.type}).\n"
             "Return plain markdown with these sections when they apply:\n"
             "## Answer\n"
             "## Evidence\n"
@@ -262,7 +257,7 @@ class MultiDatabaseCoordinator:
             "## Limitations\n\n"
             "Evidence should include result excerpts or schema facts used. SQL should "
             "include executed queries, or `None` if no SQL was executed. Limitations "
-            "should state missing data, ambiguity, or single-database constraints.\n\n"
+            "should state any missing data, ambiguity, or other relevant constraints, if present.\n\n"
             f"Question: {question}"
         )
 

--- a/src/sqlsaber/agents/multi_database_agent.py
+++ b/src/sqlsaber/agents/multi_database_agent.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterable, Awaitable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Callable, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 
@@ -27,25 +27,6 @@ class DatabaseDescriptor(BaseModel):
     description: str | None = None
     summary: str | None = None
     thread_id: str | None = None
-
-
-class DatabaseAnswer(BaseModel):
-    """Answer returned by a child database agent."""
-
-    database_id: str
-    database_name: str
-    thread_id: str | None = None
-    summary: str
-    evidence: list[str] = Field(default_factory=list)
-    limitations: list[str] = Field(default_factory=list)
-
-
-class ChildAnswerPayload(BaseModel):
-    """Structured output contract for SQLSaber child agents."""
-
-    summary: str
-    evidence: list[str] = Field(default_factory=list)
-    limitations: list[str] = Field(default_factory=list)
 
 
 @dataclass
@@ -154,7 +135,7 @@ class MultiDatabaseCoordinator:
             ctx: RunContext[MultiDatabaseDeps],
             database_id: str,
             question: str,
-        ) -> DatabaseAnswer:
+        ) -> str:
             return await self.ask_database_direct(
                 database_id,
                 question,
@@ -199,17 +180,20 @@ class MultiDatabaseCoordinator:
         question: str,
         *,
         usage: Any | None = None,
-    ) -> DatabaseAnswer:
-        """Ask a specific child database agent and normalize its structured answer."""
+    ) -> str:
+        """Ask a specific child database agent and return its text answer."""
         child = self.children.get(database_id)
         if child is None:
-            return DatabaseAnswer(
-                database_id=database_id,
-                database_name=database_id,
+            return self._format_child_answer(
+                database_id,
+                database_id,
                 thread_id=None,
-                summary=f"Unable to answer from database '{database_id}'.",
-                evidence=[],
-                limitations=[f"Unknown database id '{database_id}'."],
+                answer_text=(
+                    "## Answer\n"
+                    f"Unable to answer from database '{database_id}'.\n\n"
+                    "## Limitations\n"
+                    f"- Unknown database id '{database_id}'."
+                ),
             )
 
         model_name = self._child_model_name(child)
@@ -239,34 +223,19 @@ class MultiDatabaseCoordinator:
                 usage=usage,
             )
         except Exception as exc:
-            return DatabaseAnswer(
-                database_id=child.descriptor.id,
-                database_name=child.database_name,
+            return self._format_child_answer(
+                child.descriptor.id,
+                child.database_name,
                 thread_id=thread_id,
-                summary=(
-                    f"Unable to answer from database '{child.descriptor.id}' because "
-                    "the child agent failed."
+                answer_text=(
+                    "## Answer\n"
+                    f"Unable to answer from database '{child.descriptor.id}'.\n\n"
+                    "## Limitations\n"
+                    f"- Child agent failed: {exc}"
                 ),
-                evidence=[],
-                limitations=[f"Child agent failed: {exc}"],
             )
 
-        output = self._run_output(run_result)
-
-        if not isinstance(output, ChildAnswerPayload):
-            return DatabaseAnswer(
-                database_id=child.descriptor.id,
-                database_name=child.database_name,
-                thread_id=thread_id,
-                summary=(
-                    f"Unable to answer from database '{child.descriptor.id}' because "
-                    "the child agent returned invalid structured output."
-                ),
-                evidence=[],
-                limitations=[
-                    "Child agent did not return ChildAnswerPayload structured output."
-                ],
-            )
+        answer_text = self._coerce_child_answer_text(self._run_output(run_result))
 
         child.message_history = await child.thread_manager.save_run(
             run_result=run_result,
@@ -275,21 +244,60 @@ class MultiDatabaseCoordinator:
             model_name=model_name,
         )
 
-        return DatabaseAnswer(
-            database_id=child.descriptor.id,
-            database_name=child.database_name,
+        return self._format_child_answer(
+            child.descriptor.id,
+            child.database_name,
             thread_id=thread_id,
-            summary=output.summary,
-            evidence=output.evidence,
-            limitations=output.limitations,
+            answer_text=answer_text,
         )
 
     def _child_prompt(self, descriptor: DatabaseDescriptor, question: str) -> str:
         return (
             f"Answer using only database '{descriptor.name}' "
             f"(id: {descriptor.id}, type: {descriptor.type}).\n"
-            "Return ChildAnswerPayload with summary, evidence, and limitations.\n\n"
+            "Return plain markdown with these sections when they apply:\n"
+            "## Answer\n"
+            "## Evidence\n"
+            "## SQL\n"
+            "## Limitations\n\n"
+            "Evidence should include result excerpts or schema facts used. SQL should "
+            "include executed queries, or `None` if no SQL was executed. Limitations "
+            "should state missing data, ambiguity, or single-database constraints.\n\n"
             f"Question: {question}"
+        )
+
+    def _format_child_answer(
+        self,
+        database_id: str,
+        database_name: str,
+        *,
+        thread_id: str | None,
+        answer_text: str,
+    ) -> str:
+        thread_label = thread_id or "unavailable"
+        return (
+            f"Database: {database_name} (id: {database_id})\n"
+            f"Child thread ID: {thread_label}\n\n"
+            f"{answer_text.strip()}"
+        )
+
+    def _coerce_child_answer_text(self, output: Any) -> str:
+        if output is None:
+            return (
+                "## Answer\n"
+                "No answer was returned.\n\n"
+                "## Limitations\n"
+                "- Child agent returned no text."
+            )
+        text = output if isinstance(output, str) else str(output)
+        text = text.strip()
+        if text:
+            return text
+        return (
+            "## Answer\n"
+            "No answer was returned.\n\n"
+            "## Limitations\n"
+            "- Child agent returned an empty response."
         )
 
     def _run_output(self, run_result: Any) -> Any:

--- a/src/sqlsaber/agents/provider_factory.py
+++ b/src/sqlsaber/agents/provider_factory.py
@@ -59,6 +59,7 @@ class AgentProviderStrategy(abc.ABC):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         """Create and configure an Agent for this provider.
 
@@ -67,6 +68,7 @@ class AgentProviderStrategy(abc.ABC):
             api_key: Optional API key override.
             thinking_enabled: Whether thinking/reasoning is enabled.
             thinking_level: The thinking level to use (maps to provider-specific settings).
+            output_type: Pydantic-AI output type contract for the agent.
         """
 
 
@@ -80,6 +82,7 @@ class GoogleProviderStrategy(AgentProviderStrategy):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         if api_key:
             model_obj = GoogleModel(
@@ -96,9 +99,14 @@ class GoogleProviderStrategy(AgentProviderStrategy):
                     "thinking_level": google_level,
                 }
             )
-            return Agent(model_obj, name="sqlsaber", model_settings=settings)
+            return Agent(
+                model_obj,
+                name="sqlsaber",
+                model_settings=settings,
+                output_type=output_type,
+            )
 
-        return Agent(model_obj, name="sqlsaber")
+        return Agent(model_obj, name="sqlsaber", output_type=output_type)
 
 
 class AnthropicProviderStrategy(AgentProviderStrategy):
@@ -111,6 +119,7 @@ class AnthropicProviderStrategy(AgentProviderStrategy):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         if api_key:
             model_obj = AnthropicModel(
@@ -133,7 +142,12 @@ class AnthropicProviderStrategy(AgentProviderStrategy):
             )
 
         settings = AnthropicModelSettings(**settings_kwargs)
-        return Agent(model_obj, name="sqlsaber", model_settings=settings)
+        return Agent(
+            model_obj,
+            name="sqlsaber",
+            model_settings=settings,
+            output_type=output_type,
+        )
 
 
 class OpenAIProviderStrategy(AgentProviderStrategy):
@@ -146,6 +160,7 @@ class OpenAIProviderStrategy(AgentProviderStrategy):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         if api_key:
             model_obj = OpenAIResponsesModel(
@@ -160,9 +175,14 @@ class OpenAIProviderStrategy(AgentProviderStrategy):
                 openai_reasoning_effort=cast(Any, reasoning_effort),
                 openai_reasoning_summary=cast(Any, "auto"),
             )
-            return Agent(model_obj, name="sqlsaber", model_settings=settings)
+            return Agent(
+                model_obj,
+                name="sqlsaber",
+                model_settings=settings,
+                output_type=output_type,
+            )
 
-        return Agent(model_obj, name="sqlsaber")
+        return Agent(model_obj, name="sqlsaber", output_type=output_type)
 
 
 class GroqProviderStrategy(AgentProviderStrategy):
@@ -179,13 +199,19 @@ class GroqProviderStrategy(AgentProviderStrategy):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         # Groq only supports binary reasoning.
         if thinking_enabled:
             settings = GroqModelSettings(groq_reasoning_format="parsed")
-            return Agent(model_name, name="sqlsaber", model_settings=settings)
+            return Agent(
+                model_name,
+                name="sqlsaber",
+                model_settings=settings,
+                output_type=output_type,
+            )
 
-        return Agent(model_name, name="sqlsaber")
+        return Agent(model_name, name="sqlsaber", output_type=output_type)
 
 
 class DefaultProviderStrategy(AgentProviderStrategy):
@@ -198,8 +224,9 @@ class DefaultProviderStrategy(AgentProviderStrategy):
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
-        return Agent(model_name, name="sqlsaber")
+        return Agent(model_name, name="sqlsaber", output_type=output_type)
 
 
 class ProviderFactory:
@@ -226,6 +253,7 @@ class ProviderFactory:
         api_key: str | None = None,
         thinking_enabled: bool = False,
         thinking_level: ThinkingLevel = ThinkingLevel.MEDIUM,
+        output_type: Any = str,
     ) -> Agent:
         """Create an agent using the appropriate strategy.
 
@@ -236,6 +264,7 @@ class ProviderFactory:
             api_key: Optional API key.
             thinking_enabled: Whether to enable thinking/reasoning features.
             thinking_level: The thinking level to use (maps to provider-specific settings).
+            output_type: Pydantic-AI output type contract for the agent.
         """
         strategy = self.get_strategy(provider)
 
@@ -251,4 +280,5 @@ class ProviderFactory:
             api_key=api_key,
             thinking_enabled=thinking_enabled,
             thinking_level=thinking_level,
+            output_type=output_type,
         )

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -48,6 +48,7 @@ class SQLSaberAgent:
         allow_dangerous: bool = False,
         system_prompt: str | None = None,
         tool_overides: ToolOveridesInput | None = None,
+        output_type: Any = str,
     ):
         self.db_connection = db_connection
         self.database_name = database_name
@@ -63,6 +64,7 @@ class SQLSaberAgent:
         self.db_type = self.db_connection.display_name
         self.allow_dangerous = allow_dangerous
         self._tool_overides = normalize_tool_overides(tool_overides)
+        self.output_type = output_type
 
         self.schema_manager = SchemaManager(self.db_connection)
 
@@ -126,6 +128,7 @@ class SQLSaberAgent:
             api_key=api_key,
             thinking_enabled=self.thinking_enabled,
             thinking_level=self.thinking_level,
+            output_type=self.output_type,
         )
 
         self._setup_system_prompt(agent)
@@ -188,6 +191,7 @@ class SQLSaberAgent:
             Awaitable[None],
         ]
         | None = None,
+        usage: Any | None = None,
     ) -> Any:
         """Run the agent."""
         run_agent = cast(Agent[ToolRunDeps, Any], self.agent)
@@ -196,6 +200,7 @@ class SQLSaberAgent:
             message_history=message_history,
             event_stream_handler=event_stream_handler,
             deps=build_tool_run_deps(self._tool_overides),
+            usage=usage,
         )
 
     async def close(self) -> None:

--- a/src/sqlsaber/api.py
+++ b/src/sqlsaber/api.py
@@ -11,8 +11,9 @@ from typing import Any, Callable, Protocol, Self
 from pydantic_ai import RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 
+from sqlsaber.database import BaseDatabaseConnection
 from sqlsaber.options import SQLSaberOptions
-from sqlsaber.session import SQLSaberSession
+from sqlsaber.session import create_session
 
 
 class SQLSaberRunResult(Protocol):
@@ -84,10 +85,21 @@ class SQLSaber:
         Args:
             options: Session options bag used to build the SQLSaber session.
         """
-        self._session = SQLSaberSession(options)
+        self._session = create_session(options)
         self.db_name = self._session.db_name
-        self.connection = self._session.connection
         self.agent = self._session.agent
+        self.connections = getattr(self._session, "connections", None)
+
+    @property
+    def connection(self) -> BaseDatabaseConnection:
+        """Return the single active connection, or require .connections for multi-db."""
+        connection = getattr(self._session, "connection", None)
+        if connection is None:
+            raise RuntimeError(
+                "This SQLSaber instance has multiple database connections; "
+                "use .connections to access them by database id."
+            )
+        return connection
 
     async def query(
         self,

--- a/src/sqlsaber/application/db_setup.py
+++ b/src/sqlsaber/application/db_setup.py
@@ -26,6 +26,14 @@ def _normalize_schemas(schemas: list[str]) -> list[str]:
     return normalized
 
 
+def _normalize_description(description: str | None) -> str | None:
+    """Return a stripped description, or None when empty."""
+    if description is None:
+        return None
+    stripped = description.strip()
+    return stripped or None
+
+
 @dataclass
 class DatabaseInput:
     """Input data for database configuration."""
@@ -41,6 +49,7 @@ class DatabaseInput:
     ssl_ca: str | None = None
     ssl_cert: str | None = None
     ssl_key: str | None = None
+    description: str | None = None
     exclude_schemas: list[str] = field(default_factory=list)
 
 
@@ -187,6 +196,10 @@ async def collect_db_input(
             return None
         exclude_schemas = _normalize_schemas(exclude_prompt.split(","))
 
+    description = await prompter.text("Description (optional):", default="")
+    if description is None:
+        return None
+
     return DatabaseInput(
         name=name,
         type=db_type,
@@ -199,6 +212,7 @@ async def collect_db_input(
         ssl_ca=ssl_ca,
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
+        description=_normalize_description(description),
         exclude_schemas=exclude_schemas,
     )
 
@@ -216,6 +230,7 @@ def build_config(db_input: DatabaseInput) -> DatabaseConfig:
         ssl_ca=db_input.ssl_ca,
         ssl_cert=db_input.ssl_cert,
         ssl_key=db_input.ssl_key,
+        description=db_input.description,
         exclude_schemas=_normalize_schemas(db_input.exclude_schemas),
     )
 

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -33,6 +33,11 @@ DANGEROUS_MODE_SCOPE = (
 
 DANGEROUS_MODE_WARNING = f"The assistant can execute {DANGEROUS_MODE_SCOPE}"
 DANGEROUS_MODE_HELP = f"Allow {DANGEROUS_MODE_SCOPE}"
+DATABASE_HELP = (
+    "Database connection name, file path (CSV/SQLite/DuckDB), connection string "
+    "(postgresql://, mysql://, duckdb://), multiple databases via repeated -d, "
+    "or multiple CSV files via repeated -d (uses default if not specified)"
+)
 
 
 class CLIError(Exception):
@@ -64,7 +69,7 @@ def meta_handler(
         list[str] | None,
         cyclopts.Parameter(
             ["--database", "-d"],
-            help="Database connection name, file path (CSV/SQLite/DuckDB), connection string (postgresql://, mysql://, duckdb://), or one/more CSV files via repeated -d (uses default if not specified)",
+            help=DATABASE_HELP,
         ),
     ] = None,
 ):
@@ -99,7 +104,7 @@ def query(
         list[str] | None,
         cyclopts.Parameter(
             ["--database", "-d"],
-            help="Database connection name, file path (CSV/SQLite/DuckDB), connection string (postgresql://, mysql://, duckdb://), or one/more CSV files via repeated -d (uses default if not specified)",
+            help=DATABASE_HELP,
         ),
     ] = None,
     thinking: Annotated[
@@ -166,7 +171,7 @@ def query(
         from sqlsaber.cli.usage import SessionUsage
         from sqlsaber.database.resolver import DatabaseResolutionError
         from sqlsaber.options import SQLSaberOptions
-        from sqlsaber.session import SQLSaberSession
+        from sqlsaber.session import create_session
         from sqlsaber.threads.manager import ThreadManager
 
         # Check if query_text is None and stdin has data
@@ -191,7 +196,7 @@ def query(
             log.info("cli.onboarding.complete", success=True)
         thread_manager = ThreadManager()
         try:
-            session = SQLSaberSession(
+            session = create_session(
                 SQLSaberOptions(
                     database=database,
                     thinking_enabled=thinking,
@@ -202,7 +207,19 @@ def query(
             )
             db_name = session.db_name
             log.info("db.resolve.success", name=db_name)
-            log.info("db.connection.created", db_type=type(session.connection).__name__)
+            connections = getattr(session, "connections", None)
+            if connections:
+                log.info(
+                    "db.connection.created",
+                    db_type="multi-database",
+                    database_count=len(connections),
+                )
+            else:
+                connection = getattr(session, "connection", None)
+                log.info(
+                    "db.connection.created",
+                    db_type=type(connection).__name__ if connection else "unknown",
+                )
         except DatabaseResolutionError as e:
             log.error("db.resolve.error", error=str(e))
             raise CLIError(str(e))
@@ -214,12 +231,18 @@ def query(
             if actual_query:
                 # Single query mode with streaming
                 streaming_handler = StreamingQueryHandler(console)
-                db_type = session.agent.db_type
+                db_type = getattr(session.agent, "db_type", "multi-database")
                 model_name = session.agent.config.model.name
                 console.print(
                     f"[primary]Connected to:[/primary] {db_name} ({db_type})\n"
                     f"[primary]Model:[/primary] {model_name}\n"
                 )
+                connections = getattr(session, "connections", None)
+                if connections:
+                    console.print("[primary]Databases:[/primary]")
+                    for database_id, connection in connections.items():
+                        console.print(f"  - {database_id}: {connection.display_name}")
+                    console.print()
                 if allow_dangerous:
                     console.print(
                         Panel(

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -50,6 +50,24 @@ def _parse_schema_list(raw: str | None) -> SchemaList:
     return _normalize_schema_list(raw.split(","))
 
 
+def _normalize_description(description: str | None) -> str | None:
+    """Return a stripped description, or None when empty."""
+    if description is None:
+        return None
+    stripped = description.strip()
+    return stripped or None
+
+
+def _format_description(description: str | None) -> str:
+    """Format a concise description for table display."""
+    normalized = _normalize_description(description)
+    if normalized is None:
+        return ""
+    if len(normalized) <= 60:
+        return normalized
+    return f"{normalized[:57]}..."
+
+
 @db_app.command
 def add(
     name: Annotated[str, cyclopts.Parameter(help="Name for the database connection")],
@@ -102,6 +120,10 @@ def add(
             help="Comma-separated list of schemas to exclude from introspection",
         ),
     ] = None,
+    description: Annotated[
+        str | None,
+        cyclopts.Parameter(["--description"], help="Description of this database"),
+    ] = None,
     interactive: Annotated[
         bool,
         cyclopts.Parameter(
@@ -150,6 +172,7 @@ def add(
         ssl_ca = db_input.ssl_ca
         ssl_cert = db_input.ssl_cert
         ssl_key = db_input.ssl_key
+        description = db_input.description
         exclude_schema_list = _normalize_schema_list(db_input.exclude_schemas)
     else:
         # Non-interactive mode - use provided values or defaults
@@ -194,6 +217,8 @@ def add(
             )
         exclude_schema_list = _parse_schema_list(exclude_schemas)
 
+    normalized_description = _normalize_description(description)
+
     # Create database config
     # At this point, all required values should be set
     assert database is not None, "Database should be set by now"
@@ -213,6 +238,7 @@ def add(
         ssl_ca=ssl_ca,
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
+        description=normalized_description,
         exclude_schemas=exclude_schema_list,
     )
 
@@ -250,13 +276,16 @@ def list_databases() -> None:
 
     table = Table(title="Database Connections")
     table.add_column("Name", style="info")
+    table.add_column("Description", style="muted", overflow="fold", max_width=24)
     table.add_column("Type", style="accent")
-    table.add_column("Host", style="success")
-    table.add_column("Port", style="warning")
     table.add_column("Database", style="info")
-    table.add_column("Username", style="info")
-    table.add_column("Excluded Schemas", style="muted")
-    table.add_column("SSL", style="success")
+    show_details = console.width >= 120
+    if show_details:
+        table.add_column("Host", style="success")
+        table.add_column("Port", style="warning")
+        table.add_column("Username", style="info")
+        table.add_column("Excluded Schemas", style="muted")
+        table.add_column("SSL", style="success")
     table.add_column("Default", style="error")
 
     for db in databases:
@@ -271,20 +300,90 @@ def list_databases() -> None:
         else:
             ssl_status = "disabled" if db.type not in {"sqlite", "duckdb"} else "N/A"
 
-        table.add_row(
+        row = [
             db.name,
+            _format_description(db.description),
             db.type,
-            db.host,
-            str(db.port) if db.port else "",
             db.database,
-            db.username,
-            ", ".join(db.exclude_schemas) if db.exclude_schemas else "",
-            ssl_status,
-            is_default,
-        )
+        ]
+        if show_details:
+            row.extend(
+                [
+                    db.host or "",
+                    str(db.port) if db.port else "",
+                    db.username or "",
+                    ", ".join(db.exclude_schemas) if db.exclude_schemas else "",
+                    ssl_status,
+                ]
+            )
+        row.append(is_default)
+        table.add_row(*row)
 
     console.print(table)
     logger.info("db.list.complete", count=len(databases))
+
+
+@db_app.command
+def describe(
+    name: Annotated[
+        str,
+        cyclopts.Parameter(help="Name of the database connection to update"),
+    ],
+    set_description: Annotated[
+        str | None,
+        cyclopts.Parameter(["--set"], help="Set the database description"),
+    ] = None,
+    clear: Annotated[
+        bool,
+        cyclopts.Parameter(["--clear"], help="Clear the description"),
+    ] = False,
+) -> None:
+    """Update the description for a database connection."""
+    logger.info(
+        "db.describe.start",
+        name=name,
+        set=bool(set_description),
+        clear=clear,
+    )
+    db_config = config_manager.get_database(name)
+    if db_config is None:
+        console.print(
+            f"[bold error]Error: Database connection '{name}' not found[/bold error]"
+        )
+        logger.error("db.describe.not_found", name=name)
+        raise SystemExit(1)
+
+    if set_description is not None and clear:
+        console.print("[bold error]Error: Specify only one of --set or --clear[/bold error]")
+        logger.error("db.describe.multiple_actions", name=name)
+        raise SystemExit(1)
+
+    if clear:
+        updated_description = None
+    elif set_description is not None:
+        updated_description = _normalize_description(set_description)
+    else:
+        response = questionary.text(
+            "Description:", default=db_config.description or ""
+        ).ask()
+        if response is None:
+            console.print("[warning]Operation cancelled[/warning]")
+            logger.info("db.describe.cancelled", name=name)
+            return
+        updated_description = _normalize_description(response)
+
+    db_config.description = updated_description
+    config_manager.update_database(db_config)
+
+    console.print(
+        f"[success]Updated description for '{name}':[/success] "
+        f"{db_config.description or '(none)'}"
+    )
+    logger.info(
+        "db.describe.success",
+        name=name,
+        has_description=db_config.description is not None,
+    )
 
 
 @db_app.command

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -354,7 +354,9 @@ def describe(
         raise SystemExit(1)
 
     if set_description is not None and clear:
-        console.print("[bold error]Error: Specify only one of --set or --clear[/bold error]")
+        console.print(
+            "[bold error]Error: Specify only one of --set or --clear[/bold error]"
+        )
         logger.error("db.describe.multiple_actions", name=name)
         raise SystemExit(1)
 

--- a/src/sqlsaber/cli/display.py
+++ b/src/sqlsaber/cli/display.py
@@ -10,12 +10,13 @@ from typing import TYPE_CHECKING, Type
 
 from pydantic_ai.messages import ModelResponsePart, TextPart, ThinkingPart
 from rich.columns import Columns
-from rich.console import Console, ConsoleOptions, RenderResult
+from rich.console import Console, ConsoleOptions, Group, RenderResult
 from rich.live import Live
 from rich.markdown import CodeBlock, Markdown
 from rich.panel import Panel
 from rich.spinner import Spinner
 from rich.syntax import Syntax
+from rich.table import Table
 from rich.text import Text
 from sqlsaber.theme.manager import get_theme_manager
 from sqlsaber.tools.display import ResultConfig, SpecRenderer, ToolDisplaySpec
@@ -213,14 +214,27 @@ class DisplayManager:
         self.tm = get_theme_manager()
         self._spec_renderer = SpecRenderer(self.tm)
         self._replay_messages: list | None = None
+        self._pending_ask_database_context: dict[str, str] | None = None
+        self._pending_ask_database_contexts: dict[str, dict[str, str]] = {}
 
     def set_replay_messages(self, messages: list) -> None:
         """Set message history for replay scenarios (e.g., threads show)."""
         self._replay_messages = messages
 
-    def show_tool_executing(self, tool_name: str, tool_input: dict):
+    def show_tool_executing(
+        self,
+        tool_name: str,
+        tool_input: dict,
+        *,
+        tool_call_id: str | None = None,
+    ):
         """Display tool execution details."""
         self.show_newline()
+        if self._render_coordinator_tool_executing(
+            tool_name, tool_input, tool_call_id=tool_call_id
+        ):
+            return
+
         tool = self._get_tool(tool_name)
         if tool and tool.render_executing(self.console, tool_input):
             return
@@ -239,8 +253,19 @@ class DisplayManager:
         if text is not None:  # Extra safety check
             self.console.print(text, end="", markup=False)
 
-    def show_tool_result(self, tool_name: str, result: object) -> None:
+    def show_tool_result(
+        self,
+        tool_name: str,
+        result: object,
+        *,
+        tool_call_id: str | None = None,
+    ) -> None:
         """Display tool result using override/spec/fallback resolution."""
+        if self._render_coordinator_tool_result(
+            tool_name, result, tool_call_id=tool_call_id
+        ):
+            return
+
         tool = self._get_tool(tool_name)
         if tool:
             if self._replay_messages is not None and hasattr(
@@ -296,6 +321,185 @@ class DisplayManager:
             return tool_registry.get_tool(tool_name)
         except KeyError:
             return None
+
+    def _render_coordinator_tool_executing(
+        self, tool_name: str, tool_input: dict, *, tool_call_id: str | None
+    ) -> bool:
+        if tool_name == "ask_database":
+            database_id = str(tool_input.get("database_id") or "database")
+            question = str(tool_input.get("question") or "").strip()
+            context = {
+                "database_id": database_id,
+                "question": question,
+            }
+            if tool_call_id:
+                self._pending_ask_database_contexts[tool_call_id] = context
+            else:
+                self._pending_ask_database_context = context
+
+            if self.console.is_terminal:
+                line = Text("Asking database ", style=self.tm.style("muted"))
+                line.append(database_id, style=self.tm.style("info"))
+                self.console.print(line)
+                if question:
+                    question_text = Text("Question: ", style=self.tm.style("muted"))
+                    question_text.append(question)
+                    self.console.print(question_text)
+            else:
+                self.console.print(f"**Asking database {database_id}**")
+                if question:
+                    self.console.print(f"Question: {question}")
+            return True
+
+        if tool_name == "list_connected_databases":
+            if self.console.is_terminal:
+                self.console.print(
+                    "[muted bold]Checking connected databases[/muted bold]"
+                )
+            else:
+                self.console.print("**Checking connected databases**")
+            return True
+
+        return False
+
+    def _render_coordinator_tool_result(
+        self, tool_name: str, result: object, *, tool_call_id: str | None
+    ) -> bool:
+        if tool_name == "ask_database":
+            self._render_ask_database_result(result, tool_call_id=tool_call_id)
+            return True
+
+        if tool_name == "list_connected_databases":
+            self._render_connected_databases(result)
+            return True
+
+        return False
+
+    def _render_ask_database_result(
+        self, result: object, *, tool_call_id: str | None
+    ) -> None:
+        database_name, database_id, thread_id, answer_text = (
+            self._split_child_answer_result(str(result))
+        )
+        context = self._pop_ask_database_context(tool_call_id)
+        if not database_id:
+            database_id = context.get("database_id")
+        question = context.get("question", "").strip()
+
+        title_target = database_name or database_id or "database"
+        panel_title = f"Subagent answer: {title_target}"
+        if database_id and database_id != title_target:
+            panel_title = f"{panel_title} ({database_id})"
+
+        renderables = []
+        if question:
+            question_text = Text()
+            question_text.append("Question: ", style=self.tm.style("muted"))
+            question_text.append(question)
+            renderables.append(question_text)
+        if thread_id:
+            thread_text = Text()
+            thread_text.append("Thread: ", style=self.tm.style("muted"))
+            thread_text.append(thread_id, style=self.tm.style("muted"))
+            renderables.append(thread_text)
+        if renderables:
+            renderables.append(Text(""))
+        renderables.append(
+            Markdown(answer_text, code_theme=self.tm.pygments_style_name)
+        )
+
+        self.console.print(
+            Panel(
+                Group(*renderables),
+                title=panel_title,
+                border_style=self.tm.style("panel.border.assistant"),
+                expand=True,
+            )
+        )
+
+    def _pop_ask_database_context(self, tool_call_id: str | None) -> dict[str, str]:
+        if tool_call_id:
+            context = self._pending_ask_database_contexts.pop(tool_call_id, None)
+            if context is not None:
+                return context
+
+        context = self._pending_ask_database_context or {}
+        self._pending_ask_database_context = None
+        return context
+
+    def _split_child_answer_result(
+        self, result: str
+    ) -> tuple[str | None, str | None, str | None, str]:
+        lines = result.strip().splitlines()
+        if not lines:
+            return None, None, None, ""
+
+        database_name: str | None = None
+        database_id: str | None = None
+        thread_id: str | None = None
+        body_start = 0
+
+        first = lines[0].strip()
+        if first.startswith("Database: "):
+            database_label = first.removeprefix("Database: ").strip()
+            if database_label.endswith(")") and " (id: " in database_label:
+                database_name, raw_id = database_label.rsplit(" (id: ", 1)
+                database_id = raw_id[:-1]
+            else:
+                database_name = database_label
+            body_start = 1
+
+        if len(lines) > body_start:
+            candidate = lines[body_start].strip()
+            if candidate.startswith("Child thread ID: "):
+                thread_id = candidate.removeprefix("Child thread ID: ").strip()
+                body_start += 1
+
+        answer_text = "\n".join(lines[body_start:]).strip()
+        return database_name, database_id, thread_id, answer_text
+
+    def _render_connected_databases(self, result: object) -> None:
+        rows = self._coerce_database_rows(result)
+        if not rows:
+            self.console.print("[muted]No connected databases.[/muted]")
+            return
+
+        table = Table(title="Connected databases")
+        table.add_column("ID", style=self.tm.style("info"))
+        table.add_column("Name")
+        table.add_column("Type", style=self.tm.style("muted"))
+        table.add_column("Description", style=self.tm.style("muted"))
+        for row in rows:
+            table.add_row(
+                str(row.get("id") or ""),
+                str(row.get("name") or ""),
+                str(row.get("type") or ""),
+                str(row.get("description") or row.get("summary") or ""),
+            )
+        self.console.print(table)
+
+    def _coerce_database_rows(self, result: object) -> list[dict[str, object]]:
+        data = result
+        if isinstance(result, str):
+            try:
+                data = json.loads(result)
+            except json.JSONDecodeError:
+                return []
+
+        if not isinstance(data, list):
+            return []
+
+        rows: list[dict[str, object]] = []
+        for item in data:
+            if isinstance(item, dict):
+                rows.append({str(key): value for key, value in item.items()})
+                continue
+            model_dump = getattr(item, "model_dump", None)
+            if callable(model_dump):
+                dumped = model_dump()
+                if isinstance(dumped, dict):
+                    rows.append({str(key): value for key, value in dumped.items()})
+        return rows
 
     def _render_fallback_result(self, result: object) -> None:
         if isinstance(result, str):

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -52,7 +52,8 @@ class InteractiveSession:
         self.console = console
         self.session = session
         self.sqlsaber_agent = session.agent
-        self.db_conn = session.connection
+        self.connections = getattr(session, "connections", None)
+        self.db_conn = None if self.connections else getattr(session, "connection", None)
         self.database_name = session.db_name
         self.display = DisplayManager(console)
         self.streaming_handler = StreamingQueryHandler(console)
@@ -109,6 +110,11 @@ class InteractiveSession:
 
     def _db_type_name(self) -> str:
         """Get human-readable database type name."""
+        if self.connections:
+            return "multi-database"
+        if self.db_conn is None:
+            return "database"
+
         mapping = {
             PostgreSQLConnection: "PostgreSQL",
             MySQLConnection: "MySQL",
@@ -148,6 +154,10 @@ class InteractiveSession:
 
     async def _update_table_cache(self):
         """Update the table completer cache with fresh data."""
+        if self.connections or self.db_conn is None:
+            self.table_completer.update_cache([])
+            return
+
         try:
             tables_data = await SchemaManager(self.db_conn).list_tables()
 

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -53,7 +53,9 @@ class InteractiveSession:
         self.session = session
         self.sqlsaber_agent = session.agent
         self.connections = getattr(session, "connections", None)
-        self.db_conn = None if self.connections else getattr(session, "connection", None)
+        self.db_conn = (
+            None if self.connections else getattr(session, "connection", None)
+        )
         self.database_name = session.db_name
         self.display = DisplayManager(console)
         self.streaming_handler = StreamingQueryHandler(console)

--- a/src/sqlsaber/cli/streaming.py
+++ b/src/sqlsaber/cli/streaming.py
@@ -74,7 +74,7 @@ class StreamingQueryHandler:
             self.display.live.append(event.part.content)
         elif isinstance(event.part, ToolCallPart):
             self._tool_call_names[event.index] = event.part.tool_name
-            self._maybe_start_sql_generation_status(event.part.tool_name)
+            self._maybe_start_tool_status(event.part.tool_name)
 
     @on_event.register
     async def _(self, event: PartDeltaEvent, ctx: RunContext) -> None:
@@ -94,7 +94,7 @@ class StreamingQueryHandler:
                 current_name = self._tool_call_names.get(event.index, "")
                 updated_name = f"{current_name}{d.tool_name_delta}"
                 self._tool_call_names[event.index] = updated_name
-                self._maybe_start_sql_generation_status(updated_name)
+                self._maybe_start_tool_status(updated_name)
 
     @on_event.register
     async def _(self, event: PartEndEvent, ctx: RunContext) -> None:
@@ -113,13 +113,35 @@ class StreamingQueryHandler:
             if isinstance(query, str) and query.strip():
                 self.display.live.start_sql_block(query)
         else:
-            self.display.show_tool_executing(event.part.tool_name, args)
-            if event.part.tool_name == "viz":
-                self.display.live.start_status("Generating visualization...")
+            self.display.show_tool_executing(
+                event.part.tool_name,
+                args,
+                tool_call_id=event.part.tool_call_id,
+            )
+            status = self._tool_execution_status(event.part.tool_name, args)
+            if status:
+                self.display.live.start_status(status)
 
-    def _maybe_start_sql_generation_status(self, tool_name: str) -> None:
+    def _maybe_start_tool_status(self, tool_name: str) -> None:
+        status = self._tool_execution_status(tool_name, {})
+        if status:
+            self.display.live.start_status(status)
+
+    def _tool_execution_status(
+        self, tool_name: str, args: dict[str, Any]
+    ) -> str | None:
         if tool_name == "execute_sql":
-            self.display.live.start_status("Generating SQL...")
+            return "Generating SQL..."
+        if tool_name == "ask_database":
+            database_id = str(args.get("database_id") or "").strip()
+            if database_id:
+                return f"Querying database {database_id}..."
+            return "Querying database..."
+        if tool_name == "list_connected_databases":
+            return "Inspecting connected databases..."
+        if tool_name == "viz":
+            return "Generating visualization..."
+        return None
 
     @on_event.register
     async def _(self, event: FunctionToolResultEvent, ctx: RunContext) -> None:
@@ -129,7 +151,8 @@ class StreamingQueryHandler:
         content = event.result.content
         if tool_name is None:
             return
-        self.display.show_tool_result(tool_name, content)
+        tool_call_id = getattr(event.result, "tool_call_id", None)
+        self.display.show_tool_result(tool_name, content, tool_call_id=tool_call_id)
         # Add a blank line after tool output to separate from next segment
         self.display.show_newline()
         # Show status while agent sends a follow-up request to the model

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -14,7 +14,6 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
-from sqlsaber.cli.html_export import render_thread_html
 from sqlsaber.config.logging import get_logger
 from sqlsaber.theme.manager import create_console, get_theme_manager
 
@@ -389,6 +388,8 @@ def export(
     store = ThreadStorage()
 
     async def _run() -> None:
+        from sqlsaber.cli.html_export import render_thread_html
+
         thread = await store.get_thread(thread_id)
         if not thread:
             console.print(f"[error]Thread not found:[/error] {thread_id}")

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -39,6 +39,45 @@ def _human_readable(timestamp: float | None) -> str:
     return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp))
 
 
+def _render_thread_metadata(console: Console, raw_metadata: str | None) -> None:
+    if not raw_metadata:
+        return
+
+    try:
+        metadata = json.loads(raw_metadata)
+    except json.JSONDecodeError:
+        console.print(f"Metadata: {raw_metadata}")
+        return
+
+    if not isinstance(metadata, dict):
+        console.print(f"Metadata: {metadata}")
+        return
+
+    kind = metadata.get("kind")
+    if kind:
+        console.print(f"Kind: {kind}")
+
+    child_threads = metadata.get("child_threads")
+    if isinstance(child_threads, list) and child_threads:
+        table = Table(title="Child threads")
+        table.add_column("Database ID", style=tm.style("info"))
+        table.add_column("Database", style=tm.style("accent"))
+        table.add_column("Thread ID", style=tm.style("success"))
+        for child in child_threads:
+            if not isinstance(child, dict):
+                continue
+            table.add_row(
+                str(child.get("database_id") or "-"),
+                str(child.get("database_name") or "-"),
+                str(child.get("thread_id") or "-"),
+            )
+        console.print(table)
+
+    parent_thread_id = metadata.get("parent_thread_id")
+    if parent_thread_id:
+        console.print(f"Parent thread: {parent_thread_id}")
+
+
 def _render_transcript(
     console: Console, all_msgs: list[ModelMessage], last_n: int | None = None
 ) -> None:
@@ -216,6 +255,7 @@ def show(
     console.print(f"Title: {thread.title}")
     console.print(f"Last activity: {_human_readable(thread.last_activity_at)}")
     console.print(f"Model: {thread.model_name}")
+    _render_thread_metadata(console, getattr(thread, "extra_metadata", None))
     console.print("")
 
     _render_transcript(console, msgs, None)

--- a/src/sqlsaber/config/database.py
+++ b/src/sqlsaber/config/database.py
@@ -30,6 +30,7 @@ class DatabaseConfig:
     ssl_key: str | None = None
     schema: str | None = None
     exclude_schemas: list[str] = field(default_factory=list)
+    description: str | None = None
 
     def to_connection_string(self) -> str:
         """Convert config to database connection string."""
@@ -150,6 +151,7 @@ class DatabaseConfig:
             "ssl_cert": self.ssl_cert,
             "ssl_key": self.ssl_key,
             "schema": self.schema,
+            "description": self.description,
             "exclude_schemas": self.exclude_schemas,
         }
 
@@ -168,6 +170,7 @@ class DatabaseConfig:
             ssl_cert=data.get("ssl_cert"),
             ssl_key=data.get("ssl_key"),
             schema=data.get("schema"),
+            description=data.get("description"),
             exclude_schemas=list(data.get("exclude_schemas", [])),
         )
 

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -105,7 +105,7 @@ class CSVConnection(BaseDatabaseConnection):
 
     def _create_view(self, conn: duckdb.DuckDBPyConnection) -> None:
         header_literal = "TRUE" if self.has_header else "FALSE"
-        option_parts = [f"HEADER={header_literal}"]
+        option_parts: list[str] = [f"HEADER={header_literal}"]
 
         if self.delimiter:
             option_parts.append(f"DELIM={self._quote_literal(self.delimiter)}")

--- a/src/sqlsaber/database/resolver.py
+++ b/src/sqlsaber/database/resolver.py
@@ -18,6 +18,9 @@ class ResolvedDatabase:
     name: str  # Human-readable name for display/logging
     connection_string: str  # Canonical connection string for DatabaseConnection factory
     excluded_schemas: list[str]
+    type: str
+    description: str | None = None
+    id: str | None = None
 
 
 SUPPORTED_SCHEMES = {"postgresql", "mysql", "sqlite", "duckdb", "csv", "csvs"}
@@ -36,6 +39,29 @@ def _csv_stem_from_connection_string(connection_string: str) -> str:
     parsed = urlparse(connection_string)
     stem = Path(parsed.path).stem
     return stem or "csv"
+
+
+def _is_csv_spec(spec: str) -> bool:
+    if _is_connection_string(spec):
+        return urlparse(spec).scheme == "csv"
+    return Path(spec).suffix.lower() == ".csv"
+
+
+def _config_description(db_cfg: DatabaseConfig) -> str | None:
+    description = vars(db_cfg).get("description")
+    if isinstance(description, str) or description is None:
+        return description
+    return None
+
+
+def _assign_database_ids(databases: list[ResolvedDatabase]) -> list[ResolvedDatabase]:
+    seen: dict[str, int] = {}
+    for database in databases:
+        base_id = database.name or "database"
+        count = seen.get(base_id, 0) + 1
+        seen[base_id] = count
+        database.id = base_id if count == 1 else f"{base_id}_{count}"
+    return databases
 
 
 def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
@@ -78,7 +104,10 @@ def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
         name = f"{stems[0]} + {len(stems) - 1} more"
 
     return ResolvedDatabase(
-        name=name, connection_string=f"csvs:///?{query}", excluded_schemas=[]
+        name=name,
+        connection_string=f"csvs:///?{query}",
+        excluded_schemas=[],
+        type="csvs",
     )
 
 
@@ -112,6 +141,8 @@ def resolve_database(
             name=db_cfg.name,
             connection_string=db_cfg.to_connection_string(),
             excluded_schemas=list(db_cfg.exclude_schemas),
+            type=db_cfg.type,
+            description=_config_description(db_cfg),
         )
 
     if isinstance(spec, list):
@@ -131,7 +162,7 @@ def resolve_database(
         else:  # should not happen because of SUPPORTED_SCHEMES
             db_name = "database"
         return ResolvedDatabase(
-            name=db_name, connection_string=spec, excluded_schemas=[]
+            name=db_name, connection_string=spec, excluded_schemas=[], type=scheme
         )
 
     # 2. Raw file path?
@@ -140,19 +171,28 @@ def resolve_database(
         if not path.exists():
             raise DatabaseResolutionError(f"CSV file '{spec}' not found.")
         return ResolvedDatabase(
-            name=path.stem, connection_string=f"csv:///{path}", excluded_schemas=[]
+            name=path.stem,
+            connection_string=f"csv:///{path}",
+            excluded_schemas=[],
+            type="csv",
         )
     if path.suffix.lower() in {".db", ".sqlite", ".sqlite3"}:
         if not path.exists():
             raise DatabaseResolutionError(f"SQLite file '{spec}' not found.")
         return ResolvedDatabase(
-            name=path.stem, connection_string=f"sqlite:///{path}", excluded_schemas=[]
+            name=path.stem,
+            connection_string=f"sqlite:///{path}",
+            excluded_schemas=[],
+            type="sqlite",
         )
     if path.suffix.lower() in {".duckdb", ".ddb"}:
         if not path.exists():
             raise DatabaseResolutionError(f"DuckDB file '{spec}' not found.")
         return ResolvedDatabase(
-            name=path.stem, connection_string=f"duckdb:///{path}", excluded_schemas=[]
+            name=path.stem,
+            connection_string=f"duckdb:///{path}",
+            excluded_schemas=[],
+            type="duckdb",
         )
 
     # 3. Must be a configured name
@@ -167,4 +207,27 @@ def resolve_database(
         name=db_cfg.name,
         connection_string=db_cfg.to_connection_string(),
         excluded_schemas=list(db_cfg.exclude_schemas),
+        type=db_cfg.type,
+        description=_config_description(db_cfg),
+    )
+
+
+def resolve_databases(
+    spec: str | list[str] | None, config_mgr: DatabaseConfigManager | None = None
+) -> list[ResolvedDatabase]:
+    """Turn user CLI input into one or more resolved database connections."""
+    if not isinstance(spec, list):
+        return _assign_database_ids([resolve_database(spec, config_mgr)])
+
+    if len(spec) == 0:
+        resolve_database(spec, config_mgr)
+
+    if len(spec) == 1:
+        return _assign_database_ids([resolve_database(spec[0], config_mgr)])
+
+    if all(_is_csv_spec(item) for item in spec):
+        return _assign_database_ids([_resolve_multiple_csvs(spec)])
+
+    return _assign_database_ids(
+        [resolve_database(database_spec, config_mgr) for database_spec in spec]
     )

--- a/src/sqlsaber/multi_session.py
+++ b/src/sqlsaber/multi_session.py
@@ -10,7 +10,6 @@ from pydantic_ai import RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 
 from sqlsaber.agents.multi_database_agent import (
-    ChildAnswerPayload,
     DatabaseChild,
     DatabaseDescriptor,
     MultiDatabaseCoordinator,
@@ -88,7 +87,7 @@ class MultiDatabaseSession:
                 allow_dangerous=options.allow_dangerous,
                 system_prompt=system_prompt_text,
                 tool_overides=options.tool_overrides,
-                output_type=ChildAnswerPayload,
+                output_type=str,
             )
             descriptor = DatabaseDescriptor(
                 id=database_id,

--- a/src/sqlsaber/multi_session.py
+++ b/src/sqlsaber/multi_session.py
@@ -133,7 +133,9 @@ class MultiDatabaseSession:
             child_was_new = child.thread_manager.current_thread_id is None
             child_thread_id = await child.thread_manager.ensure_thread(
                 database_name=child.database_name,
-                title=f"[{child.database_name}] {prompt}" if child_was_new else None,
+                title=f"[{child.database_name}] |-> {prompt}"
+                if child_was_new
+                else None,
                 model_name=model_name if child_was_new else None,
                 extra_metadata=json.dumps(
                     {

--- a/src/sqlsaber/multi_session.py
+++ b/src/sqlsaber/multi_session.py
@@ -1,0 +1,247 @@
+"""Multi-database session lifecycle owner for SQLSaber SDK usage."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterable, Awaitable, Sequence
+from typing import Any, Callable
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import AgentStreamEvent, ModelMessage
+
+from sqlsaber.agents.multi_database_agent import (
+    ChildAnswerPayload,
+    DatabaseChild,
+    DatabaseDescriptor,
+    MultiDatabaseCoordinator,
+)
+from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
+from sqlsaber.config.logging import get_logger
+from sqlsaber.config.settings import Config, ThinkingLevel
+from sqlsaber.database import BaseDatabaseConnection, DatabaseConnection
+from sqlsaber.database.resolver import ResolvedDatabase, resolve_databases
+from sqlsaber.knowledge.manager import KnowledgeManager
+from sqlsaber.options import SQLSaberOptions
+from sqlsaber.threads.manager import ThreadManager
+from sqlsaber.utils.text_input import resolve_text_input
+
+logger = get_logger(__name__)
+
+
+class MultiDatabaseSession:
+    """Owns the lifecycle of a SQLSaber SDK session with multiple databases."""
+
+    def __init__(self, options: SQLSaberOptions):
+        self.options = options
+        self._closed = False
+
+        database_spec: str | list[str] | None
+        if isinstance(options.database, tuple):
+            database_spec = list(options.database)
+        else:
+            database_spec = options.database
+
+        self._resolved = resolve_databases(database_spec)
+        if len(self._resolved) < 2:
+            raise ValueError("MultiDatabaseSession requires at least two databases.")
+
+        self.db_name = " + ".join(database.name for database in self._resolved)
+        self.connections: dict[str, BaseDatabaseConnection] = {
+            self._database_id(database): DatabaseConnection(
+                database.connection_string,
+                excluded_schemas=database.excluded_schemas,
+            )
+            for database in self._resolved
+        }
+
+        self.settings = options.settings or Config.default()
+        self.knowledge_manager = options.knowledge_manager or KnowledgeManager()
+        self.thread_manager = options.thread_manager or ThreadManager()
+        self._owns_knowledge_manager = options.knowledge_manager is None
+
+        resolved_thinking_level: ThinkingLevel | None = None
+        thinking_enabled = options.thinking_enabled
+        if options.thinking_level is not None:
+            if isinstance(options.thinking_level, str):
+                resolved_thinking_level = ThinkingLevel.from_string(
+                    options.thinking_level
+                )
+            else:
+                resolved_thinking_level = options.thinking_level
+            thinking_enabled = True
+
+        system_prompt_text = resolve_text_input(options.system_prompt)
+
+        children: dict[str, DatabaseChild] = {}
+        for database in self._resolved:
+            database_id = self._database_id(database)
+            child_thread_manager = ThreadManager(storage=self.thread_manager.storage)
+            child_agent = SQLSaberAgent(
+                self.connections[database_id],
+                database.name,
+                settings=self.settings,
+                knowledge_manager=self.knowledge_manager,
+                thinking_enabled=thinking_enabled,
+                thinking_level=resolved_thinking_level,
+                model_name=options.model_name,
+                api_key=options.api_key,
+                allow_dangerous=options.allow_dangerous,
+                system_prompt=system_prompt_text,
+                tool_overides=options.tool_overrides,
+                output_type=ChildAnswerPayload,
+            )
+            descriptor = DatabaseDescriptor(
+                id=database_id,
+                name=database.name,
+                type=database.type,
+                description=database.description,
+                summary=database.description,
+                thread_id=None,
+            )
+            children[database_id] = DatabaseChild(
+                descriptor=descriptor,
+                agent=child_agent,
+                thread_manager=child_thread_manager,
+                database_name=database.name,
+            )
+
+        self.children = children
+        self.agent = MultiDatabaseCoordinator(
+            children=children,
+            database_label=self.db_name,
+            settings=self.settings,
+            thinking_enabled=thinking_enabled,
+            thinking_level=resolved_thinking_level,
+            model_name=options.model_name,
+            api_key=options.api_key,
+        )
+
+    async def _ensure_threads(self, prompt: str) -> None:
+        """Pre-create parent and child threads before coordinator execution."""
+        model_name = self._model_name()
+        parent_was_new = self.thread_manager.current_thread_id is None
+        parent_thread_id = await self.thread_manager.ensure_thread(
+            database_name=self.db_name,
+            title=prompt if parent_was_new else None,
+            model_name=model_name if parent_was_new else None,
+            extra_metadata=json.dumps(
+                {"kind": "multi_database_parent", "child_threads": []}
+            ),
+        )
+
+        child_threads: list[dict[str, str | None]] = []
+        for database_id, child in self.children.items():
+            child_was_new = child.thread_manager.current_thread_id is None
+            child_thread_id = await child.thread_manager.ensure_thread(
+                database_name=child.database_name,
+                title=f"[{child.database_name}] {prompt}" if child_was_new else None,
+                model_name=model_name if child_was_new else None,
+                extra_metadata=json.dumps(
+                    {
+                        "kind": "multi_database_child",
+                        "parent_thread_id": parent_thread_id,
+                        "database_id": database_id,
+                    }
+                ),
+            )
+            child.descriptor.thread_id = child_thread_id
+            child_threads.append(
+                {
+                    "database_id": database_id,
+                    "database_name": child.database_name,
+                    "thread_id": child_thread_id,
+                }
+            )
+
+        await self.thread_manager.ensure_thread(
+            database_name=self.db_name,
+            extra_metadata=json.dumps(
+                {
+                    "kind": "multi_database_parent",
+                    "child_threads": child_threads,
+                }
+            ),
+        )
+
+    async def query(
+        self,
+        prompt: str,
+        message_history: Sequence[ModelMessage] | None = None,
+        event_stream_handler: Callable[
+            [RunContext[Any], AsyncIterable[AgentStreamEvent]],
+            Awaitable[None],
+        ]
+        | None = None,
+    ) -> Any:
+        """Run a natural language query across configured databases."""
+        await self._ensure_threads(prompt)
+        run_result = await self.agent.run(
+            prompt,
+            message_history=message_history,
+            event_stream_handler=event_stream_handler,
+        )
+
+        try:
+            await self.thread_manager.save_run(
+                run_result=run_result,
+                database_name=self.db_name,
+                user_query=prompt,
+                model_name=self._model_name(),
+            )
+        except Exception as exc:
+            logger.warning("sdk.thread.save_failed", error=str(exc))
+
+        return run_result
+
+    async def close(self) -> None:
+        """Close resources owned by this session."""
+        if self._closed:
+            return
+        self._closed = True
+
+        errors: list[BaseException] = []
+
+        try:
+            await self.thread_manager.end_current_thread()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            logger.warning("sdk.thread.end_failed", error=str(exc))
+
+        for database_id, child in self.children.items():
+            try:
+                await child.thread_manager.end_current_thread()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.warning(
+                    "sdk.thread.child_end_failed",
+                    database_id=database_id,
+                    error=str(exc),
+                )
+
+        try:
+            await self.agent.close()
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            errors.append(exc)
+
+        if self._owns_knowledge_manager:
+            try:
+                await self.knowledge_manager.close()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                errors.append(exc)
+
+        for connection in self.connections.values():
+            try:
+                await connection.close()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                errors.append(exc)
+
+        if errors:
+            raise errors[0]
+
+    def _model_name(self) -> str:
+        model = getattr(self.agent.agent, "model", None)
+        model_name = getattr(model, "model_name", None)
+        if isinstance(model_name, str) and model_name:
+            return model_name
+        return self.settings.model.name
+
+    def _database_id(self, database: ResolvedDatabase) -> str:
+        return database.id or database.name

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -12,7 +12,7 @@ from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
 from sqlsaber.config.logging import get_logger
 from sqlsaber.config.settings import Config, ThinkingLevel
 from sqlsaber.database import DatabaseConnection
-from sqlsaber.database.resolver import resolve_database
+from sqlsaber.database.resolver import resolve_database, resolve_databases
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.options import SQLSaberOptions
 from sqlsaber.utils.text_input import resolve_text_input
@@ -83,6 +83,20 @@ class SQLSaberSession:
         | None = None,
     ) -> Any:
         """Run a natural language query against the configured database."""
+        if (
+            self.thread_manager is not None
+            and getattr(self.thread_manager, "current_thread_id", None) is None
+            and hasattr(self.thread_manager, "ensure_thread")
+        ):
+            try:
+                await self.thread_manager.ensure_thread(
+                    database_name=self.db_name,
+                    title=prompt,
+                    model_name=self._model_name(),
+                )
+            except Exception as exc:
+                logger.warning("sdk.thread.ensure_failed", error=str(exc))
+
         run_result = await self.agent.run(
             prompt,
             message_history=message_history,
@@ -91,15 +105,11 @@ class SQLSaberSession:
 
         if self.thread_manager is not None:
             try:
-                resolved_model_name = getattr(self.agent.agent.model, "model_name", "")
-                if not isinstance(resolved_model_name, str) or not resolved_model_name:
-                    resolved_model_name = self.agent.config.model.name
-
                 await self.thread_manager.save_run(
                     run_result=run_result,
                     database_name=self.db_name,
                     user_query=prompt,
-                    model_name=resolved_model_name,
+                    model_name=self._model_name(),
                 )
             except Exception as exc:
                 logger.warning("sdk.thread.save_failed", error=str(exc))
@@ -138,3 +148,25 @@ class SQLSaberSession:
 
         if errors:
             raise errors[0]
+
+    def _model_name(self) -> str:
+        resolved_model_name = getattr(self.agent.agent.model, "model_name", "")
+        if not isinstance(resolved_model_name, str) or not resolved_model_name:
+            resolved_model_name = self.agent.config.model.name
+        return resolved_model_name
+
+
+def create_session(options: SQLSaberOptions) -> SQLSaberSession:
+    """Create a single or multi-database session for the given options."""
+    database_spec: str | list[str] | None
+    if isinstance(options.database, tuple):
+        database_spec = list(options.database)
+    else:
+        database_spec = options.database
+
+    resolved = resolve_databases(database_spec)
+    if len(resolved) > 1:
+        from sqlsaber.multi_session import MultiDatabaseSession
+
+        return MultiDatabaseSession(options)  # type: ignore[return-value]
+    return SQLSaberSession(options)

--- a/src/sqlsaber/threads/manager.py
+++ b/src/sqlsaber/threads/manager.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from pydantic_ai.messages import ModelMessagesTypeAdapter
+
 from sqlsaber.config.logging import get_logger
 from sqlsaber.threads.storage import ThreadStorage
 
@@ -45,6 +47,37 @@ class ThreadManager:
         await self.end_current_thread()
         self.current_thread_id = None
         self.first_message = True
+
+    async def ensure_thread(
+        self,
+        *,
+        database_name: str | None,
+        title: str | None = None,
+        model_name: str | None = None,
+        extra_metadata: str | None = None,
+    ) -> str:
+        """Create the active thread before model execution if it does not exist."""
+        if self.current_thread_id is None:
+            self.current_thread_id = await self.storage.save_snapshot(
+                messages_json=ModelMessagesTypeAdapter.dump_json([]),
+                database_name=database_name,
+                extra_metadata=extra_metadata,
+            )
+        elif extra_metadata is not None:
+            await self.storage.save_metadata(
+                thread_id=self.current_thread_id,
+                extra_metadata=extra_metadata,
+            )
+
+        if title is not None or model_name is not None:
+            await self.storage.save_metadata(
+                thread_id=self.current_thread_id,
+                title=title,
+                model_name=model_name,
+            )
+            self.first_message = False
+
+        return self.current_thread_id
 
     async def save_run(
         self,

--- a/src/sqlsaber/threads/storage.py
+++ b/src/sqlsaber/threads/storage.py
@@ -53,6 +53,7 @@ class Thread:
         ended_at: float | None,
         last_activity_at: float,
         model_name: str | None,
+        extra_metadata: str | None = None,
     ) -> None:
         self.id = id
         self.database_name = database_name
@@ -61,6 +62,7 @@ class Thread:
         self.ended_at = ended_at
         self.last_activity_at = last_activity_at
         self.model_name = model_name
+        self.extra_metadata = extra_metadata
 
 
 class ThreadStorage:
@@ -78,6 +80,12 @@ class ThreadStorage:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
             async with aiosqlite.connect(self.db_path) as db:
                 await db.executescript(SCHEMA_SQL)
+                async with db.execute("PRAGMA table_info(threads)") as cur:
+                    columns = {row[1] async for row in cur}
+                if "extra_metadata" not in columns:
+                    await db.execute(
+                        "ALTER TABLE threads ADD COLUMN extra_metadata TEXT"
+                    )
                 await db.commit()
             self._initialized = True
             logger.info("threads.db.init", path=str(self.db_path))
@@ -155,19 +163,36 @@ class ThreadStorage:
         thread_id: str,
         title: str | None = None,
         model_name: str | None = None,
+        extra_metadata: str | None = None,
     ) -> bool:
         """Update thread metadata (title/model/extra). Only provided fields are updated."""
         await self._init_db()
+
+        update_title = title is not None
+        update_model_name = model_name is not None
+        update_extra_metadata = extra_metadata is not None
+        if not (update_title or update_model_name or update_extra_metadata):
+            return True
 
         try:
             async with self._lock, aiosqlite.connect(self.db_path) as db:
                 await db.execute(
                     """
                     UPDATE threads
-                    SET title = ?, model_name = ?
+                    SET title = CASE WHEN ? THEN ? ELSE title END,
+                        model_name = CASE WHEN ? THEN ? ELSE model_name END,
+                        extra_metadata = CASE WHEN ? THEN ? ELSE extra_metadata END
                     WHERE id = ?
                     """,
-                    (title, model_name, thread_id),
+                    (
+                        update_title,
+                        title,
+                        update_model_name,
+                        model_name,
+                        update_extra_metadata,
+                        extra_metadata,
+                        thread_id,
+                    ),
                 )
                 await db.commit()
             logger.info("threads.update_metadata", thread_id=thread_id)
@@ -200,7 +225,7 @@ class ThreadStorage:
                 async with db.execute(
                     """
                     SELECT id, database_name, title, created_at, ended_at,
-                           last_activity_at, model_name
+                           last_activity_at, model_name, extra_metadata
                     FROM threads WHERE id = ?
                     """,
                     (thread_id,),
@@ -216,6 +241,7 @@ class ThreadStorage:
                         ended_at=row[4],
                         last_activity_at=row[5],
                         model_name=row[6],
+                        extra_metadata=row[7],
                     )
         except Exception as e:  # pragma: no cover
             logger.warning("threads.get_failed", thread_id=thread_id, error=str(e))
@@ -247,7 +273,8 @@ class ThreadStorage:
         await self._init_db()
         try:
             query = (
-                "SELECT id, database_name, title, created_at, ended_at, last_activity_at, model_name"
+                "SELECT id, database_name, title, created_at, ended_at, last_activity_at,"
+                " model_name, extra_metadata"
                 " FROM threads"
             )
             params: list[Any] = []
@@ -270,6 +297,7 @@ class ThreadStorage:
                                 ended_at=row[4],
                                 last_activity_at=row[5],
                                 model_name=row[6],
+                                extra_metadata=row[7],
                             )
                         )
                     return threads

--- a/src/sqlsaber/tools/sql_guard.py
+++ b/src/sqlsaber/tools/sql_guard.py
@@ -366,7 +366,7 @@ LIMIT_ALL_UNBOUNDED_DIALECTS: set[str] = {
 }
 
 # Known from-less projection nodes/functions that can yield multiple rows.
-SET_RETURNING_PROJECTION_NODE_TYPES: tuple[type[exp.Expression], ...] = (
+SET_RETURNING_PROJECTION_NODE_TYPES: tuple[type[exp.Expr], ...] = (
     exp.Explode,
     exp.ExplodeOuter,
     exp.Unnest,
@@ -1611,7 +1611,7 @@ def _has_global_aggregate_without_group(select: exp.Select) -> bool:
     if select.args.get("group") is not None:
         return False
 
-    def should_prune(node: exp.Expression) -> bool:
+    def should_prune(node: exp.Expr) -> bool:
         return node is not select and isinstance(
             node,
             (exp.Subquery, exp.Select, exp.Union, exp.Except, exp.Intersect),
@@ -2696,7 +2696,7 @@ def _expression_references_target_symbols(
     if expression is None or not target_symbols:
         return False
 
-    def should_prune(node: exp.Expression) -> bool:
+    def should_prune(node: exp.Expr) -> bool:
         return isinstance(
             node,
             (exp.Subquery, exp.Select, exp.Union, exp.Except, exp.Intersect),
@@ -3449,7 +3449,9 @@ def _unfiltered_mutation_reason(
 
     where_clause = node.args.get("where")
     if not where_clause:
-        return f"{operation} without WHERE clause is not allowed (would affect all rows)"
+        return (
+            f"{operation} without WHERE clause is not allowed (would affect all rows)"
+        )
 
     if not isinstance(where_clause, exp.Where):
         return None
@@ -3665,9 +3667,7 @@ def has_disallowed_dangerous_mode_statement(stmt: exp.Expression) -> str | None:
             if expression is not None and not is_select_like(expression):
                 return "CREATE VIEW must be based on a SELECT-like expression"
         elif (
-            kind == "INDEX"
-            and target is not None
-            and not isinstance(target, exp.Index)
+            kind == "INDEX" and target is not None and not isinstance(target, exp.Index)
         ):
             return "Only CREATE INDEX statements are allowed in dangerous mode"
 
@@ -3727,7 +3727,7 @@ def validate_read_only(sql: str, dialect: str = "ansi") -> GuardResult:
         )
 
     stmt = statements[0]
-    if stmt is None:
+    if stmt is None or not isinstance(stmt, exp.Expression):
         return GuardResult(False, "Unable to parse query - empty statement")
 
     # Must be a SELECT-like statement
@@ -3797,7 +3797,7 @@ def validate_sql(
         )
 
     stmt = statements[0]
-    if stmt is None:
+    if stmt is None or not isinstance(stmt, exp.Expression):
         return GuardResult(False, "Unable to parse query - empty statement")
 
     try:
@@ -3864,7 +3864,7 @@ def add_limit(sql: str, dialect: str = "ansi", limit: int = 100) -> str:
             return sql
 
         stmt = statements[0]
-        if stmt is None:
+        if stmt is None or not isinstance(stmt, exp.Expression):
             return sql
 
         # Check if LIMIT/TOP/FETCH already exists

--- a/src/sqlsaber/tools/sql_tools.py
+++ b/src/sqlsaber/tools/sql_tools.py
@@ -649,7 +649,7 @@ class ExecuteSQLTool(SQLTool):
                     payload["file"] = f"result_{tool_call_id}.json"
                 return json_dumps(payload)
             if query_type in {"dml", "ddl"}:
-                payload = {"success": True}
+                payload: dict[str, Any] = {"success": True}
                 if tool_call_id:
                     payload["file"] = f"result_{tool_call_id}.json"
                 return json_dumps(payload)

--- a/tests/test_agents/test_multi_database_agent.py
+++ b/tests/test_agents/test_multi_database_agent.py
@@ -116,7 +116,9 @@ def test_database_answer_uses_specified_fields_only() -> None:
     }
 
 
-def test_database_descriptor_schema_and_system_prompt_include_database_metadata() -> None:
+def test_database_descriptor_schema_and_system_prompt_include_database_metadata() -> (
+    None
+):
     coordinator = MultiDatabaseCoordinator(
         children={
             "warehouse": DatabaseChild(
@@ -280,7 +282,9 @@ async def test_ask_database_direct_returns_failed_answer_when_child_run_raises(
     assert answer.database_name == "Orders"
     assert answer.thread_id is not None
     assert answer.evidence == []
-    assert answer.limitations == ["Child agent failed: structured output validation failed"]
+    assert answer.limitations == [
+        "Child agent failed: structured output validation failed"
+    ]
     assert child.message_history == []
 
     stored_thread = await temp_storage.get_thread(answer.thread_id)

--- a/tests/test_agents/test_multi_database_agent.py
+++ b/tests/test_agents/test_multi_database_agent.py
@@ -18,8 +18,6 @@ from pydantic_ai.messages import (
 )
 
 from sqlsaber.agents.multi_database_agent import (
-    ChildAnswerPayload,
-    DatabaseAnswer,
     DatabaseChild,
     DatabaseDescriptor,
     MultiDatabaseCoordinator,
@@ -45,7 +43,7 @@ def _messages(user_text: str, assistant_text: str) -> list[ModelMessage]:
 
 
 class FakeChildAgent:
-    def __init__(self, outputs: list[ChildAnswerPayload]) -> None:
+    def __init__(self, outputs: list[str]) -> None:
         self.outputs = outputs
         self.calls: list[dict[str, Any]] = []
         self.agent = SimpleNamespace(model=SimpleNamespace(model_name="fake-child"))
@@ -67,7 +65,7 @@ class FakeChildAgent:
         output = self.outputs.pop(0)
         messages = [
             *(message_history or []),
-            *_messages(prompt, output.summary),
+            *_messages(prompt, output),
         ]
         return SimpleNamespace(
             output=output,
@@ -94,7 +92,13 @@ class InvalidOutputChildAgent:
     async def run(self, *args: Any, **kwargs: Any) -> Any:
         _ = args
         _ = kwargs
-        return SimpleNamespace(output="not structured")
+        output = SimpleNamespace(summary="not structured")
+        messages = _messages("How many orders?", str(output))
+        return SimpleNamespace(
+            output=output,
+            all_messages=lambda: messages,
+            all_messages_json=lambda: ModelMessagesTypeAdapter.dump_json(messages),
+        )
 
 
 class AsyncClosableChildAgent:
@@ -105,15 +109,24 @@ class AsyncClosableChildAgent:
         self.closed = True
 
 
-def test_database_answer_uses_specified_fields_only() -> None:
-    assert set(DatabaseAnswer.model_fields) == {
-        "database_id",
-        "database_name",
-        "thread_id",
-        "summary",
-        "evidence",
-        "limitations",
-    }
+def test_child_prompt_requests_markdown_sections() -> None:
+    coordinator = MultiDatabaseCoordinator(
+        children={},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+    prompt = coordinator._child_prompt(
+        DatabaseDescriptor(id="orders", name="Orders", type="sqlite"),
+        "How many orders?",
+    )
+
+    assert "Answer using only database 'Orders'" in prompt
+    assert "## Answer" in prompt
+    assert "## Evidence" in prompt
+    assert "## SQL" in prompt
+    assert "## Limitations" in prompt
+    assert "ChildAnswerPayload" not in prompt
 
 
 def test_database_descriptor_schema_and_system_prompt_include_database_metadata() -> (
@@ -160,15 +173,17 @@ async def test_ask_database_direct_routes_reuses_thread_history_and_preserves_pa
 ) -> None:
     child_agent = FakeChildAgent(
         outputs=[
-            ChildAnswerPayload(
-                summary="Orders total is 42.",
-                evidence=["SELECT count(*) FROM orders"],
-                limitations=["Only completed orders were included."],
+            (
+                "## Answer\nOrders total is 42.\n\n"
+                "## Evidence\n- `SELECT count(*) FROM orders`\n\n"
+                "## SQL\n```sql\nSELECT count(*) FROM orders;\n```\n\n"
+                "## Limitations\n- Only completed orders were included."
             ),
-            ChildAnswerPayload(
-                summary="Revenue total is 99.",
-                evidence=["SELECT sum(total) FROM orders"],
-                limitations=["Refund data is unavailable."],
+            (
+                "## Answer\nRevenue total is 99.\n\n"
+                "## Evidence\n- `SELECT sum(total) FROM orders`\n\n"
+                "## SQL\n```sql\nSELECT sum(total) FROM orders;\n```\n\n"
+                "## Limitations\n- Refund data is unavailable."
             ),
         ]
     )
@@ -200,29 +215,34 @@ async def test_ask_database_direct_routes_reuses_thread_history_and_preserves_pa
         "orders", "What revenue?", usage=usage
     )
 
-    assert isinstance(first, DatabaseAnswer)
-    assert first.database_id == "orders"
-    assert first.database_name == "Orders"
-    assert first.thread_id is not None
-    assert first.summary == "Orders total is 42."
-    assert first.evidence == ["SELECT count(*) FROM orders"]
-    assert first.limitations == ["Only completed orders were included."]
+    assert isinstance(first, str)
+    assert "Database: Orders (id: orders)" in first
+    assert child.thread_manager.current_thread_id is not None
+    assert f"Child thread ID: {child.thread_manager.current_thread_id}" in first
+    assert "## Answer\nOrders total is 42." in first
+    assert "`SELECT count(*) FROM orders`" in first
+    assert "Only completed orders were included." in first
 
-    assert second.thread_id == first.thread_id
-    assert second.summary == "Revenue total is 99."
-    assert second.evidence == ["SELECT sum(total) FROM orders"]
-    assert second.limitations == ["Refund data is unavailable."]
+    assert f"Child thread ID: {child.thread_manager.current_thread_id}" in second
+    assert "## Answer\nRevenue total is 99." in second
+    assert "`SELECT sum(total) FROM orders`" in second
+    assert "Refund data is unavailable." in second
 
-    assert child.descriptor.thread_id == first.thread_id
+    assert child.descriptor.thread_id == child.thread_manager.current_thread_id
     assert child_agent.calls[0]["message_history"] == []
     assert child_agent.calls[0]["usage"] is usage
     assert child_agent.calls[1]["message_history"] == child.message_history[:2]
     assert child_agent.calls[1]["usage"] is usage
     assert len(child.message_history) == 4
 
-    stored_messages = await temp_storage.get_thread_messages(first.thread_id)
+    assert child.thread_manager.current_thread_id is not None
+    stored_messages = await temp_storage.get_thread_messages(
+        child.thread_manager.current_thread_id
+    )
     assert len(stored_messages) == 4
-    stored_thread = await temp_storage.get_thread(first.thread_id)
+    stored_thread = await temp_storage.get_thread(
+        child.thread_manager.current_thread_id
+    )
     assert stored_thread.title == "[Orders] How many orders?"
     assert stored_thread.model_name == "fake-child"
     assert json.loads(stored_thread.extra_metadata) == {
@@ -242,13 +262,13 @@ async def test_ask_database_direct_returns_limitation_for_unknown_database() -> 
 
     answer = await coordinator.ask_database_direct("missing", "What is here?")
 
-    assert answer == DatabaseAnswer(
-        database_id="missing",
-        database_name="missing",
-        thread_id=None,
-        summary="Unable to answer from database 'missing'.",
-        evidence=[],
-        limitations=["Unknown database id 'missing'."],
+    assert answer == (
+        "Database: missing (id: missing)\n"
+        "Child thread ID: unavailable\n\n"
+        "## Answer\n"
+        "Unable to answer from database 'missing'.\n\n"
+        "## Limitations\n"
+        "- Unknown database id 'missing'."
     )
 
 
@@ -278,16 +298,19 @@ async def test_ask_database_direct_returns_failed_answer_when_child_run_raises(
 
     answer = await coordinator.ask_database_direct("orders", "How many orders?")
 
-    assert answer.database_id == "orders"
-    assert answer.database_name == "Orders"
-    assert answer.thread_id is not None
-    assert answer.evidence == []
-    assert answer.limitations == [
-        "Child agent failed: structured output validation failed"
-    ]
+    assert "Database: Orders (id: orders)" in answer
+    assert child.thread_manager.current_thread_id is not None
+    assert f"Child thread ID: {child.thread_manager.current_thread_id}" in answer
+    assert "## Answer\nUnable to answer from database 'orders'." in answer
+    assert (
+        "## Limitations\n- Child agent failed: structured output validation failed"
+        in answer
+    )
     assert child.message_history == []
 
-    stored_thread = await temp_storage.get_thread(answer.thread_id)
+    stored_thread = await temp_storage.get_thread(
+        child.thread_manager.current_thread_id
+    )
     assert stored_thread.title == "[Orders] How many orders?"
     assert stored_thread.model_name == "fake-child"
     assert json.loads(stored_thread.extra_metadata) == {
@@ -297,7 +320,7 @@ async def test_ask_database_direct_returns_failed_answer_when_child_run_raises(
 
 
 @pytest.mark.asyncio
-async def test_ask_database_direct_returns_limitation_when_child_output_is_invalid(
+async def test_ask_database_direct_stringifies_non_string_child_output(
     temp_storage,
 ) -> None:
     child = DatabaseChild(
@@ -322,19 +345,9 @@ async def test_ask_database_direct_returns_limitation_when_child_output_is_inval
 
     answer = await coordinator.ask_database_direct("orders", "How many orders?")
 
-    assert answer.database_id == "orders"
-    assert answer.database_name == "Orders"
-    assert answer.thread_id is not None
-    assert answer.summary == (
-        "Unable to answer from database 'orders' because the child agent returned "
-        "invalid structured output."
-    )
-    assert answer.evidence == []
-    assert answer.limitations == [
-        "Child agent did not return ChildAnswerPayload structured output."
-    ]
-    assert not hasattr(answer, "success")
-    assert child.message_history == []
+    assert "Database: Orders (id: orders)" in answer
+    assert "namespace(summary='not structured')" in answer
+    assert child.message_history
 
 
 @pytest.mark.asyncio
@@ -353,18 +366,11 @@ async def test_registered_ask_database_tool_forwards_usage(monkeypatch) -> None:
         question: str,
         *,
         usage: Any | None = None,
-    ) -> DatabaseAnswer:
+    ) -> str:
         captured["database_id"] = database_id
         captured["question"] = question
         captured["usage"] = usage
-        return DatabaseAnswer(
-            database_id=database_id,
-            database_name="Orders",
-            thread_id="thread-1",
-            summary="ok",
-            evidence=[],
-            limitations=[],
-        )
+        return "ok"
 
     monkeypatch.setattr(coordinator, "ask_database_direct", fake_ask_database_direct)
     ask_tool = coordinator.agent._function_toolset.tools["ask_database"]
@@ -375,7 +381,7 @@ async def test_registered_ask_database_tool_forwards_usage(monkeypatch) -> None:
         "How many orders?",
     )
 
-    assert answer.summary == "ok"
+    assert answer == "ok"
     assert captured == {
         "database_id": "orders",
         "question": "How many orders?",

--- a/tests/test_agents/test_multi_database_agent.py
+++ b/tests/test_agents/test_multi_database_agent.py
@@ -1,0 +1,447 @@
+import json
+import tempfile
+from collections.abc import AsyncIterable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.messages import (
+    AgentStreamEvent,
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from sqlsaber.agents.multi_database_agent import (
+    ChildAnswerPayload,
+    DatabaseAnswer,
+    DatabaseChild,
+    DatabaseDescriptor,
+    MultiDatabaseCoordinator,
+)
+from sqlsaber.threads.manager import ThreadManager
+from sqlsaber.threads.storage import ThreadStorage
+
+
+@pytest.fixture
+def temp_storage():
+    """Local storage fixture for coordinator thread tests."""
+    with tempfile.TemporaryDirectory() as tmp:
+        storage = ThreadStorage()
+        storage.db_path = Path(tmp) / "threads.db"
+        yield storage
+
+
+def _messages(user_text: str, assistant_text: str) -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart(user_text)]),
+        ModelResponse(parts=[TextPart(assistant_text)]),
+    ]
+
+
+class FakeChildAgent:
+    def __init__(self, outputs: list[ChildAnswerPayload]) -> None:
+        self.outputs = outputs
+        self.calls: list[dict[str, Any]] = []
+        self.agent = SimpleNamespace(model=SimpleNamespace(model_name="fake-child"))
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        message_history: list[ModelMessage] | None = None,
+        usage: Any | None = None,
+    ) -> Any:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "message_history": message_history,
+                "usage": usage,
+            }
+        )
+        output = self.outputs.pop(0)
+        messages = [
+            *(message_history or []),
+            *_messages(prompt, output.summary),
+        ]
+        return SimpleNamespace(
+            output=output,
+            all_messages=lambda: messages,
+            all_messages_json=lambda: ModelMessagesTypeAdapter.dump_json(messages),
+        )
+
+
+class FailingChildAgent:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+        self.agent = SimpleNamespace(model=SimpleNamespace(model_name="fake-child"))
+
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        _ = args
+        _ = kwargs
+        raise self.error
+
+
+class InvalidOutputChildAgent:
+    def __init__(self) -> None:
+        self.agent = SimpleNamespace(model=SimpleNamespace(model_name="fake-child"))
+
+    async def run(self, *args: Any, **kwargs: Any) -> Any:
+        _ = args
+        _ = kwargs
+        return SimpleNamespace(output="not structured")
+
+
+class AsyncClosableChildAgent:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_database_answer_uses_specified_fields_only() -> None:
+    assert set(DatabaseAnswer.model_fields) == {
+        "database_id",
+        "database_name",
+        "thread_id",
+        "summary",
+        "evidence",
+        "limitations",
+    }
+
+
+def test_database_descriptor_schema_and_system_prompt_include_database_metadata() -> None:
+    coordinator = MultiDatabaseCoordinator(
+        children={
+            "warehouse": DatabaseChild(
+                descriptor=DatabaseDescriptor(
+                    id="warehouse",
+                    name="Warehouse",
+                    type="postgresql",
+                    description="Orders warehouse",
+                    summary="Contains order and fulfillment facts.",
+                    thread_id="thread-123",
+                ),
+                agent=FakeChildAgent([]),
+                thread_manager=ThreadManager(),
+                database_name="Warehouse",
+                message_history=[],
+            )
+        },
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+
+    prompt = coordinator.system_prompt_text()
+
+    assert coordinator.database_label == "analytics"
+    assert "Warehouse" in prompt
+    assert "postgresql" in prompt
+    assert "Orders warehouse" in prompt
+    assert "Contains order and fulfillment facts." in prompt
+    assert "thread-123" in prompt
+    assert "cross-database SQL joins cannot be executed" in prompt
+    assert "query databases independently" in prompt
+    assert "thread ID" in prompt
+
+
+@pytest.mark.asyncio
+async def test_ask_database_direct_routes_reuses_thread_history_and_preserves_payload(
+    temp_storage,
+) -> None:
+    child_agent = FakeChildAgent(
+        outputs=[
+            ChildAnswerPayload(
+                summary="Orders total is 42.",
+                evidence=["SELECT count(*) FROM orders"],
+                limitations=["Only completed orders were included."],
+            ),
+            ChildAnswerPayload(
+                summary="Revenue total is 99.",
+                evidence=["SELECT sum(total) FROM orders"],
+                limitations=["Refund data is unavailable."],
+            ),
+        ]
+    )
+    child = DatabaseChild(
+        descriptor=DatabaseDescriptor(
+            id="orders",
+            name="Orders",
+            type="sqlite",
+            description="Order records",
+            summary="Orders and revenue.",
+        ),
+        agent=child_agent,
+        thread_manager=ThreadManager(storage=temp_storage),
+        database_name="Orders",
+        message_history=[],
+    )
+    coordinator = MultiDatabaseCoordinator(
+        children={"orders": child},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+    usage = object()
+
+    first = await coordinator.ask_database_direct(
+        "orders", "How many orders?", usage=usage
+    )
+    second = await coordinator.ask_database_direct(
+        "orders", "What revenue?", usage=usage
+    )
+
+    assert isinstance(first, DatabaseAnswer)
+    assert first.database_id == "orders"
+    assert first.database_name == "Orders"
+    assert first.thread_id is not None
+    assert first.summary == "Orders total is 42."
+    assert first.evidence == ["SELECT count(*) FROM orders"]
+    assert first.limitations == ["Only completed orders were included."]
+
+    assert second.thread_id == first.thread_id
+    assert second.summary == "Revenue total is 99."
+    assert second.evidence == ["SELECT sum(total) FROM orders"]
+    assert second.limitations == ["Refund data is unavailable."]
+
+    assert child.descriptor.thread_id == first.thread_id
+    assert child_agent.calls[0]["message_history"] == []
+    assert child_agent.calls[0]["usage"] is usage
+    assert child_agent.calls[1]["message_history"] == child.message_history[:2]
+    assert child_agent.calls[1]["usage"] is usage
+    assert len(child.message_history) == 4
+
+    stored_messages = await temp_storage.get_thread_messages(first.thread_id)
+    assert len(stored_messages) == 4
+    stored_thread = await temp_storage.get_thread(first.thread_id)
+    assert stored_thread.title == "[Orders] How many orders?"
+    assert stored_thread.model_name == "fake-child"
+    assert json.loads(stored_thread.extra_metadata) == {
+        "kind": "multi_database_child",
+        "database_id": "orders",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ask_database_direct_returns_limitation_for_unknown_database() -> None:
+    coordinator = MultiDatabaseCoordinator(
+        children={},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+
+    answer = await coordinator.ask_database_direct("missing", "What is here?")
+
+    assert answer == DatabaseAnswer(
+        database_id="missing",
+        database_name="missing",
+        thread_id=None,
+        summary="Unable to answer from database 'missing'.",
+        evidence=[],
+        limitations=["Unknown database id 'missing'."],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_database_direct_returns_failed_answer_when_child_run_raises(
+    temp_storage,
+) -> None:
+    child = DatabaseChild(
+        descriptor=DatabaseDescriptor(
+            id="orders",
+            name="Orders",
+            type="sqlite",
+            description="Order records",
+            summary="Orders and revenue.",
+        ),
+        agent=FailingChildAgent(ValueError("structured output validation failed")),
+        thread_manager=ThreadManager(storage=temp_storage),
+        database_name="Orders",
+        message_history=[],
+    )
+    coordinator = MultiDatabaseCoordinator(
+        children={"orders": child},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+
+    answer = await coordinator.ask_database_direct("orders", "How many orders?")
+
+    assert answer.database_id == "orders"
+    assert answer.database_name == "Orders"
+    assert answer.thread_id is not None
+    assert answer.evidence == []
+    assert answer.limitations == ["Child agent failed: structured output validation failed"]
+    assert child.message_history == []
+
+    stored_thread = await temp_storage.get_thread(answer.thread_id)
+    assert stored_thread.title == "[Orders] How many orders?"
+    assert stored_thread.model_name == "fake-child"
+    assert json.loads(stored_thread.extra_metadata) == {
+        "kind": "multi_database_child",
+        "database_id": "orders",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ask_database_direct_returns_limitation_when_child_output_is_invalid(
+    temp_storage,
+) -> None:
+    child = DatabaseChild(
+        descriptor=DatabaseDescriptor(
+            id="orders",
+            name="Orders",
+            type="sqlite",
+            description="Order records",
+            summary="Orders and revenue.",
+        ),
+        agent=InvalidOutputChildAgent(),
+        thread_manager=ThreadManager(storage=temp_storage),
+        database_name="Orders",
+        message_history=[],
+    )
+    coordinator = MultiDatabaseCoordinator(
+        children={"orders": child},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+
+    answer = await coordinator.ask_database_direct("orders", "How many orders?")
+
+    assert answer.database_id == "orders"
+    assert answer.database_name == "Orders"
+    assert answer.thread_id is not None
+    assert answer.summary == (
+        "Unable to answer from database 'orders' because the child agent returned "
+        "invalid structured output."
+    )
+    assert answer.evidence == []
+    assert answer.limitations == [
+        "Child agent did not return ChildAnswerPayload structured output."
+    ]
+    assert not hasattr(answer, "success")
+    assert child.message_history == []
+
+
+@pytest.mark.asyncio
+async def test_registered_ask_database_tool_forwards_usage(monkeypatch) -> None:
+    coordinator = MultiDatabaseCoordinator(
+        children={},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+    usage = object()
+    captured: dict[str, Any] = {}
+
+    async def fake_ask_database_direct(
+        database_id: str,
+        question: str,
+        *,
+        usage: Any | None = None,
+    ) -> DatabaseAnswer:
+        captured["database_id"] = database_id
+        captured["question"] = question
+        captured["usage"] = usage
+        return DatabaseAnswer(
+            database_id=database_id,
+            database_name="Orders",
+            thread_id="thread-1",
+            summary="ok",
+            evidence=[],
+            limitations=[],
+        )
+
+    monkeypatch.setattr(coordinator, "ask_database_direct", fake_ask_database_direct)
+    ask_tool = coordinator.agent._function_toolset.tools["ask_database"]
+
+    answer = await ask_tool.function(
+        SimpleNamespace(usage=usage),
+        "orders",
+        "How many orders?",
+    )
+
+    assert answer.summary == "ok"
+    assert captured == {
+        "database_id": "orders",
+        "question": "How many orders?",
+        "usage": usage,
+    }
+
+
+@pytest.mark.asyncio
+async def test_close_closes_child_agents_with_async_close() -> None:
+    child_agent = AsyncClosableChildAgent()
+    coordinator = MultiDatabaseCoordinator(
+        children={
+            "orders": DatabaseChild(
+                descriptor=DatabaseDescriptor(
+                    id="orders",
+                    name="Orders",
+                    type="sqlite",
+                    description="Order records",
+                    summary="Orders and revenue.",
+                ),
+                agent=child_agent,
+                thread_manager=ThreadManager(),
+                database_name="Orders",
+                message_history=[],
+            )
+        },
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+
+    await coordinator.close()
+
+    assert child_agent.closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_forwards_history_stream_handler_and_deps(monkeypatch) -> None:
+    coordinator = MultiDatabaseCoordinator(
+        children={},
+        database_label="analytics",
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+    )
+    message_history = _messages("hello", "there")
+    captured: dict[str, Any] = {}
+
+    async def fake_stream_handler(
+        ctx: RunContext[Any],
+        events: AsyncIterable[AgentStreamEvent],
+    ) -> None:
+        _ = ctx
+        async for _ in events:
+            pass
+
+    async def fake_run(prompt: str, **kwargs: Any) -> Any:
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return SimpleNamespace(output="ok")
+
+    monkeypatch.setattr(coordinator.agent, "run", fake_run)
+
+    result = await coordinator.run(
+        "Compare databases.",
+        message_history=message_history,
+        event_stream_handler=fake_stream_handler,
+    )
+
+    assert result.output == "ok"
+    assert captured["prompt"] == "Compare databases."
+    assert captured["message_history"] == message_history
+    assert captured["event_stream_handler"] is fake_stream_handler
+    assert captured["deps"].children is coordinator.children

--- a/tests/test_agents/test_provider_factory.py
+++ b/tests/test_agents/test_provider_factory.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import BaseModel
 from pydantic_ai import Agent
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.google import GoogleModel
@@ -16,6 +17,10 @@ from sqlsaber.agents.provider_factory import (
     ProviderFactory,
 )
 from sqlsaber.config.settings import ThinkingLevel
+
+
+class StructuredResult(BaseModel):
+    value: str
 
 
 @pytest.fixture
@@ -107,6 +112,18 @@ def test_factory_create_agent_integration(factory, monkeypatch):
     )
     assert isinstance(agent.model, GoogleModel)
     assert agent.model.model_name == "gemini-pro"
+
+
+def test_factory_create_agent_accepts_output_type(factory):
+    """Test factory forwards structured output type to pydantic-ai Agent."""
+    agent = factory.create_agent(
+        provider="unknown",
+        model_name="test",
+        full_model_str="test",
+        output_type=StructuredResult,
+    )
+
+    assert agent.output_type is StructuredResult
 
 
 def test_anthropic_strategy_with_explicit_api_key():

--- a/tests/test_agents/test_pydantic_ai_agent.py
+++ b/tests/test_agents/test_pydantic_ai_agent.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
+from pydantic import BaseModel
 
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
 from sqlsaber.database.sqlite import SQLiteConnection
@@ -10,6 +11,10 @@ from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.knowledge.sqlite_store import SQLiteKnowledgeStore
 from sqlsaber.overrides import ToolRunDeps
 from sqlsaber.tools.knowledge_tool import SearchKnowledgeTool
+
+
+class StructuredResult(BaseModel):
+    value: str
 
 
 @pytest.fixture
@@ -51,6 +56,17 @@ class TestSQLSaberAgentKnowledge:
         assert isinstance(tool, SearchKnowledgeTool)
         assert tool.database_name == "test-db"
         assert tool.knowledge_manager is agent.knowledge_manager
+
+
+def test_sqlsaber_agent_passes_output_type_to_pydantic_agent(in_memory_db):
+    agent = SQLSaberAgent(
+        db_connection=in_memory_db,
+        model_name="anthropic:claude-3-5-sonnet",
+        api_key="test-key",
+        output_type=StructuredResult,
+    )
+
+    assert agent.agent.output_type is StructuredResult
 
 
 class TestSQLSaberAgentDeps:
@@ -106,6 +122,38 @@ class TestSQLSaberAgentDeps:
         deps = captured.get("deps")
         assert isinstance(deps, ToolRunDeps)
         assert deps.tool_overides == {}
+
+    @pytest.mark.asyncio
+    async def test_sqlsaber_agent_forwards_usage_to_pydantic_run(
+        self, in_memory_db, monkeypatch
+    ):
+        agent = SQLSaberAgent(
+            db_connection=in_memory_db,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="test-key",
+            tool_overides={
+                "viz": {
+                    "model_name": "openai:gpt-5-mini",
+                    "api_key": "override-api-key",
+                }
+            },
+        )
+        usage = object()
+        captured: dict[str, object] = {}
+
+        async def fake_run(prompt: str, **kwargs):
+            _ = prompt
+            captured.update(kwargs)
+            return SimpleNamespace(output="ok")
+
+        monkeypatch.setattr(agent.agent, "run", fake_run)
+
+        await agent.run("hello", usage=usage)
+
+        assert captured["usage"] is usage
+        deps = captured.get("deps")
+        assert isinstance(deps, ToolRunDeps)
+        assert deps.tool_overides["viz"].model_name == "openai:gpt-5-mini"
 
 
 class TestSQLSaberAgentLifecycle:

--- a/tests/test_api/test_multi_database.py
+++ b/tests/test_api/test_multi_database.py
@@ -85,6 +85,26 @@ async def test_multi_database_api_exposes_connections_and_rejects_single_connect
 
 
 @pytest.mark.asyncio
+async def test_multi_session_child_agents_use_plain_text_output(temp_dir):
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+        )
+    )
+
+    try:
+        assert all(
+            child.agent.output_type is str for child in saber._session.children.values()
+        )
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
 async def test_all_csv_list_stays_single_connection(temp_dir):
     users = temp_dir / "users.csv"
     orders = temp_dir / "orders.csv"

--- a/tests/test_api/test_multi_database.py
+++ b/tests/test_api/test_multi_database.py
@@ -76,7 +76,9 @@ async def test_multi_database_api_exposes_connections_and_rejects_single_connect
     try:
         assert saber.db_name == "a + b"
         assert set(saber.connections or {}) == {"a", "b"}
-        with pytest.raises(RuntimeError, match=r"multiple database connections.*connections"):
+        with pytest.raises(
+            RuntimeError, match=r"multiple database connections.*connections"
+        ):
             _ = saber.connection
     finally:
         await saber.close()
@@ -99,8 +101,7 @@ async def test_all_csv_list_stays_single_connection(temp_dir):
     try:
         assert saber.connections is None
         rows = await saber.connection.execute_query(
-            'SELECT u.name, o.total FROM "users" u '
-            'JOIN "orders" o ON u.id = o.user_id'
+            'SELECT u.name, o.total FROM "users" u JOIN "orders" o ON u.id = o.user_id'
         )
         assert rows == [{"name": "Alice", "total": 9.99}]
     finally:
@@ -151,9 +152,10 @@ async def test_multi_session_precreates_threads_and_saves_parent_run(
         assert parent.title == "compare counts"
         parent_metadata = json.loads(parent.extra_metadata or "{}")
         assert parent_metadata["kind"] == "multi_database_parent"
-        assert {
-            item["database_id"] for item in parent_metadata["child_threads"]
-        } == {"a", "b"}
+        assert {item["database_id"] for item in parent_metadata["child_threads"]} == {
+            "a",
+            "b",
+        }
 
         child_ids = {
             item["database_id"]: item["thread_id"]
@@ -176,9 +178,7 @@ async def test_multi_session_precreates_threads_and_saves_parent_run(
 
 
 @pytest.mark.asyncio
-async def test_multi_session_close_ends_parent_and_child_threads(
-    temp_dir, monkeypatch
-):
+async def test_multi_session_close_ends_parent_and_child_threads(temp_dir, monkeypatch):
     storage = ThreadStorage()
     storage.db_path = temp_dir / "threads.db"
     thread_manager = ThreadManager(storage=storage)
@@ -211,9 +211,7 @@ async def test_multi_session_close_ends_parent_and_child_threads(
     parent = await storage.get_thread(parent_id)
     assert parent is not None
     parent_metadata = json.loads(parent.extra_metadata or "{}")
-    child_ids = [
-        item["thread_id"] for item in parent_metadata["child_threads"]
-    ]
+    child_ids = [item["thread_id"] for item in parent_metadata["child_threads"]]
     assert all(child_ids)
 
     await saber.close()

--- a/tests/test_api/test_multi_database.py
+++ b/tests/test_api/test_multi_database.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.config.settings import Config
+from sqlsaber.threads.manager import ThreadManager
+from sqlsaber.threads.storage import ThreadStorage
+
+
+def _settings() -> Config:
+    return Config.in_memory(
+        model_name="anthropic:claude-3-5-sonnet",
+        api_keys={"anthropic": "test-key"},
+    )
+
+
+def _sqlite_uri(path: Path) -> str:
+    return f"sqlite:///{path}"
+
+
+def _messages_bytes(user_text: str, assistant_text: str) -> bytes:
+    return ModelMessagesTypeAdapter.dump_json(
+        [
+            ModelRequest(parts=[UserPromptPart(user_text)]),
+            ModelResponse(parts=[TextPart(assistant_text)]),
+        ]
+    )
+
+
+@dataclass
+class FakeRunResult:
+    output: str
+    _messages_json: bytes
+
+    def usage(self) -> None:
+        return None
+
+    def new_messages(self) -> list[ModelMessage]:
+        return ModelMessagesTypeAdapter.validate_json(self._messages_json)
+
+    def all_messages(self) -> list[ModelMessage]:
+        return ModelMessagesTypeAdapter.validate_json(self._messages_json)
+
+    def all_messages_json(self) -> bytes:
+        return self._messages_json
+
+
+@pytest.mark.asyncio
+async def test_multi_database_api_exposes_connections_and_rejects_single_connection(
+    temp_dir,
+):
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+        )
+    )
+
+    try:
+        assert saber.db_name == "a + b"
+        assert set(saber.connections or {}) == {"a", "b"}
+        with pytest.raises(RuntimeError, match=r"multiple database connections.*connections"):
+            _ = saber.connection
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_all_csv_list_stays_single_connection(temp_dir):
+    users = temp_dir / "users.csv"
+    orders = temp_dir / "orders.csv"
+    users.write_text("id,name\n1,Alice\n", encoding="utf-8")
+    orders.write_text("id,user_id,total\n10,1,9.99\n", encoding="utf-8")
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[str(users), str(orders)],
+            settings=_settings(),
+        )
+    )
+
+    try:
+        assert saber.connections is None
+        rows = await saber.connection.execute_query(
+            'SELECT u.name, o.total FROM "users" u '
+            'JOIN "orders" o ON u.id = o.user_id'
+        )
+        assert rows == [{"name": "Alice", "total": 9.99}]
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_session_precreates_threads_and_saves_parent_run(
+    temp_dir, monkeypatch
+):
+    storage = ThreadStorage()
+    storage.db_path = temp_dir / "threads.db"
+    thread_manager = ThreadManager(storage=storage)
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+            thread_manager=thread_manager,
+        )
+    )
+
+    async def fake_run(self, prompt: str, **kwargs: Any) -> FakeRunResult:
+        assert prompt == "compare counts"
+        assert kwargs["message_history"] is None
+        assert kwargs["event_stream_handler"] is None
+        return FakeRunResult(
+            output="combined answer",
+            _messages_json=_messages_bytes("compare counts", "combined answer"),
+        )
+
+    monkeypatch.setattr(
+        "sqlsaber.agents.multi_database_agent.MultiDatabaseCoordinator.run",
+        fake_run,
+    )
+
+    try:
+        result = await saber.query("compare counts")
+        assert str(result) == "combined answer"
+
+        parent_id = thread_manager.current_thread_id
+        assert parent_id is not None
+        parent = await storage.get_thread(parent_id)
+        assert parent is not None
+        assert parent.database_name == "a + b"
+        assert parent.title == "compare counts"
+        parent_metadata = json.loads(parent.extra_metadata or "{}")
+        assert parent_metadata["kind"] == "multi_database_parent"
+        assert {
+            item["database_id"] for item in parent_metadata["child_threads"]
+        } == {"a", "b"}
+
+        child_ids = {
+            item["database_id"]: item["thread_id"]
+            for item in parent_metadata["child_threads"]
+        }
+        assert all(child_ids.values())
+
+        for database_id, child_id in child_ids.items():
+            child = await storage.get_thread(child_id)
+            assert child is not None
+            assert child.title == f"[{database_id}] compare counts"
+            child_metadata = json.loads(child.extra_metadata or "{}")
+            assert child_metadata == {
+                "kind": "multi_database_child",
+                "parent_thread_id": parent_id,
+                "database_id": database_id,
+            }
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_session_close_ends_parent_and_child_threads(
+    temp_dir, monkeypatch
+):
+    storage = ThreadStorage()
+    storage.db_path = temp_dir / "threads.db"
+    thread_manager = ThreadManager(storage=storage)
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+            thread_manager=thread_manager,
+        )
+    )
+
+    async def fake_run(self, prompt: str, **kwargs: Any) -> FakeRunResult:
+        _ = self, prompt, kwargs
+        return FakeRunResult(
+            output="combined answer",
+            _messages_json=_messages_bytes("compare counts", "combined answer"),
+        )
+
+    monkeypatch.setattr(
+        "sqlsaber.agents.multi_database_agent.MultiDatabaseCoordinator.run",
+        fake_run,
+    )
+
+    await saber.query("compare counts")
+    parent_id = thread_manager.current_thread_id
+    assert parent_id is not None
+    parent = await storage.get_thread(parent_id)
+    assert parent is not None
+    parent_metadata = json.loads(parent.extra_metadata or "{}")
+    child_ids = [
+        item["thread_id"] for item in parent_metadata["child_threads"]
+    ]
+    assert all(child_ids)
+
+    await saber.close()
+
+    ended_parent = await storage.get_thread(parent_id)
+    assert ended_parent is not None
+    assert ended_parent.ended_at is not None
+
+    for child_id in child_ids:
+        child = await storage.get_thread(child_id)
+        assert child is not None
+        assert child.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_multi_session_followup_reuses_parent_and_child_threads(
+    temp_dir, monkeypatch
+):
+    storage = ThreadStorage()
+    storage.db_path = temp_dir / "threads.db"
+    thread_manager = ThreadManager(storage=storage)
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+            thread_manager=thread_manager,
+        )
+    )
+
+    payloads = iter(
+        [
+            FakeRunResult("first answer", _messages_bytes("first", "first answer")),
+            FakeRunResult("second answer", _messages_bytes("second", "second answer")),
+        ]
+    )
+
+    async def fake_run(self, prompt: str, **kwargs: Any) -> FakeRunResult:
+        _ = self, prompt, kwargs
+        return next(payloads)
+
+    monkeypatch.setattr(
+        "sqlsaber.agents.multi_database_agent.MultiDatabaseCoordinator.run",
+        fake_run,
+    )
+
+    try:
+        await saber.query("first")
+        parent_id = thread_manager.current_thread_id
+        assert parent_id is not None
+        parent = await storage.get_thread(parent_id)
+        assert parent is not None
+        initial_metadata = json.loads(parent.extra_metadata or "{}")
+        child_ids = {
+            item["database_id"]: item["thread_id"]
+            for item in initial_metadata["child_threads"]
+        }
+
+        await saber.query("second")
+        assert thread_manager.current_thread_id == parent_id
+        updated_parent = await storage.get_thread(parent_id)
+        assert updated_parent is not None
+        assert updated_parent.title == "first"
+        updated_metadata = json.loads(updated_parent.extra_metadata or "{}")
+        updated_child_ids = {
+            item["database_id"]: item["thread_id"]
+            for item in updated_metadata["child_threads"]
+        }
+        assert updated_child_ids == child_ids
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_non_csv_databases_use_multi_session(temp_dir):
+    a = temp_dir / "a.db"
+    b = temp_dir / "b.db"
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[_sqlite_uri(a), _sqlite_uri(b)],
+            settings=_settings(),
+        )
+    )
+
+    try:
+        assert saber.connections is not None
+        assert set(saber.connections) == {"a", "b"}
+        with pytest.raises(RuntimeError):
+            _ = saber.connection
+    finally:
+        await saber.close()

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -1,8 +1,20 @@
 """Tests for CLI commands."""
 
+import re
+
 import pytest
 
 from sqlsaber.cli.commands import app
+
+
+def test_query_help_mentions_multiple_databases(capsys):
+    """Test query help mentions repeated database options."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert re.search(r"multiple\W+databases", captured.out.lower())
 
 
 class TestCLICommands:

--- a/tests/test_cli/test_database_descriptions.py
+++ b/tests/test_cli/test_database_descriptions.py
@@ -1,0 +1,63 @@
+import pytest
+
+from sqlsaber.cli.database import add, describe, list_databases
+from sqlsaber.config.database import DatabaseConfigManager
+
+
+@pytest.fixture
+def isolated_db_config(temp_dir, monkeypatch):
+    config_dir = temp_dir / "config"
+    monkeypatch.setattr(
+        "platformdirs.user_config_dir", lambda *args, **kwargs: str(config_dir)
+    )
+    manager = DatabaseConfigManager()
+    monkeypatch.setattr("sqlsaber.cli.database.config_manager", manager)
+    return manager
+
+
+def test_db_add_accepts_description(isolated_db_config) -> None:
+    add(
+        name="warehouse",
+        type="sqlite",
+        database="/tmp/warehouse.db",
+        interactive=False,
+        description="Analytics warehouse",
+    )
+
+    config = isolated_db_config.get_database("warehouse")
+    assert config is not None
+    assert config.description == "Analytics warehouse"
+
+
+def test_db_describe_sets_and_clears_description(isolated_db_config) -> None:
+    add(
+        name="warehouse",
+        type="sqlite",
+        database="/tmp/warehouse.db",
+        interactive=False,
+    )
+
+    describe("warehouse", set_description="Analytics warehouse")
+    config = isolated_db_config.get_database("warehouse")
+    assert config is not None
+    assert config.description == "Analytics warehouse"
+
+    describe("warehouse", clear=True)
+    config = isolated_db_config.get_database("warehouse")
+    assert config is not None
+    assert config.description is None
+
+
+def test_db_list_shows_description(isolated_db_config, capsys) -> None:
+    add(
+        name="warehouse",
+        type="sqlite",
+        database="/tmp/warehouse.db",
+        interactive=False,
+        description="Analytics warehouse",
+    )
+
+    list_databases()
+
+    captured = capsys.readouterr()
+    assert "Analytics warehouse" in captured.out

--- a/tests/test_cli/test_streaming.py
+++ b/tests/test_cli/test_streaming.py
@@ -6,10 +6,13 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pydantic_ai.messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
     PartDeltaEvent,
     PartStartEvent,
     ToolCallPart,
     ToolCallPartDelta,
+    ToolReturnPart,
 )
 
 from sqlsaber.cli.streaming import StreamingQueryHandler
@@ -93,3 +96,89 @@ async def test_execute_sql_delta_name_shows_generating_status(
     )
 
     start_status.assert_called_once_with("Generating SQL...")
+
+
+@pytest.mark.asyncio
+async def test_ask_database_part_start_shows_querying_status(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    console = create_console(file=StringIO(), width=120, legacy_windows=False)
+    handler = StreamingQueryHandler(console)
+
+    start_status = Mock()
+    monkeypatch.setattr(handler.display.live, "start_status", start_status)
+
+    await handler.on_event(
+        PartStartEvent(
+            index=0,
+            part=ToolCallPart(
+                tool_name="ask_database",
+                args={},
+                tool_call_id="call-3",
+            ),
+        ),
+        SimpleNamespace(messages=[]),
+    )
+
+    start_status.assert_called_once_with("Querying database...")
+
+
+@pytest.mark.asyncio
+async def test_ask_database_tool_call_shows_target_database_status(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    console = create_console(file=StringIO(), width=120, legacy_windows=False)
+    handler = StreamingQueryHandler(console)
+
+    start_status = Mock()
+    monkeypatch.setattr(handler.display.live, "start_status", start_status)
+    monkeypatch.setattr(handler.display.live, "end_status", Mock())
+    monkeypatch.setattr(handler.display.live, "end_if_active", Mock())
+    monkeypatch.setattr(handler.display, "show_tool_executing", Mock())
+
+    await handler.on_event(
+        FunctionToolCallEvent(
+            part=ToolCallPart(
+                tool_name="ask_database",
+                args={"database_id": "orders", "question": "How many orders?"},
+                tool_call_id="call-4",
+            )
+        ),
+        SimpleNamespace(messages=[]),
+    )
+
+    handler.display.show_tool_executing.assert_called_once_with(
+        "ask_database",
+        {"database_id": "orders", "question": "How many orders?"},
+        tool_call_id="call-4",
+    )
+    start_status.assert_called_once_with("Querying database orders...")
+
+
+@pytest.mark.asyncio
+async def test_tool_result_forwards_tool_call_id_to_display(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    console = create_console(file=StringIO(), width=120, legacy_windows=False)
+    handler = StreamingQueryHandler(console)
+
+    show_tool_result = Mock()
+    monkeypatch.setattr(handler.display, "show_tool_result", show_tool_result)
+    monkeypatch.setattr(handler.display.live, "end_status", Mock())
+    monkeypatch.setattr(handler.display, "show_newline", Mock())
+    monkeypatch.setattr(handler.display.live, "start_status", Mock())
+
+    await handler.on_event(
+        FunctionToolResultEvent(
+            result=ToolReturnPart(
+                tool_name="ask_database",
+                content="child answer",
+                tool_call_id="call-5",
+            )
+        ),
+        SimpleNamespace(messages=[]),
+    )
+
+    show_tool_result.assert_called_once_with(
+        "ask_database", "child answer", tool_call_id="call-5"
+    )

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -1,3 +1,4 @@
+import asyncio
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -25,6 +26,34 @@ from sqlsaber.cli.threads import (
 )
 from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.threads.storage import Thread, ThreadStorage
+
+
+def test_threads_show_renders_child_thread_metadata(capsys, temp_dir, monkeypatch):
+    from sqlsaber.cli.threads import show
+    from sqlsaber.threads.storage import ThreadStorage
+
+    store = ThreadStorage()
+    store.db_path = temp_dir / "threads.db"
+    monkeypatch.setattr("sqlsaber.threads.ThreadStorage", lambda: store)
+
+    async def _create() -> str:
+        return await store.save_snapshot(
+            messages_json=b"[]",
+            database_name="warehouse + billing",
+            extra_metadata=(
+                '{"kind":"multi_database_parent","child_threads":'
+                '[{"database_id":"billing","database_name":"billing","thread_id":"child-1"}]}'
+            ),
+        )
+
+    thread_id = asyncio.run(_create())
+
+    show(thread_id)
+
+    captured = capsys.readouterr()
+    assert "Child threads" in captured.out
+    assert "billing" in captured.out
+    assert "child-1" in captured.out
 
 
 class TestThreadsCLI:

--- a/tests/test_config/test_database.py
+++ b/tests/test_config/test_database.py
@@ -146,10 +146,14 @@ def test_config_description_round_trips() -> None:
     )
 
     data = config.to_dict()
-    assert data["description"] == "Analytics warehouse with customers and revenue facts."
+    assert (
+        data["description"] == "Analytics warehouse with customers and revenue facts."
+    )
 
     restored = DatabaseConfig.from_dict(data)
-    assert restored.description == "Analytics warehouse with customers and revenue facts."
+    assert (
+        restored.description == "Analytics warehouse with customers and revenue facts."
+    )
 
 
 def test_config_from_old_dict_defaults_description_to_none() -> None:

--- a/tests/test_config/test_database.py
+++ b/tests/test_config/test_database.py
@@ -109,6 +109,7 @@ class TestDatabaseConfig:
             "ssl_cert": None,
             "ssl_key": None,
             "exclude_schemas": [],
+            "description": None,
         }
 
     def test_config_from_dict(self):
@@ -130,6 +131,61 @@ class TestDatabaseConfig:
         assert config.username == "admin"
         assert config.database == "production"
         assert config.exclude_schemas == []
+
+
+def test_config_description_round_trips() -> None:
+    config = DatabaseConfig(
+        name="warehouse",
+        type="postgresql",
+        host="localhost",
+        port=5432,
+        username="user",
+        password="pass",
+        database="analytics",
+        description="Analytics warehouse with customers and revenue facts.",
+    )
+
+    data = config.to_dict()
+    assert data["description"] == "Analytics warehouse with customers and revenue facts."
+
+    restored = DatabaseConfig.from_dict(data)
+    assert restored.description == "Analytics warehouse with customers and revenue facts."
+
+
+def test_config_from_old_dict_defaults_description_to_none() -> None:
+    config = DatabaseConfig.from_dict(
+        {
+            "name": "legacy",
+            "type": "mysql",
+            "host": "localhost",
+            "port": 3306,
+            "username": "root",
+            "database": "app",
+        }
+    )
+
+    assert config.description is None
+
+
+def test_config_preserves_positional_exclude_schemas_compatibility() -> None:
+    config = DatabaseConfig(
+        "warehouse",
+        "postgresql",
+        "localhost",
+        5432,
+        "analytics",
+        "user",
+        "pass",
+        None,
+        None,
+        None,
+        None,
+        None,
+        ["information_schema"],
+    )
+
+    assert config.exclude_schemas == ["information_schema"]
+    assert config.description is None
 
 
 class TestDatabaseConfigManager:

--- a/tests/test_database_resolver.py
+++ b/tests/test_database_resolver.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from sqlsaber.config.database import DatabaseConfig
-from sqlsaber.database.resolver import DatabaseResolutionError, resolve_database
+from sqlsaber.database.resolver import (
+    DatabaseResolutionError,
+    resolve_database,
+    resolve_databases,
+)
 
 
 class TestDatabaseResolver:
@@ -20,30 +24,41 @@ class TestDatabaseResolver:
         assert result.name == "testdb"
         assert result.connection_string == "postgresql://user:pass@host:5432/testdb"
         assert result.excluded_schemas == []
+        assert result.type == "postgresql"
+        assert result.description is None
+        assert result.id is None
 
         # MySQL connection string
         result = resolve_database("mysql://user:pass@host:3306/mydb", config_mgr)
         assert result.name == "mydb"
         assert result.connection_string == "mysql://user:pass@host:3306/mydb"
         assert result.excluded_schemas == []
+        assert result.type == "mysql"
+        assert result.description is None
 
         # SQLite connection string
         result = resolve_database("sqlite:///test.db", config_mgr)
         assert result.name == "test"
         assert result.connection_string == "sqlite:///test.db"
         assert result.excluded_schemas == []
+        assert result.type == "sqlite"
+        assert result.description is None
 
         # CSV connection string
         result = resolve_database("csv:///data.csv", config_mgr)
         assert result.name == "data"
         assert result.connection_string == "csv:///data.csv"
         assert result.excluded_schemas == []
+        assert result.type == "csv"
+        assert result.description is None
 
         # DuckDB connection string
         result = resolve_database("duckdb:///path/to/data.duckdb", config_mgr)
         assert result.name == "data"
         assert result.connection_string == "duckdb:///path/to/data.duckdb"
         assert result.excluded_schemas == []
+        assert result.type == "duckdb"
+        assert result.description is None
 
     @patch("pathlib.Path.exists")
     def test_resolve_file_paths(self, mock_exists):
@@ -57,6 +72,8 @@ class TestDatabaseResolver:
         assert result.connection_string.startswith("csv:///")
         assert result.connection_string.endswith("data.csv")
         assert result.excluded_schemas == []
+        assert result.type == "csv"
+        assert result.description is None
 
         # SQLite file
         result = resolve_database("test.db", config_mgr)
@@ -64,6 +81,8 @@ class TestDatabaseResolver:
         assert result.connection_string.startswith("sqlite:///")
         assert result.connection_string.endswith("test.db")
         assert result.excluded_schemas == []
+        assert result.type == "sqlite"
+        assert result.description is None
 
         # DuckDB file
         result = resolve_database("data.duckdb", config_mgr)
@@ -71,6 +90,8 @@ class TestDatabaseResolver:
         assert result.connection_string.startswith("duckdb:///")
         assert result.connection_string.endswith("data.duckdb")
         assert result.excluded_schemas == []
+        assert result.type == "duckdb"
+        assert result.description is None
 
     @patch("pathlib.Path.exists")
     def test_resolve_multiple_csv_file_paths(self, mock_exists):
@@ -82,6 +103,8 @@ class TestDatabaseResolver:
         assert result.connection_string.startswith("csvs:///?")
         assert "spec=" in result.connection_string
         assert result.excluded_schemas == []
+        assert result.type == "csvs"
+        assert result.description is None
 
     def test_multiple_database_args_must_be_csv(self):
         config_mgr = Mock()
@@ -118,6 +141,8 @@ class TestDatabaseResolver:
         config_mgr = Mock()
         db_config = Mock(spec=DatabaseConfig)
         db_config.name = "mydb"
+        db_config.type = "postgresql"
+        db_config.description = "Primary warehouse"
         db_config.to_connection_string.return_value = "postgresql://localhost:5432/mydb"
         db_config.exclude_schemas = ["foo"]
         config_mgr.get_database.return_value = db_config
@@ -126,6 +151,8 @@ class TestDatabaseResolver:
         assert result.name == "mydb"
         assert result.connection_string == "postgresql://localhost:5432/mydb"
         assert result.excluded_schemas == ["foo"]
+        assert result.type == "postgresql"
+        assert result.description == "Primary warehouse"
 
     def test_configured_database_not_found(self):
         """Test error when configured database doesn't exist."""
@@ -142,6 +169,8 @@ class TestDatabaseResolver:
         config_mgr = Mock()
         db_config = Mock(spec=DatabaseConfig)
         db_config.name = "default"
+        db_config.type = "postgresql"
+        db_config.description = None
         db_config.to_connection_string.return_value = (
             "postgresql://localhost:5432/default"
         )
@@ -152,6 +181,8 @@ class TestDatabaseResolver:
         assert result.name == "default"
         assert result.connection_string == "postgresql://localhost:5432/default"
         assert result.excluded_schemas == ["bar"]
+        assert result.type == "postgresql"
+        assert result.description is None
 
     def test_no_default_database_error(self):
         """Test error when no default database is configured."""
@@ -171,13 +202,125 @@ class TestDatabaseResolver:
         result = resolve_database("postgresql://user:pass@host:5432/", config_mgr)
         assert result.name == "database"  # fallback name
         assert result.excluded_schemas == []
+        assert result.type == "postgresql"
 
         # PostgreSQL with no path at all
         result = resolve_database("postgresql://user:pass@host:5432", config_mgr)
         assert result.name == "database"  # fallback name
         assert result.excluded_schemas == []
+        assert result.type == "postgresql"
 
         # DuckDB without explicit database
         result = resolve_database("duckdb://", config_mgr)
         assert result.name == "database"
         assert result.excluded_schemas == []
+        assert result.type == "duckdb"
+
+    def test_legacy_configured_database_description_defaults_to_none(self):
+        """Test legacy config-like objects without description resolve cleanly."""
+
+        class LegacyDatabaseConfig:
+            name = "legacy"
+            type = "mysql"
+            exclude_schemas: list[str] = []
+
+            def to_connection_string(self) -> str:
+                return "mysql://localhost:3306/legacy"
+
+        config_mgr = Mock()
+        config_mgr.get_database.return_value = LegacyDatabaseConfig()
+
+        result = resolve_database("legacy", config_mgr)
+        assert result.type == "mysql"
+        assert result.description is None
+
+    @patch("pathlib.Path.exists")
+    def test_resolve_databases_multiple_csvs_collapse(self, mock_exists):
+        """Test multi-CSV specs collapse into one csvs database."""
+        mock_exists.return_value = True
+        config_mgr = Mock()
+
+        results = resolve_databases(["a.csv", "b.csv"], config_mgr)
+
+        assert len(results) == 1
+        assert results[0].name == "a + b"
+        assert results[0].type == "csvs"
+        assert results[0].id == "a + b"
+
+    def test_resolve_databases_configured_databases_in_order_with_ids(self):
+        """Test multiple configured names resolve independently in order."""
+        config_mgr = Mock()
+        warehouse_config = Mock(spec=DatabaseConfig)
+        warehouse_config.name = "warehouse"
+        warehouse_config.type = "postgresql"
+        warehouse_config.description = "Analytics warehouse"
+        warehouse_config.to_connection_string.return_value = (
+            "postgresql://localhost:5432/warehouse"
+        )
+        warehouse_config.exclude_schemas = ["scratch"]
+        billing_config = Mock(spec=DatabaseConfig)
+        billing_config.name = "billing"
+        billing_config.type = "mysql"
+        billing_config.description = "Billing store"
+        billing_config.to_connection_string.return_value = (
+            "mysql://localhost:3306/billing"
+        )
+        billing_config.exclude_schemas = []
+        config_mgr.get_database.side_effect = [warehouse_config, billing_config]
+
+        results = resolve_databases(["warehouse", "billing"], config_mgr)
+
+        assert [result.name for result in results] == ["warehouse", "billing"]
+        assert [result.type for result in results] == ["postgresql", "mysql"]
+        assert [result.description for result in results] == [
+            "Analytics warehouse",
+            "Billing store",
+        ]
+        assert [result.id for result in results] == ["warehouse", "billing"]
+        assert results[0].excluded_schemas == ["scratch"]
+
+    def test_resolve_databases_duplicate_names_receive_suffixed_ids(self):
+        """Test stable IDs are suffixed when database names duplicate."""
+        config_mgr = Mock()
+
+        results = resolve_databases(
+            [
+                "sqlite:///data/report.db",
+                "duckdb:///warehouse/report.duckdb",
+                "postgresql://localhost/report",
+            ],
+            config_mgr,
+        )
+
+        assert [result.name for result in results] == ["report", "report", "report"]
+        assert [result.id for result in results] == ["report", "report_2", "report_3"]
+
+    @patch("pathlib.Path.exists")
+    def test_resolve_databases_mixed_csv_and_non_csv_resolve_independently(
+        self, mock_exists
+    ):
+        """Test resolve_databases does not apply strict multi-CSV rules to mixed specs."""
+        mock_exists.return_value = True
+        config_mgr = Mock()
+
+        results = resolve_databases(["a.csv", "sqlite:///test.db"], config_mgr)
+
+        assert [result.type for result in results] == ["csv", "sqlite"]
+        assert [result.id for result in results] == ["a", "test"]
+
+    def test_resolve_databases_single_spec_assigns_id(self):
+        """Test non-list specs resolve to a one-item list with an ID."""
+        config_mgr = Mock()
+
+        results = resolve_databases("sqlite:///test.db", config_mgr)
+
+        assert len(results) == 1
+        assert results[0].name == "test"
+        assert results[0].id == "test"
+
+    def test_resolve_databases_empty_list_raises(self):
+        """Test empty list raises the same error as resolve_database."""
+        config_mgr = Mock()
+
+        with pytest.raises(DatabaseResolutionError, match="Empty database argument list"):
+            resolve_databases([], config_mgr)

--- a/tests/test_database_resolver.py
+++ b/tests/test_database_resolver.py
@@ -322,5 +322,7 @@ class TestDatabaseResolver:
         """Test empty list raises the same error as resolve_database."""
         config_mgr = Mock()
 
-        with pytest.raises(DatabaseResolutionError, match="Empty database argument list"):
+        with pytest.raises(
+            DatabaseResolutionError, match="Empty database argument list"
+        ):
             resolve_databases([], config_mgr)

--- a/tests/test_tools/test_display.py
+++ b/tests/test_tools/test_display.py
@@ -170,6 +170,116 @@ class TestDisplayManagerResolution:
         assert "```json" in output
         assert "value" in output
 
+    def test_render_ask_database_executing_uses_readable_summary(self):
+        console, buffer = self._make_console()
+        display = DisplayManager(console)
+
+        display.show_tool_executing(
+            "ask_database",
+            {"database_id": "orders", "question": "How many orders?"},
+        )
+
+        output = buffer.getvalue()
+        assert "Asking database orders" in output
+        assert "Question:" in output
+        assert "How many orders?" in output
+        assert "```json" not in output
+        assert '"database_id"' not in output
+
+    def test_render_ask_database_result_uses_matching_tool_call_question(self):
+        console, buffer = self._make_console()
+        display = DisplayManager(console)
+        display.show_tool_executing(
+            "ask_database",
+            {"database_id": "spock-data", "question": "Question for spock"},
+            tool_call_id="call-spock",
+        )
+        display.show_tool_executing(
+            "ask_database",
+            {"database_id": "ocean-local", "question": "Question for ocean"},
+            tool_call_id="call-ocean",
+        )
+
+        display.show_tool_result(
+            "ask_database",
+            "Database: spock-data (id: spock-data)\n"
+            "Child thread ID: thread-spock\n\n"
+            "## Answer\nSpock answer.",
+            tool_call_id="call-spock",
+        )
+        display.show_tool_result(
+            "ask_database",
+            "Database: ocean-local (id: ocean-local)\n"
+            "Child thread ID: thread-ocean\n\n"
+            "## Answer\nOcean answer.",
+            tool_call_id="call-ocean",
+        )
+
+        output = buffer.getvalue()
+        spock_question_index = output.index("Question for spock")
+        spock_answer_index = output.index("Spock answer.")
+        ocean_question_index = output.index("Question for ocean")
+        ocean_answer_index = output.index("Ocean answer.")
+        assert spock_question_index < spock_answer_index
+        assert ocean_question_index < ocean_answer_index
+        assert output.count("Question for spock") == 2
+        assert output.count("Question for ocean") == 2
+
+    def test_render_ask_database_result_as_bounded_markdown_panel(self):
+        console, buffer = self._make_console()
+        display = DisplayManager(console)
+        display.show_tool_executing(
+            "ask_database",
+            {"database_id": "orders", "question": "How many orders?"},
+        )
+
+        display.show_tool_result(
+            "ask_database",
+            (
+                "Database: Orders (id: orders)\n"
+                "Child thread ID: thread-1\n\n"
+                "## Answer\n"
+                "There are 42 orders.\n\n"
+                "## SQL\n"
+                "```sql\nSELECT count(*) FROM orders;\n```"
+            ),
+        )
+
+        output = buffer.getvalue()
+        assert "Subagent answer: Orders" in output
+        assert "orders" in output
+        assert "thread-1" in output
+        assert "Question" in output
+        assert "How many orders?" in output
+        assert "There are 42 orders." in output
+        assert "SELECT count(*) FROM orders;" in output
+        assert "Database: Orders" not in output
+        assert "Child thread ID:" not in output
+        assert "```" not in output
+
+    def test_render_connected_databases_as_readable_list(self):
+        console, buffer = self._make_console()
+        display = DisplayManager(console)
+
+        display.show_tool_result(
+            "list_connected_databases",
+            [
+                {
+                    "id": "orders",
+                    "name": "Orders",
+                    "type": "sqlite",
+                    "description": "Order records",
+                }
+            ],
+        )
+
+        output = buffer.getvalue()
+        assert "Connected databases" in output
+        assert "orders" in output
+        assert "Orders" in output
+        assert "sqlite" in output
+        assert "```json" not in output
+
     def test_render_result_html_from_spec(self):
         class HtmlTool(Tool):
             display_spec = ToolDisplaySpec(

--- a/tests/threads/test_threads_manager.py
+++ b/tests/threads/test_threads_manager.py
@@ -55,6 +55,34 @@ async def test_init_with_id(temp_storage):
 
 
 @pytest.mark.asyncio
+async def test_ensure_thread_precreates_thread(thread_manager, temp_storage) -> None:
+    thread_id = await thread_manager.ensure_thread(
+        database_name="warehouse",
+        title="Compare customers",
+        model_name="claude",
+        extra_metadata='{"kind": "multi_database_parent"}',
+    )
+
+    assert thread_manager.current_thread_id == thread_id
+    assert thread_manager.first_message is False
+
+    thread = await temp_storage.get_thread(thread_id)
+    assert thread is not None
+    assert thread.database_name == "warehouse"
+    assert thread.title == "Compare customers"
+    assert thread.model_name == "claude"
+    assert thread.extra_metadata == '{"kind": "multi_database_parent"}'
+
+
+@pytest.mark.asyncio
+async def test_ensure_thread_reuses_existing_thread(thread_manager) -> None:
+    first_id = await thread_manager.ensure_thread(database_name="warehouse")
+    second_id = await thread_manager.ensure_thread(database_name="warehouse")
+
+    assert second_id == first_id
+
+
+@pytest.mark.asyncio
 async def test_end_current_thread_active(thread_manager, temp_storage):
     """Test ending an active thread."""
     # Create a thread first

--- a/tests/threads/test_threads_storage.py
+++ b/tests/threads/test_threads_storage.py
@@ -1,5 +1,7 @@
 """Tests for ThreadStorage (pydantic-ai snapshot threads)."""
 
+import json
+import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -13,6 +15,14 @@ from pydantic_ai.messages import (
 )
 
 from sqlsaber.threads.storage import ThreadStorage
+
+
+@pytest.fixture
+def temp_storage():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ThreadStorage()
+        store.db_path = Path(tmp) / "threads.db"
+        yield store
 
 
 def _messages_bytes(user_text: str, *assistant_texts: str) -> bytes:
@@ -87,3 +97,88 @@ async def test_list_end_delete_threads():
         assert deleted
         remaining = await store.list_threads()
         assert len(remaining) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_snapshot_stores_extra_metadata(temp_storage) -> None:
+    thread_id = await temp_storage.save_snapshot(
+        messages_json=b"[]",
+        database_name="warehouse",
+        extra_metadata=json.dumps({"kind": "multi_database_parent"}),
+    )
+
+    thread = await temp_storage.get_thread(thread_id)
+    assert thread is not None
+    assert thread.extra_metadata == '{"kind": "multi_database_parent"}'
+
+
+@pytest.mark.asyncio
+async def test_save_metadata_updates_only_provided_fields(temp_storage) -> None:
+    thread_id = await temp_storage.save_snapshot(
+        messages_json=b"[]",
+        database_name="warehouse",
+    )
+    await temp_storage.save_metadata(
+        thread_id=thread_id,
+        title="first title",
+        model_name="first model",
+        extra_metadata='{"kind": "single"}',
+    )
+
+    await temp_storage.save_metadata(thread_id=thread_id, model_name="second model")
+
+    thread = await temp_storage.get_thread(thread_id)
+    assert thread is not None
+    assert thread.title == "first title"
+    assert thread.model_name == "second model"
+    assert thread.extra_metadata == '{"kind": "single"}'
+
+
+@pytest.mark.asyncio
+async def test_init_db_migrates_old_threads_table_for_extra_metadata(
+    temp_storage,
+) -> None:
+    temp_storage.db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(temp_storage.db_path) as db:
+        db.execute(
+            """
+            CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                database_name TEXT,
+                title TEXT,
+                created_at REAL NOT NULL,
+                ended_at REAL,
+                last_activity_at REAL NOT NULL,
+                model_name TEXT,
+                messages_json BLOB NOT NULL
+            )
+            """
+        )
+
+    thread_id = await temp_storage.save_snapshot(
+        messages_json=b"[]",
+        database_name="warehouse",
+        extra_metadata='{"kind": "parent"}',
+    )
+
+    thread = await temp_storage.get_thread(thread_id)
+    assert thread is not None
+    assert thread.extra_metadata == '{"kind": "parent"}'
+
+    await temp_storage.save_metadata(
+        thread_id=thread_id,
+        extra_metadata='{"kind": "updated"}',
+    )
+    await temp_storage.save_snapshot(
+        messages_json=b"[]",
+        database_name="warehouse",
+        thread_id=thread_id,
+    )
+
+    updated = await temp_storage.get_thread(thread_id)
+    assert updated is not None
+    assert updated.extra_metadata == '{"kind": "updated"}'
+
+    listed = await temp_storage.list_threads()
+    assert len(listed) == 1
+    assert listed[0].extra_metadata == '{"kind": "updated"}'


### PR DESCRIPTION
## Summary
- add database descriptions and thread metadata for parent/child traceability
- resolve repeated non-CSV -d flags into multi-database sessions while preserving multi-CSV behavior
- add a multi-database coordinator that routes work to child SQLSaber agents and records child thread IDs
- wire multi-database mode through the API, CLI, and interactive session
- clean up final formatting/type issues and keep saber --help startup fast

## Verification
- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- uvx ty check src/
- /usr/bin/time -p uv run saber --help