### PR TITLE
docs: add Python SDK documentation section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -95,6 +95,22 @@ export default defineConfig({
 					],
 				},
 				{
+					label: "Python SDK",
+					items: [
+						{ label: "Overview", slug: "sdk/overview" },
+						{ label: "Configuration", slug: "sdk/configuration" },
+						{
+							label: "Credentials & Models",
+							slug: "sdk/credentials-and-models",
+						},
+						{
+							label: "Results & Streaming",
+							slug: "sdk/results-and-streaming",
+						},
+						{ label: "Advanced", slug: "sdk/advanced" },
+					],
+				},
+				{
 					label: "Reference",
 					items: [
 						{ label: "Commands", slug: "reference/commands" },

--- a/docs/src/content/docs/sdk/advanced.mdx
+++ b/docs/src/content/docs/sdk/advanced.mdx
@@ -1,0 +1,135 @@
+---
+title: Advanced
+description: "Advanced SQLsaber SDK usage: per-tool model overrides, custom system prompts, write access, and injecting knowledge base and conversation thread managers."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## Per-tool model overrides
+
+You can run specific internal tools (for example a visualization or summarization
+tool) on a different model than the main agent. Use `tool_overrides`, mapping a
+tool name to a `ModelOverides`:
+
+```python
+from sqlsaber import SQLSaber, SQLSaberOptions, ModelOverides
+
+options = SQLSaberOptions(
+    database="sqlite:///my.db",
+    model_name="anthropic:claude-sonnet-4-5-20250929",
+    tool_overrides={
+        "viz": ModelOverides(
+            model_name="openai:gpt-5-mini",
+            api_key="sk-...",
+        ),
+    },
+)
+```
+
+You may also pass a plain dict instead of `ModelOverides`:
+
+```python
+tool_overrides={"viz": {"model_name": "openai:gpt-5-mini"}}
+```
+
+<Aside type="note">
+  An `api_key` override requires a `model_name`, since the provider is derived
+  from the model. Setting `api_key` without `model_name` raises an error.
+</Aside>
+
+## Custom system prompt
+
+Override the agent's system prompt with inline text or a path to a file:
+
+```python
+from pathlib import Path
+
+# Inline
+SQLSaberOptions(
+    database="sqlite:///my.db",
+    system_prompt="You are a senior data analyst. Prefer concise answers.",
+)
+
+# From a file
+SQLSaberOptions(
+    database="sqlite:///my.db",
+    system_prompt=Path("prompts/analyst.txt"),
+)
+```
+
+## Allowing write operations
+
+By default the SDK only permits read-only `SELECT` queries. Set
+`allow_dangerous=True` to permit DML and a restricted subset of DDL:
+
+```python
+SQLSaberOptions(database="sqlite:///my.db", allow_dangerous=True)
+```
+
+<Aside type="caution">
+  This allows data modifications (INSERT/UPDATE/DELETE, with UPDATE/DELETE
+  requiring a `WHERE`) and limited DDL. Destructive operations such as DROP and
+  TRUNCATE remain blocked. See [Running Queries](/guides/queries#dangerous-mode)
+  for the full policy.
+</Aside>
+
+## Injecting a knowledge base
+
+Provide domain context by injecting your own `KnowledgeManager`. The agent can
+search it while answering:
+
+```python
+import asyncio
+
+from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.knowledge import KnowledgeManager, SQLiteKnowledgeStore
+
+
+async def main() -> None:
+    manager = KnowledgeManager(store=SQLiteKnowledgeStore(db_path="knowledge.db"))
+
+    await manager.add_knowledge(
+        database_name="analytics",
+        name="Gross margin",
+        description="(Revenue - COGS) / Revenue",
+        source="finance-handbook",
+    )
+
+    async with SQLSaber(
+        options=SQLSaberOptions(
+            database="analytics",
+            knowledge_manager=manager,
+        )
+    ) as saber:
+        print(await saber.query("How do we define gross margin?"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+<Aside type="note">
+  When you inject your own `knowledge_manager`, the session does **not** close it
+  for you — you own its lifecycle. If you omit it, the session creates and closes
+  one automatically.
+</Aside>
+
+See the [Knowledge Base guide](/guides/knowledge) for managing entries.
+
+## Persisting conversation threads
+
+Inject a `ThreadManager` to persist each run's history, just like the CLI does
+between sessions:
+
+```python
+from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.threads.manager import ThreadManager
+
+options = SQLSaberOptions(
+    database="analytics",
+    thread_manager=ThreadManager(),
+)
+```
+
+The session saves each run and ends the current thread when it closes. See the
+[Conversation Threads guide](/guides/threads) for how threads work.

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -1,0 +1,83 @@
+---
+title: Configuration
+description: "Configure the SQLsaber Python SDK with SQLSaberOptions: database connections, model selection, thinking, system prompts, and injectable components."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Every `SQLSaber` session is configured through a single `SQLSaberOptions`
+dataclass. Construct it with keyword arguments and pass it to `SQLSaber(options=...)`.
+
+```python
+from sqlsaber import SQLSaberOptions
+
+options = SQLSaberOptions(
+    database="postgresql://user:pass@localhost:5432/analytics",
+    model_name="anthropic:claude-sonnet-4-5-20250929",
+    thinking_level="medium",
+)
+```
+
+## Options reference
+
+| Field               | Type                                          | Default | Description                                                                                  |
+| ------------------- | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, or a list of CSV paths.                    |
+| `model_name`        | `str \| None`                                 | `None`  | Model in `"provider:model"` form. Falls back to your configured/default model.               |
+| `api_key`           | `str \| None`                                 | `None`  | API key for the model's provider. Usually unnecessary — see [Credentials](/sdk/credentials-and-models). |
+| `thinking_enabled`  | `bool \| None`                                | `None`  | Toggle extended thinking on supported reasoning models.                                      |
+| `thinking_level`    | `ThinkingLevel \| str \| None`                | `None`  | `"minimal" \| "low" \| "medium" \| "high" \| "maximum"`. Setting a level enables thinking.   |
+| `system_prompt`     | `str \| Path \| None`                         | `None`  | Custom system prompt text, or a path to a file containing it.                                |
+| `settings`          | `Config \| None`                              | `None`  | Inject a `Config` (e.g. `Config.in_memory(...)`). Defaults to file-backed `Config.default()`. |
+| `knowledge_manager` | `KnowledgeManager \| None`                    | `None`  | Inject your own knowledge base (see [Advanced](/sdk/advanced)).                              |
+| `thread_manager`    | `ThreadManager \| None`                       | `None`  | Persist conversation history across runs (see [Advanced](/sdk/advanced)).                    |
+| `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)).                            |
+| `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL (see [Advanced](/sdk/advanced)).       |
+
+<Aside type="note">
+  `model_name`, `thinking_*`, `system_prompt`, and the injectable components all
+  have sensible defaults. For many use cases just `database` (plus credentials in
+  your environment) is enough.
+</Aside>
+
+## Choosing a database
+
+The `database` option accepts the same targets as the CLI's `-d` flag.
+
+### Connection strings
+
+```python
+SQLSaberOptions(database="postgresql://user:pass@host:5432/db")
+SQLSaberOptions(database="mysql://user:pass@host:3306/db")
+SQLSaberOptions(database="sqlite:///path/to/local.db")
+SQLSaberOptions(database="duckdb:///path/to/warehouse.duckdb")
+```
+
+### File paths
+
+Point directly at a SQLite, DuckDB, or CSV file:
+
+```python
+SQLSaberOptions(database="./data/sales.db")
+SQLSaberOptions(database="./customers.csv")
+```
+
+### Multiple CSV files
+
+Pass a list (or tuple) of CSV paths to query across them together:
+
+```python
+SQLSaberOptions(database=["users.csv", "orders.csv"])
+```
+
+### A configured database
+
+If you've already registered a connection with the CLI (`saber db add`), refer
+to it by name:
+
+```python
+SQLSaberOptions(database="prod-db")
+```
+
+See the [Database Setup guide](/guides/database-setup) for details on connection
+strings and registering databases.

--- a/docs/src/content/docs/sdk/credentials-and-models.mdx
+++ b/docs/src/content/docs/sdk/credentials-and-models.mdx
@@ -1,0 +1,116 @@
+---
+title: Credentials & Models
+description: "Provide API keys and select models for the SQLsaber Python SDK using stored CLI auth, environment variables, or an in-memory Config."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The SDK needs an LLM provider API key to run queries. There are three ways to
+supply credentials, and you can choose whichever fits your deployment.
+
+## 1. Reuse CLI-stored credentials (default)
+
+If you omit `settings`, the session uses a file-backed `Config.default()` — the
+same configuration the `saber` CLI uses. Any keys you saved with `saber auth`
+are picked up automatically:
+
+```python
+from sqlsaber import SQLSaber, SQLSaberOptions
+
+# Uses your stored CLI credentials and configured default model.
+options = SQLSaberOptions(database="sqlite:///my.db")
+```
+
+This is the most convenient option for local scripts on a machine where you
+already use SQLsaber. See the [Authentication guide](/guides/authentication).
+
+## 2. Environment variables
+
+Both the default and in-memory configs check the provider's environment variable
+before anything else, so exporting a key just works:
+
+```bash
+export ANTHROPIC_API_KEY="sk-..."
+```
+
+```python
+options = SQLSaberOptions(
+    database="sqlite:///my.db",
+    model_name="anthropic:claude-sonnet-4-5-20250929",
+)
+```
+
+Each provider has its own variable (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`GOOGLE_API_KEY`, `GROQ_API_KEY`).
+
+## 3. Pass keys explicitly in code
+
+For servers, CI, or notebooks where you don't want to touch the filesystem or
+keyring, build an in-memory `Config` and inject it via `settings`. This avoids
+any file or keyring I/O:
+
+```python
+from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.config.settings import Config
+
+options = SQLSaberOptions(
+    database="sqlite:///my.db",
+    settings=Config.in_memory(
+        model_name="anthropic:claude-sonnet-4-5-20250929",
+        api_keys={"anthropic": "sk-..."},
+    ),
+)
+```
+
+`api_keys` is a mapping of provider name to key. Supported provider keys are
+`anthropic`, `openai`, `google`, and `groq`.
+
+<Aside type="caution">
+  Avoid hard-coding API keys in source files. Prefer environment variables or a
+  secrets manager, and read them into `api_keys` at runtime.
+</Aside>
+
+For a single key without building a `Config`, you can also set `api_key` directly
+on `SQLSaberOptions` (it requires `model_name` so the provider can be determined):
+
+```python
+options = SQLSaberOptions(
+    database="sqlite:///my.db",
+    model_name="anthropic:claude-sonnet-4-5-20250929",
+    api_key="sk-...",
+)
+```
+
+## Selecting a model
+
+Models are identified as `"provider:model"`:
+
+```python
+SQLSaberOptions(database="...", model_name="anthropic:claude-sonnet-4-5-20250929")
+SQLSaberOptions(database="...", model_name="openai:gpt-5-mini")
+SQLSaberOptions(database="...", model_name="google:gemini-2.5-pro")
+```
+
+If `model_name` is omitted, the session uses your configured default model. See
+the [Models guide](/guides/models) for the full list of supported providers.
+
+## Extended thinking
+
+Reasoning models support extended thinking. Enable it and pick a level:
+
+```python
+SQLSaberOptions(
+    database="...",
+    model_name="anthropic:claude-sonnet-4-5-20250929",
+    thinking_level="high",  # minimal | low | medium | high | maximum
+)
+```
+
+Setting `thinking_level` implies `thinking_enabled=True`. You can also set
+`thinking_enabled` on its own to use the model's default level.
+
+<Aside type="note">
+  Extended thinking is supported for Anthropic, OpenAI, Google, and Groq
+  reasoning models. See [Running Queries](/guides/queries) for how levels map to
+  each provider.
+</Aside>

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -1,0 +1,87 @@
+---
+title: Overview
+description: "Use SQLsaber from Python. Run natural-language to SQL queries programmatically with the async SQLSaber SDK instead of the CLI."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+SQLsaber ships a small public Python API (the SDK) so you can run natural-language
+queries against your databases directly from Python code, instead of through the
+`saber` CLI. It is the same agent that powers the CLI, exposed as an `async`
+interface you can embed in scripts, notebooks, web backends, or data pipelines.
+
+The SDK exposes three names from the top-level `sqlsaber` package:
+
+| Export            | Purpose                                                       |
+| ----------------- | ------------------------------------------------------------- |
+| `SQLSaber`        | Main entry point — runs queries and owns the DB connection.   |
+| `SQLSaberOptions` | Typed options bag used to configure a `SQLSaber` session.     |
+| `ModelOverides`   | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)). |
+
+## Installation
+
+The SDK is included with the main package — no extra install required.
+
+```bash
+uv add sqlsaber
+# or
+pip install sqlsaber
+```
+
+## Quickstart
+
+Create a `SQLSaberOptions`, open a `SQLSaber` session, and `await` a query. The
+result behaves like a string containing the agent's answer.
+
+```python
+import asyncio
+
+from sqlsaber import SQLSaber, SQLSaberOptions
+
+
+async def main() -> None:
+    options = SQLSaberOptions(database="sqlite:///my.db")
+
+    async with SQLSaber(options=options) as saber:
+        result = await saber.query("Show me the top 5 users by order count")
+        print(result)        # the agent's text answer
+        print(result.usage)  # token usage for the run
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+<Aside type="note">
+  `query()` is asynchronous, so call it inside an `async` function (e.g. via
+  `asyncio.run`). The `SQLSaber` constructor is keyword-only — always pass
+  `options=...`.
+</Aside>
+
+## Managing the connection
+
+`SQLSaber` owns a live database connection. Use it as an async context manager
+(`async with`) so the connection is closed automatically, or call `await
+saber.close()` yourself:
+
+```python
+saber = SQLSaber(options=SQLSaberOptions(database="sqlite:///my.db"))
+try:
+    result = await saber.query("How many orders shipped last week?")
+finally:
+    await saber.close()
+```
+
+## Credentials
+
+By default the SDK reuses the credentials you configured for the CLI (via
+`saber auth`) and any provider environment variables such as
+`ANTHROPIC_API_KEY`. You can also pass keys explicitly in code — see
+[Credentials & Models](/sdk/credentials-and-models).
+
+## Where to next?
+
+1. [Configuration](/sdk/configuration) — every `SQLSaberOptions` field.
+2. [Credentials & Models](/sdk/credentials-and-models) — auth and model selection.
+3. [Results & Streaming](/sdk/results-and-streaming) — read SQL, usage, and stream events.
+4. [Advanced](/sdk/advanced) — tool overrides, custom prompts, write access, and more.

--- a/docs/src/content/docs/sdk/results-and-streaming.mdx
+++ b/docs/src/content/docs/sdk/results-and-streaming.mdx
@@ -1,0 +1,97 @@
+---
+title: Results & Streaming
+description: "Read SQLsaber SDK query results: the text answer, generated SQL, token usage, streaming events, and multi-turn conversations with message history."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+`saber.query()` returns a `SQLSaberResult`. It subclasses `str`, so it *is* the
+agent's text answer, while also exposing the full execution details.
+
+```python
+result = await saber.query("How many orders shipped last week?")
+
+print(result)            # the answer, as a string
+print(result.usage)      # token usage for this run
+print(result.messages)   # messages from this run (incl. tool calls / SQL)
+```
+
+## Result properties
+
+| Property        | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| _(the value)_   | The result *is* a `str` containing the agent's final text answer.        |
+| `.usage`        | Token usage statistics for the run.                                      |
+| `.messages`     | New messages produced by this run, including tool calls and SQL.         |
+| `.all_messages` | The full message history, including any prior turns you passed in.       |
+
+## Inspecting the generated SQL
+
+The SQL the agent ran lives in the run's messages as tool calls. The message
+objects are `pydantic_ai` message types; iterate over their parts to find tool
+calls:
+
+```python
+from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+result = await saber.query("Top 5 customers by revenue")
+
+for message in result.messages:
+    if isinstance(message, ModelResponse):
+        for part in message.parts:
+            if isinstance(part, ToolCallPart):
+                print(part.tool_name, part.args)
+```
+
+## Streaming events
+
+Pass an `event_stream_handler` to react to events (text chunks, tool calls,
+etc.) as they arrive, rather than waiting for the final answer. The handler is an
+async function that receives the run context and an async iterable of events:
+
+```python
+from collections.abc import AsyncIterable
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import AgentStreamEvent
+
+
+async def on_event(
+    ctx: RunContext[Any],
+    events: AsyncIterable[AgentStreamEvent],
+) -> None:
+    async for event in events:
+        print(event)
+
+
+result = await saber.query(
+    "Show me revenue by month",
+    event_stream_handler=on_event,
+)
+```
+
+<Aside type="note">
+  The event and context types come from
+  <a href="https://ai.pydantic.dev/">pydantic-ai</a>, which powers SQLsaber's
+  agent. Refer to its docs for the full event taxonomy.
+</Aside>
+
+## Multi-turn conversations
+
+To continue a conversation, feed the previous result's messages back into the
+next call via `message_history`:
+
+```python
+async with SQLSaber(options=options) as saber:
+    first = await saber.query("How many active customers do we have?")
+
+    follow_up = await saber.query(
+        "Now break that down by country",
+        message_history=first.all_messages,
+    )
+    print(follow_up)
+```
+
+Use `result.all_messages` to carry the whole history forward, or
+`result.messages` to pass only the latest turn.


### PR DESCRIPTION
Add a dedicated "Python SDK" sidebar group documenting the public
SQLSaber/SQLSaberOptions/ModelOverides API: overview/quickstart,
configuration, credentials & models, results & streaming, and advanced
usage (tool overrides, custom prompts, write access, knowledge/threads).

https://claude.ai/code/session_0149rp4uo5Q4KMDJJAQ6spqc