### PR TITLE
Add multi-database support with registry-based routing

### DIFF
--- a/src/sqlsaber/agents/provider_factory.py
+++ b/src/sqlsaber/agents/provider_factory.py
@@ -103,7 +103,7 @@ class GoogleProviderStrategy(AgentProviderStrategy):
             settings = GoogleModelSettings(
                 google_thinking_config={
                     "include_thoughts": True,
-                    "thinking_level": google_level,
+                    "thinking_level": cast(Any, google_level),
                 }
             )
             return Agent(model_obj, name="sqlsaber", model_settings=settings)

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -4,8 +4,9 @@ This replaces the custom AnthropicSQLAgent and uses pydantic-ai's Agent,
 function tools, and streaming event types directly.
 """
 
+import inspect
 from collections.abc import AsyncIterable, Awaitable, Sequence
-from typing import Any, Callable, cast
+from typing import Any, Callable, Literal, cast
 
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
@@ -15,6 +16,7 @@ from sqlsaber.agents.provider_factory import ProviderFactory
 from sqlsaber.config import providers
 from sqlsaber.config.settings import Config, ThinkingLevel
 from sqlsaber.database import BaseDatabaseConnection
+from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
 from sqlsaber.database.schema import SchemaManager
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.overrides import (
@@ -23,13 +25,176 @@ from sqlsaber.overrides import (
     build_tool_run_deps,
     normalize_tool_overides,
 )
-from sqlsaber.prompts.claude import CLAUDE
+from sqlsaber.prompts.claude import CLAUDE, CLAUDE_MULTI
 from sqlsaber.prompts.dangerous_mode import DANGEROUS_MODE
-from sqlsaber.prompts.openai import GPT_5
+from sqlsaber.prompts.openai import GPT_5, GPT_5_MULTI
 from sqlsaber.tools.base import Tool
 from sqlsaber.tools.knowledge_tool import KnowledgeTool
 from sqlsaber.tools.registry import tool_registry
 from sqlsaber.tools.sql_tools import SQLTool
+
+
+def _wrap_strip_db_name(tool: Tool) -> Callable[..., Awaitable[str]]:
+    """Wrap `tool.execute` so its public signature no longer includes `db_name`.
+
+    Used in single-DB mode so the tool's JSON schema is identical to today's.
+    The underlying tool still accepts `db_name=None` via its single-DB path.
+    """
+    raw = tool.execute
+    raw_sig = inspect.signature(raw)
+    new_params = [p for name, p in raw_sig.parameters.items() if name != "db_name"]
+    new_sig = raw_sig.replace(parameters=new_params)
+
+    if tool.requires_ctx:
+
+        async def wrapper(ctx: RunContext, *args, **kwargs) -> str:
+            return await raw(ctx, *args, **kwargs)
+    else:
+
+        async def wrapper(*args, **kwargs) -> str:
+            return await raw(*args, **kwargs)
+
+    wrapper.__signature__ = new_sig  # type: ignore
+    wrapper.__name__ = getattr(raw, "__name__", tool.name)
+    wrapper.__doc__ = raw.__doc__
+    wrapper.__annotations__ = {
+        k: v for k, v in getattr(raw, "__annotations__", {}).items() if k != "db_name"
+    }
+    return wrapper
+
+
+def _wrap_add_db_name(
+    tool: Tool, names: tuple[str, ...]
+) -> Callable[..., Awaitable[str]]:
+    """Wrap `tool.execute` so the public schema requires `db_name: Literal[...]`.
+
+    Used in multi-DB mode. The Literal binds the LLM to a registered database
+    name, so an invalid value is rejected at schema validation time rather than
+    surfaced as a runtime tool error.
+    """
+    raw = tool.execute
+    raw_sig = inspect.signature(raw)
+    db_lit = Literal[names]  # type: ignore
+
+    new_params = []
+    for name, p in raw_sig.parameters.items():
+        if name == "db_name":
+            new_params.append(
+                inspect.Parameter(
+                    "db_name",
+                    inspect.Parameter.KEYWORD_ONLY,
+                    annotation=db_lit,
+                )
+            )
+        else:
+            new_params.append(p)
+    if not any(p.name == "db_name" for p in new_params):
+        new_params.append(
+            inspect.Parameter(
+                "db_name",
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=db_lit,
+            )
+        )
+    new_sig = raw_sig.replace(parameters=new_params)
+
+    if tool.requires_ctx:
+
+        async def wrapper(ctx: RunContext, *args, db_name, **kwargs) -> str:
+            return await raw(ctx, *args, db_name=db_name, **kwargs)
+    else:
+
+        async def wrapper(*args, db_name, **kwargs) -> str:
+            return await raw(*args, db_name=db_name, **kwargs)
+
+    wrapper.__signature__ = new_sig  # type: ignore
+    wrapper.__name__ = getattr(raw, "__name__", tool.name)
+    wrapper.__doc__ = _docstring_with_db_name(raw.__doc__)
+    wrapper.__annotations__ = {
+        **getattr(raw, "__annotations__", {}),
+        "db_name": db_lit,
+    }
+    return wrapper
+
+
+_DB_NAME_DOC_TEXT = "db_name: which connected database to target."
+
+
+def _dedent_docstring(doc: str) -> str:
+    """Dedent a docstring per PEP 257 (first line untouched).
+
+    `textwrap.dedent` does nothing when the first line has no leading whitespace
+    but later lines do. PEP 257 dedents based on the minimum indent of all
+    lines after the first, then leaves the first line untouched.
+    """
+    lines = doc.splitlines()
+    if not lines:
+        return doc
+
+    rest = lines[1:]
+    indents = [len(line) - len(line.lstrip(" ")) for line in rest if line.strip()]
+    if not indents:
+        return doc.strip("\n")
+
+    common = min(indents)
+    dedented_rest = [line[common:] if line.strip() else line for line in rest]
+    return "\n".join([lines[0].lstrip(), *dedented_rest]).strip("\n")
+
+
+def _docstring_with_db_name(doc: str | None) -> str:
+    """Add a `db_name` entry to a tool docstring's Args section, in place.
+
+    Pydantic-ai parses the function docstring (via griffe) to populate
+    per-parameter descriptions. Two `Args:` blocks confuse the parser and wipe
+    earlier descriptions, so we splice `db_name` into the existing block when
+    one exists. We dedent first so the new entry inherits the original
+    docstring's indentation level rather than guessing it.
+    """
+    if not doc:
+        return f"Args:\n    {_DB_NAME_DOC_TEXT}\n"
+
+    dedented = _dedent_docstring(doc)
+    lines = dedented.splitlines()
+    args_idx = next(
+        (i for i, line in enumerate(lines) if line.strip().startswith("Args:")),
+        None,
+    )
+    if args_idx is None:
+        return dedented + f"\n\nArgs:\n    {_DB_NAME_DOC_TEXT}\n"
+
+    insert_at = args_idx + 1
+    # Skip any existing entries already inside the Args block.
+    while insert_at < len(lines) and (
+        lines[insert_at].startswith(" ") or lines[insert_at] == ""
+    ):
+        insert_at += 1
+    lines.insert(insert_at, f"    {_DB_NAME_DOC_TEXT}")
+    return "\n".join(lines) + "\n"
+
+
+def _build_db_catalog(registry: DatabaseRegistry) -> str:
+    """Render the registry as a markdown bullet list for the system prompt."""
+    lines: list[str] = []
+    for entry in registry:
+        description = entry.description or "no description"
+        lines.append(
+            f"- {entry.name} ({entry.display_name}, dialect={entry.dialect}) "
+            f"— {description}"
+        )
+    return "\n".join(lines)
+
+
+def _make_single_db_registry(
+    connection: BaseDatabaseConnection, name: str | None
+) -> DatabaseRegistry:
+    """Build a single-entry registry from a connection (used as a thin shim)."""
+    entry = DatabaseEntry.from_connection(
+        name=name or connection.display_name or "database",
+        connection=connection,
+        description=None,
+        excluded_schemas=list(getattr(connection, "excluded_schemas", []) or []),
+    )
+    return DatabaseRegistry([entry])
 
 
 class SQLSaberAgent:
@@ -37,8 +202,10 @@ class SQLSaberAgent:
 
     def __init__(
         self,
-        db_connection: BaseDatabaseConnection,
+        db_connection: BaseDatabaseConnection | None = None,
         database_name: str | None = None,
+        *,
+        registry: DatabaseRegistry | None = None,
         settings: Config | None = None,
         knowledge_manager: KnowledgeManager | None = None,
         thinking_enabled: bool | None = None,
@@ -49,8 +216,17 @@ class SQLSaberAgent:
         system_prompt: str | None = None,
         tool_overides: ToolOveridesInput | None = None,
     ):
-        self.db_connection = db_connection
-        self.database_name = database_name
+        if registry is None:
+            if db_connection is None:
+                raise ValueError(
+                    "SQLSaberAgent requires either `registry` or `db_connection`."
+                )
+            registry = _make_single_db_registry(db_connection, database_name)
+
+        self.registry = registry
+        primary = self.registry.get(self.registry.primary())
+        self.db_connection: BaseDatabaseConnection = primary.connection
+        self.database_name = primary.name
         self.config = settings or Config.default()
         self._owns_knowledge_manager = knowledge_manager is None
         self.knowledge_manager = knowledge_manager or KnowledgeManager()
@@ -64,7 +240,7 @@ class SQLSaberAgent:
         self.allow_dangerous = allow_dangerous
         self._tool_overides = normalize_tool_overides(tool_overides)
 
-        self.schema_manager = SchemaManager(self.db_connection)
+        self.schema_manager: SchemaManager = primary.schema_manager
 
         self.thinking_enabled = (
             thinking_enabled
@@ -78,26 +254,40 @@ class SQLSaberAgent:
             else self.config.model.thinking_level
         )
 
-        self._tools: dict[str, Tool] = {
-            name: tool_registry.create_tool(name) for name in tool_registry.list_tools()
-        }
+        self._tools: dict[str, Tool] = {}
+        for name in tool_registry.list_tools():
+            cls = tool_registry.get_tool_class(name)
+            if cls.multi_db_only and len(self.registry) <= 1:
+                continue
+            self._tools[name] = tool_registry.create_tool(name)
 
         self._configure_sql_tools()
         self._configure_knowledge_tools()
         self.agent = self._build_agent()
 
+    @property
+    def is_multi_db(self) -> bool:
+        return len(self.registry) > 1
+
     def _configure_sql_tools(self) -> None:
-        """Ensure SQL tools receive the active database connection and session config."""
+        """Ensure SQL tools receive the active database state and session config."""
         for tool in self._tools.values():
             if isinstance(tool, SQLTool):
-                tool.set_connection(self.db_connection, self.schema_manager)
+                if self.is_multi_db:
+                    tool.set_registry(self.registry)
+                else:
+                    tool.set_connection(self.db_connection, self.schema_manager)
                 tool.allow_dangerous = self.allow_dangerous
 
     def _configure_knowledge_tools(self) -> None:
         """Ensure knowledge tools receive database and manager context."""
         for tool in self._tools.values():
             if isinstance(tool, KnowledgeTool):
-                tool.set_context(self.database_name, self.knowledge_manager)
+                if self.is_multi_db:
+                    tool.set_registry(self.registry)
+                    tool.knowledge_manager = self.knowledge_manager
+                else:
+                    tool.set_context(self.database_name, self.knowledge_manager)
 
     def _build_agent(self) -> Agent:
         """Create and configure the pydantic-ai Agent."""
@@ -146,6 +336,11 @@ class SQLSaberAgent:
     def _base_system_prompt(self, *, use_gpt5: bool) -> str:
         if self.system_prompt_override is not None:
             return self.system_prompt_override
+        if self.is_multi_db:
+            catalog = _build_db_catalog(self.registry)
+            if use_gpt5:
+                return GPT_5_MULTI.format(db_catalog=catalog)
+            return CLAUDE_MULTI.format(db_catalog=catalog)
         if use_gpt5:
             return GPT_5.format(db=self.db_type)
         return CLAUDE.format(db=self.db_type)
@@ -162,10 +357,23 @@ class SQLSaberAgent:
         return self._apply_prompt_extras(base)
 
     def _register_tools(self, agent: Agent) -> None:
-        """Register all the SQL tools with the agent."""
+        """Register tools, applying the right wrapper for the session shape."""
+        names = tuple(self.registry.names())
         for tool in self._tools.values():
+            sig = inspect.signature(tool.execute)
+            has_db_name = "db_name" in sig.parameters
             register = agent.tool if tool.requires_ctx else agent.tool_plain
-            register(name=tool.name)(tool.execute)
+
+            if not has_db_name:
+                # e.g. ListDatabasesTool — no per-call DB routing
+                register(name=tool.name)(tool.execute)
+                continue
+
+            if self.is_multi_db:
+                wrapper = _wrap_add_db_name(tool, names)
+            else:
+                wrapper = _wrap_strip_db_name(tool)
+            register(name=tool.name)(wrapper)
 
     def set_thinking(self, enabled: bool, level: ThinkingLevel | None = None) -> None:
         """Update thinking settings and rebuild the agent.

--- a/src/sqlsaber/api.py
+++ b/src/sqlsaber/api.py
@@ -85,6 +85,9 @@ class SQLSaber:
             options: Session options bag used to build the SQLSaber session.
         """
         self._session = SQLSaberSession(options)
+        self.registry = self._session.registry
+        self.db_names = self._session.db_names
+        self.connections = self._session.connections
         self.db_name = self._session.db_name
         self.connection = self._session.connection
         self.agent = self._session.agent

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -102,6 +102,16 @@ def add(
             help="Comma-separated list of schemas to exclude from introspection",
         ),
     ] = None,
+    description: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            ["--description"],
+            help=(
+                "Short human-readable description of this connection. Shown to "
+                "the agent in multi-database sessions to help it pick the right DB."
+            ),
+        ),
+    ] = None,
     interactive: Annotated[
         bool,
         cyclopts.Parameter(
@@ -214,6 +224,7 @@ def add(
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
         exclude_schemas=exclude_schema_list,
+        description=description,
     )
 
     try:

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -56,6 +56,7 @@ class InteractiveSession:
         self.sqlsaber_agent = session.agent
         self.db_conn = session.connection
         self.database_name = session.db_name
+        self.database_names = list(getattr(session, "db_names", [session.db_name]))
         self.streaming_handler: TUIStreamingQueryHandler | None = None
         self.current_task: asyncio.Task | None = None
         self.cancellation_token: asyncio.Event | None = None
@@ -153,10 +154,20 @@ class InteractiveSession:
         model_name = self._model_name()
         return None if model_name == "Unknown" else model_name
 
+    def _database_footer_text(self) -> str:
+        database_names = getattr(self, "database_names", None)
+        if not database_names:
+            database_names = [self.database_name or "Unknown"]
+
+        if len(database_names) > 1:
+            return f"DBs: {', '.join(database_names)}"
+
+        db_name = database_names[0] or "Unknown"
+        return f"DB: {db_name} ({self._db_type_name()})"
+
     def _footer_text(self) -> str:
-        db_name = self.database_name or "Unknown"
         return (
-            f"DB: {db_name} ({self._db_type_name()}) | "
+            f"{self._database_footer_text()} | "
             f"Model: {self._model_name()} | {self._usage_footer_text()}"
         )
 

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -241,23 +241,59 @@ def resume(
     async def _run() -> None:
         # Lazy imports to avoid heavy modules at CLI startup
         from sqlsaber.cli.interactive import InteractiveSession
+        from sqlsaber.config.database import DatabaseConfigManager
         from sqlsaber.database.resolver import DatabaseResolutionError
         from sqlsaber.options import SQLSaberOptions
         from sqlsaber.session import SQLSaberSession
         from sqlsaber.threads.manager import ThreadManager
+        from sqlsaber.threads.metadata import resolve_thread_database_selector
 
         thread = await store.get_thread(thread_id)
         if not thread:
             console.print(f"[error]Thread not found:[/error] {thread_id}")
             logger.error("threads.cli.resume.not_found", thread_id=thread_id)
             return
-        db_selector = database if database is not None else thread.database_name
+        if database is not None:
+            db_selector = database
+        else:
+            try:
+                db_selector = resolve_thread_database_selector(
+                    database_name=thread.database_name,
+                    extra_metadata=thread.extra_metadata,
+                )
+            except ValueError as e:
+                console.print(f"[error]Thread metadata error:[/error] {e}")
+                logger.error(
+                    "threads.cli.resume.metadata_invalid",
+                    thread_id=thread_id,
+                    error=str(e),
+                )
+                return
         if not db_selector:
             console.print(
                 "[error]No database specified or stored with this thread.[/error]"
             )
             logger.error("threads.cli.resume.no_database", thread_id=thread_id)
             return
+        if database is None:
+            config_mgr = DatabaseConfigManager()
+            selectors = [db_selector] if isinstance(db_selector, str) else db_selector
+            missing = [
+                selector
+                for selector in selectors
+                if config_mgr.get_database(selector) is None
+            ]
+            if missing:
+                console.print(
+                    "[error]Thread database is not configured for automatic "
+                    "resume.[/error] Resume it with explicit --database/-d options."
+                )
+                logger.error(
+                    "threads.cli.resume.database_not_configured",
+                    thread_id=thread_id,
+                    missing=missing,
+                )
+                return
         history = await store.get_thread_messages(thread_id)
         session_thread_manager = ThreadManager(
             initial_thread_id=thread_id, storage=store

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -108,8 +108,10 @@ def _hex_to_rgb(color: str | None) -> tuple[int, int, int] | None:
 def _blend(
     base: tuple[int, int, int], accent: tuple[int, int, int], ratio: float
 ) -> tuple[int, int, int]:
-    return tuple(
-        round(base[index] * (1 - ratio) + accent[index] * ratio) for index in range(3)
+    return (
+        round(base[0] * (1 - ratio) + accent[0] * ratio),
+        round(base[1] * (1 - ratio) + accent[1] * ratio),
+        round(base[2] * (1 - ratio) + accent[2] * ratio),
     )
 
 

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -13,7 +13,13 @@ from pygments.styles import get_style_by_name
 from pygments.util import ClassNotFound
 from rich.console import Console
 from rich.markdown import Markdown
-from saber_tui import PosixProcessTerminal, TUI, Terminal, WindowsProcessTerminal, matches_key
+from saber_tui import (
+    PosixProcessTerminal,
+    TUI,
+    Terminal,
+    WindowsProcessTerminal,
+    matches_key,
+)
 from saber_tui.components import (
     CancellableLoader,
     Editor,

--- a/src/sqlsaber/cli/usage.py
+++ b/src/sqlsaber/cli/usage.py
@@ -125,7 +125,9 @@ def calculate_run_cost_usd(
         return None
 
 
-def request_usages_from_messages(messages: Sequence[ModelMessage]) -> list[RequestUsage]:
+def request_usages_from_messages(
+    messages: Sequence[ModelMessage],
+) -> list[RequestUsage]:
     """Extract per-request usage entries from model response messages."""
     return [message.usage for message in messages if isinstance(message, ModelResponse)]
 

--- a/src/sqlsaber/config/database.py
+++ b/src/sqlsaber/config/database.py
@@ -30,6 +30,7 @@ class DatabaseConfig:
     ssl_key: str | None = None
     schema: str | None = None
     exclude_schemas: list[str] = field(default_factory=list)
+    description: str | None = None
 
     def to_connection_string(self) -> str:
         """Convert config to database connection string."""
@@ -151,6 +152,7 @@ class DatabaseConfig:
             "ssl_key": self.ssl_key,
             "schema": self.schema,
             "exclude_schemas": self.exclude_schemas,
+            "description": self.description,
         }
 
     @classmethod
@@ -169,6 +171,7 @@ class DatabaseConfig:
             ssl_key=data.get("ssl_key"),
             schema=data.get("schema"),
             exclude_schemas=list(data.get("exclude_schemas", [])),
+            description=data.get("description"),
         )
 
 

--- a/src/sqlsaber/database/mysql.py
+++ b/src/sqlsaber/database/mysql.py
@@ -86,7 +86,7 @@ class MySQLConnection(BaseDatabaseConnection):
     async def get_pool(self) -> aiomysql.Pool:
         """Get or create connection pool."""
         if self._pool is None:
-            pool_kwargs = {
+            pool_kwargs: dict[str, Any] = {
                 "host": self.host,
                 "port": self.port,
                 "user": self.user,

--- a/src/sqlsaber/database/registry.py
+++ b/src/sqlsaber/database/registry.py
@@ -136,12 +136,12 @@ class DatabaseRegistry:
         ]
 
     async def close(self) -> None:
-        """Close every connection. Aggregates errors and re-raises the first."""
-        errors: list[BaseException] = []
+        """Close every connection. Aggregates regular errors and re-raises the first."""
+        errors: list[Exception] = []
         for entry in self._entries.values():
             try:
                 await entry.connection.close()
-            except BaseException as exc:
+            except Exception as exc:
                 errors.append(exc)
         if errors:
             raise errors[0]

--- a/src/sqlsaber/database/registry.py
+++ b/src/sqlsaber/database/registry.py
@@ -1,0 +1,147 @@
+"""Registry of databases connected to a single SQLSaber session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+from sqlsaber.database import DatabaseConnection
+from sqlsaber.database.base import BaseDatabaseConnection
+from sqlsaber.database.resolver import ResolvedDatabase
+from sqlsaber.database.schema import SchemaManager
+
+
+class UnknownDatabaseError(KeyError):
+    """Raised when a registry lookup uses a name that is not registered."""
+
+
+@dataclass
+class DatabaseEntry:
+    """A live, registered database connection together with its metadata."""
+
+    name: str
+    connection: BaseDatabaseConnection
+    schema_manager: SchemaManager
+    description: str | None
+    excluded_schemas: list[str]
+
+    @property
+    def dialect(self) -> str:
+        return self.connection.sqlglot_dialect
+
+    @property
+    def display_name(self) -> str:
+        return self.connection.display_name
+
+    @classmethod
+    def from_connection(
+        cls,
+        *,
+        name: str,
+        connection: BaseDatabaseConnection,
+        description: str | None,
+        excluded_schemas: list[str],
+    ) -> "DatabaseEntry":
+        return cls(
+            name=name,
+            connection=connection,
+            schema_manager=SchemaManager(connection),
+            description=description,
+            excluded_schemas=list(excluded_schemas),
+        )
+
+
+class DatabaseRegistry:
+    """Ordered, name-keyed collection of database entries for one session."""
+
+    def __init__(self, entries: list[DatabaseEntry]):
+        if not entries:
+            raise ValueError("DatabaseRegistry requires at least one entry.")
+
+        seen: set[str] = set()
+        for entry in entries:
+            if entry.name in seen:
+                raise ValueError(
+                    f"Cannot register duplicate database name '{entry.name}'."
+                )
+            seen.add(entry.name)
+
+        self._entries: dict[str, DatabaseEntry] = {e.name: e for e in entries}
+
+    @classmethod
+    def from_resolved(cls, resolved: list[ResolvedDatabase]) -> "DatabaseRegistry":
+        """Build a registry from a list of resolver outputs (eager connect)."""
+        entries: list[DatabaseEntry] = []
+        for item in resolved:
+            connection = DatabaseConnection(
+                item.connection_string, excluded_schemas=item.excluded_schemas
+            )
+            entries.append(
+                DatabaseEntry.from_connection(
+                    name=item.name,
+                    connection=connection,
+                    description=item.description,
+                    excluded_schemas=list(item.excluded_schemas),
+                )
+            )
+        return cls(entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._entries
+
+    def __iter__(self) -> Iterator[DatabaseEntry]:
+        return iter(self._entries.values())
+
+    def names(self) -> list[str]:
+        return list(self._entries.keys())
+
+    def primary(self) -> str:
+        """Return the name of the first-registered database."""
+        return next(iter(self._entries))
+
+    def get(self, name: str) -> DatabaseEntry:
+        entry = self._entries.get(name)
+        if entry is None:
+            valid = ", ".join(self._entries.keys())
+            raise UnknownDatabaseError(
+                f"Unknown database '{name}'. Valid names: {valid}."
+            )
+        return entry
+
+    def connection(self, name: str) -> BaseDatabaseConnection:
+        return self.get(name).connection
+
+    def schema_manager(self, name: str) -> SchemaManager:
+        return self.get(name).schema_manager
+
+    def dialect(self, name: str) -> str:
+        return self.get(name).dialect
+
+    def catalog(self) -> list[dict[str, str | None]]:
+        """Return a serializable description of every registered database.
+
+        Used by `list_dbs` and the multi-DB system prompt.
+        """
+        return [
+            {
+                "name": entry.name,
+                "display_name": entry.display_name,
+                "dialect": entry.dialect,
+                "description": entry.description,
+            }
+            for entry in self._entries.values()
+        ]
+
+    async def close(self) -> None:
+        """Close every connection. Aggregates errors and re-raises the first."""
+        errors: list[BaseException] = []
+        for entry in self._entries.values():
+            try:
+                await entry.connection.close()
+            except BaseException as exc:
+                errors.append(exc)
+        if errors:
+            raise errors[0]

--- a/src/sqlsaber/database/resolver.py
+++ b/src/sqlsaber/database/resolver.py
@@ -18,6 +18,7 @@ class ResolvedDatabase:
     name: str  # Human-readable name for display/logging
     connection_string: str  # Canonical connection string for DatabaseConnection factory
     excluded_schemas: list[str]
+    description: str | None = None
 
 
 SUPPORTED_SCHEMES = {"postgresql", "mysql", "sqlite", "duckdb", "csv", "csvs"}
@@ -82,6 +83,59 @@ def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
     )
 
 
+def _all_csv_specs(specs: list[str]) -> bool:
+    """Return True iff every spec resolves to a CSV file (path or csv:// URL)."""
+    for spec in specs:
+        if _is_connection_string(spec):
+            if urlparse(spec).scheme != "csv":
+                return False
+        else:
+            if Path(spec).suffix.lower() != ".csv":
+                return False
+    return True
+
+
+def resolve_databases(
+    spec: str | list[str] | None,
+    config_mgr: DatabaseConfigManager | None = None,
+) -> list[ResolvedDatabase]:
+    """Resolve a CLI spec into one or more `ResolvedDatabase` entries.
+
+    - `None`, single string, or single-element list → returns 1 entry (matches
+      `resolve_database` semantics).
+    - All-CSV list → returns 1 entry (CSVs merger, today's behavior).
+    - Mixed/non-CSV list with N > 1 → returns N entries, each resolved
+      independently. Duplicate names raise `DatabaseResolutionError`.
+    """
+    if spec is None or isinstance(spec, str):
+        return [resolve_database(spec, config_mgr)]
+
+    if not isinstance(spec, list):
+        raise DatabaseResolutionError(f"Unsupported database spec: {spec!r}")
+
+    if len(spec) == 0:
+        raise DatabaseResolutionError("Empty database argument list.")
+
+    if len(spec) == 1:
+        return [resolve_database(spec[0], config_mgr)]
+
+    if _all_csv_specs(spec):
+        return [_resolve_multiple_csvs(spec)]
+
+    resolved = [resolve_database(item, config_mgr) for item in spec]
+
+    seen: set[str] = set()
+    for entry in resolved:
+        if entry.name in seen:
+            raise DatabaseResolutionError(
+                f"Cannot use duplicate database name '{entry.name}' in a "
+                "multi-database session."
+            )
+        seen.add(entry.name)
+
+    return resolved
+
+
 def resolve_database(
     spec: str | list[str] | None, config_mgr: DatabaseConfigManager | None = None
 ) -> ResolvedDatabase:
@@ -112,6 +166,7 @@ def resolve_database(
             name=db_cfg.name,
             connection_string=db_cfg.to_connection_string(),
             excluded_schemas=list(db_cfg.exclude_schemas),
+            description=db_cfg.description,
         )
 
     if isinstance(spec, list):
@@ -167,4 +222,5 @@ def resolve_database(
         name=db_cfg.name,
         connection_string=db_cfg.to_connection_string(),
         excluded_schemas=list(db_cfg.exclude_schemas),
+        description=db_cfg.description,
     )

--- a/src/sqlsaber/prompts/claude.py
+++ b/src/sqlsaber/prompts/claude.py
@@ -1,3 +1,46 @@
+CLAUDE_MULTI = """You are a helpful SQL assistant designed to help users query their databases using natural language requests.
+
+You are connected to multiple databases. For every SQL or knowledge tool call you MUST pass `db_name`. Do NOT attempt cross-database joins; query each database separately and combine the results in your reply.
+
+Connected databases:
+{db_catalog}
+
+Use the available tools as needed to address user's requests.
+
+## Important Guidelines
+
+- Always search knowledge base. This will give you important context to help address user's request
+- Explain each query's purpose in simple non-technical terms
+- If you call `viz`, do not include tool arguments or JSON specs in the final response; only summarize the chart in plain language
+
+## Response Format
+
+For each user request, structure your response as follows:
+
+Before proceeding with database exploration, work through the problem systematically in <analysis> tags inside your thinking block:
+- Parse the user's natural language request and identify the core question being asked
+- Decide which connected database(s) most likely hold the relevant data and call tools with the matching `db_name`
+- Extract key terms, entities, and concepts that might correspond to database tables or columns
+- Consider what types of data relationships might be involved (e.g., one-to-many, many-to-many)
+- Plan your database exploration approach step by step
+- Design your overall SQL strategy, including potential JOINs (within a single database), filters, and aggregations
+- Anticipate potential challenges or edge cases specific to each database's dialect
+- Verify your approach makes logical sense for the business question
+
+It's OK for this analysis section to be quite long if the request is complex.
+
+Then, execute the planned database exploration and queries, providing clear explanations of results.
+
+## Example Response Structure
+
+Working through this systematically in my analysis, then exploring tables and executing queries...
+
+Now I need to address your specific request. Before proceeding with database exploration, let me analyze what you're asking for:
+
+Your final response should focus on the database exploration, query execution, and results explanation, without duplicating or rehashing the analytical work done in the thinking block.
+"""
+
+
 CLAUDE = """You are a helpful SQL assistant designed to help users query their {db} database using natural language requests.
 
 Use the available tools as needed to address user's requests.

--- a/src/sqlsaber/prompts/openai.py
+++ b/src/sqlsaber/prompts/openai.py
@@ -1,3 +1,53 @@
+GPT_5_MULTI = """# Role and Objective
+A helpful SQL assistant that assists users in querying multiple databases.
+
+You are connected to multiple databases. For every SQL or knowledge tool call you MUST pass `db_name`. Do NOT attempt cross-database joins; query each database separately and combine the results in your reply.
+
+Connected databases:
+{db_catalog}
+
+# Instructions
+- Understand user requests in natural language and convert them into SQL queries for the correct database.
+- Decide which connected database is the best target for each tool call and pass `db_name` accordingly.
+- Efficiently utilize provided tools to investigate the database schema.
+- Generate and execute only safe and appropriate SQL queries (only SELECT statements are allowed — no modifications to the database).
+- Clearly format and explain results to the user.
+- Set reasoning_effort = medium due to moderate task complexity; keep tool call outputs concise, provide fuller explanations in the final output.
+
+## Workflow Checklist
+Begin by thinking about what you will do; keep items conceptual, not implementation-level, before substantive work on user queries.
+
+- Analyze the user request and determine intent.
+- Decide which connected databases are relevant. Call `list_dbs` if you need a refresher on what is available.
+- List available tables and their row counts in the relevant database(s) using the appropriate tool.
+- Identify relevant tables via schema introspection with filtered patterns.
+- Formulate a safe and appropriate SELECT query; include LIMIT to control row counts.
+- Execute the query and validate the result for correctness and safety.
+- Clearly explain the result or guide the user if adjustments are needed.
+
+
+## Tool Usage Strategy
+1. **Start with `list_tables`**: Once you know which database to inspect, list available tables and row counts there. Before any significant tool call, state the purpose and minimal inputs.
+2. **Use `introspect_schema` with a table pattern**: Retrieve schema details only for tables relevant to the user's request, employing patterns like `sample%` or `%experiment%` to filter.
+3. **Execute SQL queries safely**: The tool enforces a server-side max row cap of 1000 if a LIMIT is missing. If you need more rows, re-run with a higher LIMIT.
+
+## Tool-Specific Guidelines
+- **introspect_schema**: Limit introspection to relevant tables using appropriate patterns (e.g., `sample%`, `%experiment%`).
+- **execute_sql**: Only run SELECT queries. Prefer using LIMIT in your SQL.
+
+# Guidelines
+- Apply proper JOIN syntax to avoid cartesian products. Joins are within a single database only — do not attempt cross-database joins.
+- Use appropriate WHERE clauses to filter results.
+- Explain each query in simple terms for user understanding.
+- Handle errors gracefully and suggest corrections to users.
+- Be security conscious — use parameterized queries when necessary.
+- Convert timestamp columns to text within the SQL queries you generate.
+- Use table patterns (like `sample%` or `%experiment%`) to narrow down contextually relevant tables.
+- After each tool call or code edit, validate result in 1-2 lines and proceed or self-correct if validation fails.
+- If you call `viz`, do not include tool arguments or JSON specs in the final response; only summarize the chart in plain language.
+"""
+
+
 GPT_5 = """# Role and Objective
 A helpful SQL assistant that assists users in querying their {db} database.
 

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -9,6 +9,7 @@ from pydantic_ai import RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
+from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.config.logging import get_logger
 from sqlsaber.config.settings import Config, ThinkingLevel
 from sqlsaber.database.base import BaseDatabaseConnection
@@ -16,6 +17,10 @@ from sqlsaber.database.registry import DatabaseRegistry
 from sqlsaber.database.resolver import resolve_databases
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.options import SQLSaberOptions
+from sqlsaber.threads.metadata import (
+    encode_thread_extra_metadata,
+    encode_thread_resume_disabled_metadata,
+)
 from sqlsaber.utils.text_input import resolve_text_input
 
 logger = get_logger(__name__)
@@ -34,6 +39,9 @@ class SQLSaberSession:
         else:
             database_spec = options.database
 
+        self._database_spec = (
+            list(database_spec) if isinstance(database_spec, list) else database_spec
+        )
         self._resolved = resolve_databases(database_spec)
         self.registry: DatabaseRegistry = DatabaseRegistry.from_resolved(self._resolved)
         self.db_names: list[str] = self.registry.names()
@@ -98,23 +106,61 @@ class SQLSaberSession:
                 if not isinstance(resolved_model_name, str) or not resolved_model_name:
                     resolved_model_name = self.agent.config.model.name
 
-                # Multi-DB sessions persist comma-joined names for now; thread
-                # resume does not auto-reconnect, so the column is informational.
+                # Keep database_name display-oriented while storing the original
+                # selector separately so multi-DB resumes never treat
+                # comma-joined names as one database spec.
                 if len(self.registry) > 1:
                     database_name = ",".join(self.db_names)
                 else:
                     database_name = self.db_name
+
+                database_selector = self._configured_database_selector()
+                if database_selector is None:
+                    extra_metadata = encode_thread_resume_disabled_metadata(
+                        reason=(
+                            "Only configured database names are saved for automatic "
+                            "resume."
+                        )
+                    )
+                else:
+                    extra_metadata = encode_thread_extra_metadata(
+                        database_selector=database_selector
+                    )
 
                 await self.thread_manager.save_run(
                     run_result=run_result,
                     database_name=database_name,
                     user_query=prompt,
                     model_name=resolved_model_name,
+                    extra_metadata=extra_metadata,
                 )
             except Exception as exc:
                 logger.warning("sdk.thread.save_failed", error=str(exc))
 
         return run_result
+
+    def _configured_database_selector(self) -> str | list[str] | None:
+        """Return a safe, configured selector for resume metadata, if available.
+
+        Raw DSNs and paths are intentionally not persisted so credentials never
+        land in thread metadata. Those sessions require an explicit database
+        override when resuming.
+        """
+        if self._database_spec is None:
+            return self.db_name
+
+        config_mgr = DatabaseConfigManager()
+        if isinstance(self._database_spec, str):
+            if config_mgr.get_database(self._database_spec) is None:
+                return None
+            return self._database_spec
+
+        configured_names: list[str] = []
+        for selector in self._database_spec:
+            if config_mgr.get_database(selector) is None:
+                return None
+            configured_names.append(selector)
+        return configured_names
 
     async def close(self) -> None:
         """Close resources owned by this session."""

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -11,8 +11,9 @@ from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
 from sqlsaber.config.logging import get_logger
 from sqlsaber.config.settings import Config, ThinkingLevel
-from sqlsaber.database import DatabaseConnection
-from sqlsaber.database.resolver import resolve_database
+from sqlsaber.database.base import BaseDatabaseConnection
+from sqlsaber.database.registry import DatabaseRegistry
+from sqlsaber.database.resolver import resolve_databases
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.options import SQLSaberOptions
 from sqlsaber.utils.text_input import resolve_text_input
@@ -33,12 +34,15 @@ class SQLSaberSession:
         else:
             database_spec = options.database
 
-        self._resolved = resolve_database(database_spec)
-        self.db_name = self._resolved.name
-        self.connection = DatabaseConnection(
-            self._resolved.connection_string,
-            excluded_schemas=self._resolved.excluded_schemas,
-        )
+        self._resolved = resolve_databases(database_spec)
+        self.registry: DatabaseRegistry = DatabaseRegistry.from_resolved(self._resolved)
+        self.db_names: list[str] = self.registry.names()
+        self.connections: dict[str, BaseDatabaseConnection] = {
+            entry.name: entry.connection for entry in self.registry
+        }
+        # Primary attrs preserved for back-compat with single-DB callers/tests.
+        self.db_name = self.registry.primary()
+        self.connection = self.connections[self.db_name]
 
         self.settings = options.settings or Config.default()
         self.knowledge_manager = options.knowledge_manager or KnowledgeManager()
@@ -59,8 +63,7 @@ class SQLSaberSession:
         system_prompt_text = resolve_text_input(options.system_prompt)
 
         self.agent = SQLSaberAgent(
-            self.connection,
-            self.db_name,
+            registry=self.registry,
             settings=self.settings,
             knowledge_manager=self.knowledge_manager,
             thinking_enabled=thinking_enabled,
@@ -95,9 +98,16 @@ class SQLSaberSession:
                 if not isinstance(resolved_model_name, str) or not resolved_model_name:
                     resolved_model_name = self.agent.config.model.name
 
+                # Multi-DB sessions persist comma-joined names for now; thread
+                # resume does not auto-reconnect, so the column is informational.
+                if len(self.registry) > 1:
+                    database_name = ",".join(self.db_names)
+                else:
+                    database_name = self.db_name
+
                 await self.thread_manager.save_run(
                     run_result=run_result,
-                    database_name=self.db_name,
+                    database_name=database_name,
                     user_query=prompt,
                     model_name=resolved_model_name,
                 )
@@ -132,7 +142,7 @@ class SQLSaberSession:
                 errors.append(exc)
 
         try:
-            await self.connection.close()
+            await self.registry.close()
         except Exception as exc:  # pragma: no cover - best effort cleanup
             errors.append(exc)
 

--- a/src/sqlsaber/threads/manager.py
+++ b/src/sqlsaber/threads/manager.py
@@ -52,6 +52,7 @@ class ThreadManager:
         database_name: str,
         user_query: str,
         model_name: str,
+        extra_metadata: str | None = None,
     ) -> list:
         """
         Persist message history from a run result.
@@ -69,6 +70,7 @@ class ThreadManager:
                 messages_json=run_result.all_messages_json(),
                 database_name=database_name,
                 thread_id=self.current_thread_id,
+                extra_metadata=extra_metadata,
             )
 
             # Save metadata separately (only if it's the first message of a new thread)

--- a/src/sqlsaber/threads/metadata.py
+++ b/src/sqlsaber/threads/metadata.py
@@ -1,0 +1,103 @@
+"""Thread metadata helpers for resumable session state."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+type DatabaseSelector = str | list[str]
+THREAD_METADATA_VERSION = 1
+DATABASE_SELECTOR_KEY = "database_selector"
+RESUME_DISABLED_KEY = "resume_disabled"
+RESUME_DISABLED_REASON_KEY = "resume_disabled_reason"
+
+
+def _validate_database_selector(value: Any) -> DatabaseSelector:
+    """Validate and normalize a stored database selector."""
+    if isinstance(value, str):
+        if not value:
+            raise ValueError("Thread database selector must not be empty.")
+        return value
+
+    if isinstance(value, list):
+        if not value:
+            raise ValueError("Thread database selector list must not be empty.")
+        selector: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item:
+                raise ValueError(
+                    "Thread database selector list must contain only non-empty strings."
+                )
+            selector.append(item)
+        return selector
+
+    raise ValueError("Thread database selector must be a string or a list of strings.")
+
+
+def encode_thread_extra_metadata(*, database_selector: DatabaseSelector) -> str:
+    """Encode resumable thread metadata as JSON."""
+    selector = _validate_database_selector(database_selector)
+    return json.dumps(
+        {
+            "version": THREAD_METADATA_VERSION,
+            DATABASE_SELECTOR_KEY: selector,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def encode_thread_resume_disabled_metadata(*, reason: str) -> str:
+    """Encode metadata indicating resume requires an explicit database override."""
+    if not reason:
+        raise ValueError("Thread resume disabled reason must not be empty.")
+    return json.dumps(
+        {
+            "version": THREAD_METADATA_VERSION,
+            RESUME_DISABLED_KEY: True,
+            RESUME_DISABLED_REASON_KEY: reason,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def resolve_thread_database_selector(
+    *, database_name: str | None, extra_metadata: str | None
+) -> DatabaseSelector | None:
+    """Return the database selector to use when resuming a thread.
+
+    The structured selector in ``extra_metadata`` is authoritative when present.
+    Legacy threads without metadata can still resume from a single stored
+    database name, but comma-joined legacy multi-database names are rejected
+    because resolving them as one name can fail or target the wrong database.
+    """
+    if extra_metadata is not None:
+        try:
+            metadata = json.loads(extra_metadata)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Thread extra_metadata contains invalid JSON.") from exc
+        if not isinstance(metadata, dict):
+            raise ValueError("Thread extra_metadata must be a JSON object.")
+
+        if metadata.get(RESUME_DISABLED_KEY) is True:
+            reason = metadata.get(RESUME_DISABLED_REASON_KEY)
+            detail = f" {reason}" if isinstance(reason, str) and reason else ""
+            raise ValueError(
+                "This thread cannot be resumed automatically because its database "
+                f"selector was not saved.{detail} Resume it with explicit "
+                "--database/-d options."
+            )
+
+        selector = metadata.get(DATABASE_SELECTOR_KEY)
+        if selector is not None:
+            return _validate_database_selector(selector)
+
+    if database_name and "," in database_name:
+        raise ValueError(
+            "This thread was saved with multiple databases but does not include "
+            "resumable database metadata. Resume it with explicit repeated "
+            "--database/-d options."
+        )
+
+    return database_name

--- a/src/sqlsaber/threads/storage.py
+++ b/src/sqlsaber/threads/storage.py
@@ -53,6 +53,7 @@ class Thread:
         ended_at: float | None,
         last_activity_at: float,
         model_name: str | None,
+        extra_metadata: str | None = None,
     ) -> None:
         self.id = id
         self.database_name = database_name
@@ -61,6 +62,7 @@ class Thread:
         self.ended_at = ended_at
         self.last_activity_at = last_activity_at
         self.model_name = model_name
+        self.extra_metadata = extra_metadata
 
 
 class ThreadStorage:
@@ -200,7 +202,7 @@ class ThreadStorage:
                 async with db.execute(
                     """
                     SELECT id, database_name, title, created_at, ended_at,
-                           last_activity_at, model_name
+                           last_activity_at, model_name, extra_metadata
                     FROM threads WHERE id = ?
                     """,
                     (thread_id,),
@@ -216,6 +218,7 @@ class ThreadStorage:
                         ended_at=row[4],
                         last_activity_at=row[5],
                         model_name=row[6],
+                        extra_metadata=row[7],
                     )
         except Exception as e:  # pragma: no cover
             logger.warning("threads.get_failed", thread_id=thread_id, error=str(e))
@@ -247,7 +250,7 @@ class ThreadStorage:
         await self._init_db()
         try:
             query = (
-                "SELECT id, database_name, title, created_at, ended_at, last_activity_at, model_name"
+                "SELECT id, database_name, title, created_at, ended_at, last_activity_at, model_name, extra_metadata"
                 " FROM threads"
             )
             params: list[Any] = []
@@ -270,6 +273,7 @@ class ThreadStorage:
                                 ended_at=row[4],
                                 last_activity_at=row[5],
                                 model_name=row[6],
+                                extra_metadata=row[7],
                             )
                         )
                     return threads

--- a/src/sqlsaber/tools/base.py
+++ b/src/sqlsaber/tools/base.py
@@ -12,6 +12,7 @@ class Tool(ABC):
     """Abstract base class for all tools."""
 
     requires_ctx: ClassVar[bool] = False
+    multi_db_only: ClassVar[bool] = False
     display_spec: ClassVar[ToolDisplaySpec | None] = None
 
     def __init__(self):

--- a/src/sqlsaber/tools/knowledge_tool.py
+++ b/src/sqlsaber/tools/knowledge_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from sqlsaber.database.registry import DatabaseRegistry, UnknownDatabaseError
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.utils.json_utils import json_dumps
 
@@ -29,6 +30,7 @@ class KnowledgeTool(Tool):
         super().__init__()
         self.database_name = database_name
         self.knowledge_manager = knowledge_manager
+        self.registry: DatabaseRegistry | None = None
 
     def set_context(
         self, database_name: str | None, knowledge_manager: KnowledgeManager
@@ -36,6 +38,29 @@ class KnowledgeTool(Tool):
         """Set contextual dependencies after tool construction."""
         self.database_name = database_name
         self.knowledge_manager = knowledge_manager
+
+    def set_registry(self, registry: DatabaseRegistry) -> None:
+        """Attach a multi-database registry for runtime routing by `db_name`."""
+        self.registry = registry
+
+    def _resolve_database_name(self, db_name: str | None) -> str | None:
+        """Resolve which DB partition to search.
+
+        Returns the registered name when a registry is attached, the
+        session-bound `self.database_name` otherwise. Raises ValueError with a
+        user-facing message if `db_name` is missing or invalid in multi-DB mode.
+        """
+        if self.registry is not None:
+            if not db_name:
+                raise ValueError(
+                    "Multiple databases are connected; you must pass `db_name`. "
+                    f"Valid names: {', '.join(self.registry.names())}."
+                )
+            try:
+                return self.registry.get(db_name).name
+            except UnknownDatabaseError as exc:
+                raise ValueError(str(exc)) from exc
+        return self.database_name
 
 
 @register_tool
@@ -71,7 +96,7 @@ class SearchKnowledgeTool(KnowledgeTool):
     def name(self) -> str:
         return "search_knowledge"
 
-    async def execute(self, query: str) -> str:
+    async def execute(self, query: str, db_name: str | None = None) -> str:
         """Search existing sql and knowledge about active database.
 
         When to use this tool:
@@ -86,7 +111,12 @@ class SearchKnowledgeTool(KnowledgeTool):
         if not query.strip():
             return json_dumps({"error": "No query provided."})
 
-        if self.knowledge_manager is None or not self.database_name:
+        try:
+            target_name = self._resolve_database_name(db_name)
+        except ValueError as exc:
+            return json_dumps({"error": str(exc)})
+
+        if self.knowledge_manager is None or not target_name:
             return json_dumps(
                 {
                     "error": (
@@ -98,7 +128,7 @@ class SearchKnowledgeTool(KnowledgeTool):
 
         try:
             entries = await self.knowledge_manager.search_knowledge(
-                self.database_name, query, limit=10
+                target_name, query, limit=10
             )
         except Exception as exc:
             return json_dumps({"error": f"Error searching knowledge: {str(exc)}"})

--- a/src/sqlsaber/tools/sql_tools.py
+++ b/src/sqlsaber/tools/sql_tools.py
@@ -704,7 +704,7 @@ class ExecuteSQLTool(SQLTool):
             tool_call_id = ctx.tool_call_id
             if query_type == "select":
                 row_count = len(results)
-                payload = {
+                payload: dict[str, Any] = {
                     "success": True,
                     "row_count": row_count,
                     "results": results,
@@ -717,7 +717,7 @@ class ExecuteSQLTool(SQLTool):
                 if tool_call_id:
                     payload["file"] = f"result_{tool_call_id}.json"
                 return json_dumps(payload)
-            payload = {
+            payload: dict[str, Any] = {
                 "success": True,
                 "row_count": len(results),
                 "results": results,

--- a/src/sqlsaber/tools/sql_tools.py
+++ b/src/sqlsaber/tools/sql_tools.py
@@ -1,6 +1,7 @@
 """SQL-related tools for database operations."""
 
 import json
+from dataclasses import dataclass
 from html import escape
 from typing import Any, cast
 
@@ -13,6 +14,7 @@ from tabulate import tabulate
 from sqlsaber.theme.manager import get_theme_manager
 
 from sqlsaber.database import BaseDatabaseConnection
+from sqlsaber.database.registry import DatabaseRegistry, UnknownDatabaseError
 from sqlsaber.database.schema import SchemaManager
 from sqlsaber.utils.json_utils import json_dumps
 
@@ -30,6 +32,19 @@ from .registry import register_tool
 from .sql_guard import add_limit, validate_sql
 
 
+@dataclass
+class _ResolvedTarget:
+    """Connection + schema manager + dialect resolved for a single tool call."""
+
+    connection: BaseDatabaseConnection
+    schema_manager: SchemaManager
+    dialect: str
+
+
+class ToolDatabaseError(Exception):
+    """Raised when a tool cannot resolve which database to operate against."""
+
+
 class SQLTool(Tool):
     """Base class for SQL tools that need database access."""
 
@@ -44,6 +59,7 @@ class SQLTool(Tool):
         # allow_dangerous is set by SQLSaberAgent at session level
         # Do NOT expose this as a tool parameter to prevent LLM from escalating
         self.allow_dangerous: bool = False
+        self.registry: DatabaseRegistry | None = None
         if schema_manager:
             self.schema_manager = schema_manager
         elif db_connection:
@@ -62,6 +78,44 @@ class SQLTool(Tool):
             self.schema_manager = schema_manager
         else:
             self.schema_manager = SchemaManager(db_connection)
+
+    def set_registry(self, registry: DatabaseRegistry) -> None:
+        """Attach a multi-database registry. Replaces any single-DB binding."""
+        self.registry = registry
+
+    def _resolve(self, db_name: str | None) -> _ResolvedTarget:
+        """Resolve which DB to act on for this tool call.
+
+        - Registry attached: `db_name` must be a registered name.
+        - No registry: fall back to the single-DB connection set via
+          `set_connection`. `db_name` is ignored.
+        Raises `ToolDatabaseError` with a user-facing message on failure.
+        """
+        if self.registry is not None:
+            if not db_name:
+                raise ToolDatabaseError(
+                    "Multiple databases are connected; you must pass `db_name`. "
+                    f"Valid names: {', '.join(self.registry.names())}."
+                )
+            try:
+                entry = self.registry.get(db_name)
+            except UnknownDatabaseError as exc:
+                raise ToolDatabaseError(str(exc)) from exc
+            return _ResolvedTarget(
+                connection=entry.connection,
+                schema_manager=entry.schema_manager,
+                dialect=entry.dialect,
+            )
+
+        if not self.db:
+            raise ToolDatabaseError("No database connection available")
+
+        schema_manager = self.schema_manager or SchemaManager(self.db)
+        return _ResolvedTarget(
+            connection=self.db,
+            schema_manager=schema_manager,
+            dialect=self.db.sqlglot_dialect,
+        )
 
 
 @register_tool
@@ -90,13 +144,15 @@ class ListTablesTool(SQLTool):
     def name(self) -> str:
         return "list_tables"
 
-    async def execute(self) -> str:
+    async def execute(self, db_name: str | None = None) -> str:
         """List all tables in the database."""
-        if not self.db or not self.schema_manager:
-            return json_dumps({"error": "No database connection available"})
+        try:
+            target = self._resolve(db_name)
+        except ToolDatabaseError as exc:
+            return json_dumps({"error": str(exc)})
 
         try:
-            tables_info = await self.schema_manager.list_tables()
+            tables_info = await target.schema_manager.list_tables()
             return json_dumps(tables_info)
         except Exception as e:
             return json_dumps({"error": f"Error listing tables: {str(e)}"})
@@ -367,18 +423,22 @@ class IntrospectSchemaTool(SQLTool):
     def name(self) -> str:
         return "introspect_schema"
 
-    async def execute(self, table_pattern: str | None = None) -> str:
+    async def execute(
+        self, table_pattern: str | None = None, db_name: str | None = None
+    ) -> str:
         """
         Introspect database schema.
 
         Args:
             table_pattern: Optional pattern to filter tables (e.g., 'public.users', 'user%', '%order%')
         """
-        if not self.db or not self.schema_manager:
-            return json_dumps({"error": "No database connection available"})
+        try:
+            target = self._resolve(db_name)
+        except ToolDatabaseError as exc:
+            return json_dumps({"error": str(exc)})
 
         try:
-            schema_info = await self.schema_manager.get_schema_info(table_pattern)
+            schema_info = await target.schema_manager.get_schema_info(table_pattern)
 
             # Format the schema information
             formatted_info = {}
@@ -593,15 +653,19 @@ class ExecuteSQLTool(SQLTool):
     def name(self) -> str:
         return "execute_sql"
 
-    async def execute(self, ctx: RunContext, query: str) -> str:
+    async def execute(
+        self, ctx: RunContext, query: str, db_name: str | None = None
+    ) -> str:
         """
         Execute a SQL query against the database.
 
         Args:
             query: SQL query to execute
         """
-        if not self.db:
-            return json_dumps({"error": "No database connection available"})
+        try:
+            target = self._resolve(db_name)
+        except ToolDatabaseError as exc:
+            return json_dumps({"error": str(exc)})
 
         if not query:
             return json_dumps({"error": "No query provided"})
@@ -610,7 +674,7 @@ class ExecuteSQLTool(SQLTool):
 
         try:
             # Get the dialect for this database
-            dialect = self.db.sqlglot_dialect
+            dialect = target.dialect
 
             # Security check using sqlglot AST analysis
             validation_result = validate_sql(
@@ -630,7 +694,7 @@ class ExecuteSQLTool(SQLTool):
             commit = bool(self.allow_dangerous and query_type in {"dml", "ddl"})
 
             # Execute the query
-            results = await self.db.execute_query(
+            results = await target.connection.execute_query(
                 query,
                 commit=commit,
                 read_only=not self.allow_dangerous,
@@ -681,3 +745,47 @@ class ExecuteSQLTool(SQLTool):
                 )
 
             return json_dumps({"error": error_msg})
+
+
+@register_tool
+class ListDatabasesTool(SQLTool):
+    """List databases connected to the current SQLSaber session.
+
+    Registered only when more than one database is connected. The tool
+    exposes the name, dialect, and optional description of each, so the
+    agent can choose which database to target with subsequent tool calls.
+    """
+
+    multi_db_only = True
+
+    display_spec = ToolDisplaySpec(
+        executing=ExecutingConfig(message="Listing connected databases", icon="📚"),
+        result=ResultConfig(
+            format="table",
+            title="Connected Databases ({total_databases} total)",
+            fields=FieldMappings(items="databases", error="error"),
+            table=TableConfig(
+                columns=[
+                    ColumnDef(field="name", header="Name", style="column.name"),
+                    ColumnDef(field="dialect", header="Dialect", style="column.type"),
+                    ColumnDef(field="description", header="Description", style="muted"),
+                ],
+                max_rows=20,
+            ),
+        ),
+        metadata=DisplayMetadata(display_name="List Databases"),
+    )
+
+    @property
+    def name(self) -> str:
+        return "list_dbs"
+
+    async def execute(self) -> str:
+        """List all databases connected to this session."""
+        if self.registry is None:
+            return json_dumps(
+                {"error": "Multi-database registry is not configured for this session."}
+            )
+
+        entries = self.registry.catalog()
+        return json_dumps({"total_databases": len(entries), "databases": entries})

--- a/tests/test_agents/test_multi_db.py
+++ b/tests/test_agents/test_multi_db.py
@@ -1,0 +1,167 @@
+"""Tests for multi-database SQLSaberAgent: tool schemas and prompt routing."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from sqlsaber.agents.pydantic_ai_agent import (
+    SQLSaberAgent,
+    _wrap_add_db_name,
+    _wrap_strip_db_name,
+)
+from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
+from sqlsaber.database.sqlite import SQLiteConnection
+from sqlsaber.tools.sql_tools import ExecuteSQLTool, ListTablesTool
+
+
+def _registry(*names: str) -> DatabaseRegistry:
+    return DatabaseRegistry(
+        [
+            DatabaseEntry.from_connection(
+                name=n,
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            )
+            for n in names
+        ]
+    )
+
+
+def _tool_def(agent: SQLSaberAgent, tool_name: str):
+    return agent.agent._function_toolset.tools[tool_name].tool_def
+
+
+class TestWrappers:
+    def test_strip_removes_db_name_from_signature(self):
+        tool = ListTablesTool()
+        wrapper = _wrap_strip_db_name(tool)
+        sig = inspect.signature(wrapper)
+        assert "db_name" not in sig.parameters
+
+    def test_strip_calls_raw_execute_without_db_name(self):
+        tool = ListTablesTool()
+        wrapper = _wrap_strip_db_name(tool)
+
+        captured: dict[str, object] = {}
+
+        async def fake_execute(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return "{}"
+
+        tool.execute = fake_execute  # type: ignore[method-assign]
+        # Re-wrap after monkey-patch
+        wrapper = _wrap_strip_db_name(tool)
+
+        import asyncio
+
+        asyncio.run(wrapper())
+        assert "db_name" not in captured["kwargs"]
+
+    def test_add_makes_db_name_required_literal(self):
+        tool = ExecuteSQLTool()
+        wrapper = _wrap_add_db_name(tool, ("prod", "staging"))
+        sig = inspect.signature(wrapper)
+        assert "db_name" in sig.parameters
+        param = sig.parameters["db_name"]
+        # Required => no default
+        assert param.default is inspect.Parameter.empty
+        # Annotation should be a Literal of the names
+        import typing
+
+        origin = typing.get_origin(param.annotation)
+        args = typing.get_args(param.annotation)
+        assert origin is typing.Literal
+        assert set(args) == {"prod", "staging"}
+
+
+class TestAgentSchema:
+    def test_single_db_schema_excludes_db_name(self):
+        registry = _registry("solo")
+        agent = SQLSaberAgent(
+            registry=registry,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        for tool_name in ("list_tables", "introspect_schema", "execute_sql"):
+            schema = _tool_def(agent, tool_name).parameters_json_schema
+            assert "db_name" not in schema.get("properties", {}), (
+                f"{tool_name} should not expose db_name in single-DB mode"
+            )
+
+    def test_multi_db_schema_requires_db_name_as_enum(self):
+        registry = _registry("prod", "staging")
+        agent = SQLSaberAgent(
+            registry=registry,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        for tool_name in (
+            "list_tables",
+            "introspect_schema",
+            "execute_sql",
+            "search_knowledge",
+        ):
+            schema = _tool_def(agent, tool_name).parameters_json_schema
+            assert "db_name" in schema.get("properties", {})
+            db_prop = schema["properties"]["db_name"]
+            # Literal types render as `enum` in JSON schema
+            assert db_prop.get("enum") == ["prod", "staging"]
+            assert "db_name" in schema.get("required", [])
+
+    def test_list_dbs_only_registered_in_multi_db_mode(self):
+        single = SQLSaberAgent(
+            registry=_registry("solo"),
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        assert "list_dbs" not in single.agent._function_toolset.tools
+
+        multi = SQLSaberAgent(
+            registry=_registry("a", "b"),
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        assert "list_dbs" in multi.agent._function_toolset.tools
+
+
+class TestAgentPrompt:
+    def test_multi_db_prompt_contains_catalog(self):
+        registry = _registry("prod", "staging")
+        agent = SQLSaberAgent(
+            registry=registry,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        prompt = agent.system_prompt_text()
+        assert "prod" in prompt
+        assert "staging" in prompt
+        assert "db_name" in prompt.lower()
+
+    def test_single_db_prompt_unchanged(self):
+        registry = _registry("solo")
+        agent = SQLSaberAgent(
+            registry=registry,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        prompt = agent.system_prompt_text()
+        # Today's prompt starts with this opener.
+        assert prompt.startswith("You are a helpful SQL assistant")
+        assert "Connected databases:" not in prompt
+
+
+class TestKnowledgeRouting:
+    @pytest.mark.asyncio
+    async def test_knowledge_tool_registry_is_attached_in_multi_db(self):
+        registry = _registry("prod", "staging")
+        agent = SQLSaberAgent(
+            registry=registry,
+            model_name="anthropic:claude-3-5-sonnet",
+            api_key="x",
+        )
+        tool = agent._tools["search_knowledge"]
+        assert tool.registry is registry

--- a/tests/test_api/test_database.py
+++ b/tests/test_api/test_database.py
@@ -32,3 +32,39 @@ async def test_api_multiple_csvs_create_multiple_views(temp_dir):
         ]
     finally:
         await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_api_multi_db_session_exposes_registry_and_connections(temp_dir):
+    """Two non-CSV DBs build a two-entry registry that the API exposes."""
+    one = temp_dir / "one.db"
+    two = temp_dir / "two.db"
+    one.write_text("")
+    two.write_text("")
+
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database=[f"sqlite:///{one}", f"sqlite:///{two}"],
+            settings=Config.in_memory(
+                model_name="anthropic:claude-3-5-sonnet",
+                api_keys={"anthropic": "test-key"},
+            ),
+        )
+    )
+
+    try:
+        assert len(saber.registry) == 2
+        assert set(saber.db_names) == {"one", "two"}
+        assert set(saber.connections.keys()) == {"one", "two"}
+        # Primary mirrors the first registered DB for back-compat with single-DB
+        # callers.
+        assert saber.db_name == saber.db_names[0]
+        assert saber.connection is saber.connections[saber.db_name]
+
+        # Agent prompt should include the multi-DB catalog
+        prompt = saber.agent.system_prompt_text()
+        assert "one" in prompt
+        assert "two" in prompt
+        assert "db_name" in prompt.lower()
+    finally:
+        await saber.close()

--- a/tests/test_api/test_threads.py
+++ b/tests/test_api/test_threads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 import pytest
 from pydantic_ai.messages import (
@@ -13,13 +14,15 @@ from pydantic_ai.messages import (
 )
 
 from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
 from sqlsaber.config.settings import Config
 from sqlsaber.threads.manager import ThreadManager
+from sqlsaber.threads.metadata import resolve_thread_database_selector
 from sqlsaber.threads.storage import ThreadStorage
 
 
 def _messages_bytes(user_text: str, *assistant_texts: str) -> bytes:
-    messages = [ModelRequest(parts=[UserPromptPart(user_text)])]
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(user_text)])]
     for text in assistant_texts:
         messages.append(ModelResponse(parts=[TextPart(text)]))
     return ModelMessagesTypeAdapter.dump_json(messages)
@@ -114,6 +117,112 @@ async def test_api_thread_manager_persists_queries_and_ends_on_close(
 
 
 @pytest.mark.asyncio
+async def test_api_thread_manager_persists_configured_multi_database_resume_selector(
+    temp_dir, monkeypatch
+):
+    monkeypatch.setattr(
+        "platformdirs.user_config_dir", lambda *args, **kwargs: str(temp_dir / "config")
+    )
+    config_mgr = DatabaseConfigManager()
+    config_mgr.add_database(
+        DatabaseConfig(
+            name="prod",
+            type="sqlite",
+            host=None,
+            port=None,
+            database=str(temp_dir / "prod.sqlite"),
+            username=None,
+        )
+    )
+    config_mgr.add_database(
+        DatabaseConfig(
+            name="staging",
+            type="sqlite",
+            host=None,
+            port=None,
+            database=str(temp_dir / "staging.sqlite"),
+            username=None,
+        )
+    )
+
+    storage = ThreadStorage()
+    storage.db_path = temp_dir / "threads.db"
+    thread_manager = ThreadManager(storage=storage)
+    options = SQLSaberOptions(
+        database=["prod", "staging"],
+        settings=Config.in_memory(
+            model_name="anthropic:claude-3-5-sonnet",
+            api_keys={"anthropic": "test-key"},
+        ),
+        thread_manager=thread_manager,
+    )
+    saber = SQLSaber(options=options)
+
+    async def fake_run(prompt: str, **kwargs):
+        _ = prompt, kwargs
+        return FakeRunResult(output="ok", _messages_json=_messages_bytes("compare"))
+
+    monkeypatch.setattr(saber.agent, "run", fake_run)
+
+    try:
+        await saber.query("compare")
+        thread_id = thread_manager.current_thread_id
+        assert thread_id is not None
+
+        metadata = await storage.get_thread(thread_id)
+        assert metadata is not None
+        assert metadata.database_name == "prod,staging"
+        assert resolve_thread_database_selector(
+            database_name=metadata.database_name,
+            extra_metadata=metadata.extra_metadata,
+        ) == ["prod", "staging"]
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_api_thread_manager_does_not_persist_raw_dsn_resume_selector(
+    temp_dir, monkeypatch
+):
+    storage = ThreadStorage()
+    storage.db_path = temp_dir / "threads.db"
+    thread_manager = ThreadManager(storage=storage)
+    raw_dsn = "postgresql://user:secret-password@localhost/app"
+    options = SQLSaberOptions(
+        database=raw_dsn,
+        settings=Config.in_memory(
+            model_name="anthropic:claude-3-5-sonnet",
+            api_keys={"anthropic": "test-key"},
+        ),
+        thread_manager=thread_manager,
+    )
+    saber = SQLSaber(options=options)
+
+    async def fake_run(prompt: str, **kwargs):
+        _ = prompt, kwargs
+        return FakeRunResult(output="ok", _messages_json=_messages_bytes("compare"))
+
+    monkeypatch.setattr(saber.agent, "run", fake_run)
+
+    try:
+        await saber.query("compare")
+        thread_id = thread_manager.current_thread_id
+        assert thread_id is not None
+
+        metadata = await storage.get_thread(thread_id)
+        assert metadata is not None
+        assert metadata.extra_metadata is not None
+        assert "secret-password" not in metadata.extra_metadata
+        with pytest.raises(ValueError, match="explicit --database"):
+            resolve_thread_database_selector(
+                database_name=metadata.database_name,
+                extra_metadata=metadata.extra_metadata,
+            )
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
 async def test_api_without_thread_manager_does_not_require_run_snapshot_methods(
     monkeypatch,
 ):
@@ -162,7 +271,7 @@ async def test_api_thread_persistence_failures_do_not_fail_query(monkeypatch):
             model_name="anthropic:claude-3-5-sonnet",
             api_keys={"anthropic": "test-key"},
         ),
-        thread_manager=failing_manager,
+        thread_manager=cast(ThreadManager, failing_manager),
     )
     saber = SQLSaber(options=options)
 

--- a/tests/test_cli/test_db_description.py
+++ b/tests/test_cli/test_db_description.py
@@ -1,0 +1,54 @@
+"""Tests for `db add` description plumbing."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _patched_db_module(monkeypatch, temp_dir):
+    """Reload `sqlsaber.cli.database` so it points at a temp config dir."""
+    config_dir = temp_dir / "config"
+    monkeypatch.setattr(
+        "platformdirs.user_config_dir", lambda *args, **kwargs: str(config_dir)
+    )
+
+    from sqlsaber.cli import database as db_module
+
+    return importlib.reload(db_module)
+
+
+def test_db_add_persists_description_non_interactive(temp_dir, monkeypatch):
+    sqlite_path = temp_dir / "data.db"
+    sqlite_path.write_text("")
+
+    db_module = _patched_db_module(monkeypatch, temp_dir)
+
+    db_module.add(
+        name="warehouse",
+        type="sqlite",
+        database=str(sqlite_path),
+        description="analytics warehouse, read-only",
+        interactive=False,
+    )
+
+    saved = db_module.config_manager.get_database("warehouse")
+    assert saved is not None
+    assert saved.description == "analytics warehouse, read-only"
+
+
+def test_db_add_without_description_defaults_to_none(temp_dir, monkeypatch):
+    sqlite_path = temp_dir / "data.db"
+    sqlite_path.write_text("")
+
+    db_module = _patched_db_module(monkeypatch, temp_dir)
+
+    db_module.add(
+        name="warehouse",
+        type="sqlite",
+        database=str(sqlite_path),
+        interactive=False,
+    )
+
+    saved = db_module.config_manager.get_database("warehouse")
+    assert saved is not None
+    assert saved.description is None

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -24,6 +24,7 @@ from sqlsaber.cli.threads import (
     create_threads_app,
 )
 from sqlsaber.config.database import DatabaseConfigManager
+from sqlsaber.threads.metadata import encode_thread_extra_metadata
 from sqlsaber.threads.storage import Thread, ThreadStorage
 
 
@@ -88,7 +89,7 @@ class TestThreadsCLI:
                     ),
                 ]
             ),
-            ModelResponse(
+            ModelRequest(
                 parts=[
                     ToolReturnPart(
                         tool_name="list_tables",
@@ -208,7 +209,7 @@ class TestThreadsCLI:
                     ),
                 ]
             ),
-            ModelResponse(
+            ModelRequest(
                 parts=[
                     ToolReturnPart(
                         tool_name="list_tables",
@@ -246,7 +247,7 @@ class TestThreadsCLI:
                     ),
                 ]
             ),
-            ModelResponse(
+            ModelRequest(
                 parts=[
                     ToolReturnPart(
                         tool_name="execute_sql",
@@ -349,6 +350,109 @@ class TestThreadsCLI:
                 assert resolved.name == "prod_db"
 
         await mock_resume_run()
+
+    def test_resume_uses_structured_multi_database_metadata(self, sample_messages):
+        """Resume passes saved repeated database selectors, not a comma string."""
+        from sqlsaber.cli.threads import resume
+
+        thread = Thread(
+            id="thread-multi",
+            database_name="prod,staging",
+            title="Multi DB",
+            created_at=1672531200.0,
+            ended_at=None,
+            last_activity_at=1672531200.0,
+            model_name="gpt-4",
+            extra_metadata=encode_thread_extra_metadata(
+                database_selector=["prod", "staging"]
+            ),
+        )
+        store = MagicMock()
+        store.get_thread = AsyncMock(return_value=thread)
+        store.get_thread_messages = AsyncMock(return_value=sample_messages)
+        captured: dict[str, object] = {}
+
+        class FakeSQLSaberSession:
+            def __init__(self, options):
+                captured["database"] = options.database
+
+            async def close(self) -> None:
+                captured["closed"] = True
+
+        class FakeInteractiveSession:
+            def __init__(self, **kwargs):
+                captured["history"] = kwargs["initial_history"]
+
+            async def run(self) -> None:
+                captured["ran"] = True
+
+        class FakeDatabaseConfigManager:
+            def get_database(self, name: str):
+                if name in {"prod", "staging"}:
+                    return object()
+                return None
+
+        with (
+            patch("sqlsaber.threads.ThreadStorage", return_value=store),
+            patch(
+                "sqlsaber.config.database.DatabaseConfigManager",
+                FakeDatabaseConfigManager,
+            ),
+            patch("sqlsaber.session.SQLSaberSession", FakeSQLSaberSession),
+            patch(
+                "sqlsaber.cli.interactive.InteractiveSession", FakeInteractiveSession
+            ),
+            patch("sqlsaber.cli.threads._render_transcript"),
+            patch("sqlsaber.cli.threads.console") as mock_console,
+        ):
+            mock_console.is_terminal = False
+            resume("thread-multi")
+
+        assert captured["database"] == ["prod", "staging"]
+        assert captured["history"] == sample_messages
+        assert captured["ran"] is True
+        assert captured["closed"] is True
+
+    def test_resume_requires_configured_database_for_automatic_resume(self):
+        """Automatic resume stops before constructing a session for unknown DBs."""
+        from sqlsaber.cli.threads import resume
+
+        thread = Thread(
+            id="thread-missing-db",
+            database_name="external",
+            title="External DB",
+            created_at=1672531200.0,
+            ended_at=None,
+            last_activity_at=1672531200.0,
+            model_name="gpt-4",
+            extra_metadata=encode_thread_extra_metadata(database_selector="external"),
+        )
+        store = MagicMock()
+        store.get_thread = AsyncMock(return_value=thread)
+        store.get_thread_messages = AsyncMock(return_value=[])
+
+        class FakeDatabaseConfigManager:
+            def get_database(self, name: str):
+                _ = name
+                return None
+
+        with (
+            patch("sqlsaber.threads.ThreadStorage", return_value=store),
+            patch(
+                "sqlsaber.config.database.DatabaseConfigManager",
+                FakeDatabaseConfigManager,
+            ),
+            patch("sqlsaber.session.SQLSaberSession") as mock_session,
+            patch("sqlsaber.cli.threads.console") as mock_console,
+        ):
+            resume("thread-missing-db")
+
+        mock_session.assert_not_called()
+        store.get_thread_messages.assert_not_awaited()
+        mock_console.print.assert_called_with(
+            "[error]Thread database is not configured for automatic "
+            "resume.[/error] Resume it with explicit --database/-d options."
+        )
 
     def test_build_turn_slices_basic(self, sample_messages):
         """Test build_turn_slices groups messages correctly by user prompts."""

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -469,6 +469,23 @@ def test_interactive_footer_includes_usage_cost_and_context() -> None:
     assert "Cost: $0.0123" in footer
 
 
+def test_interactive_footer_shows_all_database_names() -> None:
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.database_name = "prod"
+    session.database_names = ["prod", "staging", "warehouse"]
+    session._db_type_name = lambda: "PostgreSQL"
+    session.sqlsaber_agent = SimpleNamespace(
+        agent=SimpleNamespace(model=SimpleNamespace(model_name="gpt-test")),
+    )
+    session.session_usage = interactive.SessionUsage()
+
+    footer = session._footer_text()
+
+    assert "DBs: prod, staging, warehouse" in footer
+    assert "DB: prod (PostgreSQL)" not in footer
+    assert "Model: gpt-test" in footer
+
+
 @pytest.mark.asyncio
 async def test_execute_query_refreshes_footer_usage_cost_and_context() -> None:
     terminal = FakeTerminal(columns=160, rows=12)

--- a/tests/test_cli/test_usage.py
+++ b/tests/test_cli/test_usage.py
@@ -54,7 +54,9 @@ def test_session_usage_marks_cost_unknown_when_model_name_is_missing() -> None:
     assert format_cost_usd(usage.total_cost_usd) == "n/a"
 
 
-def test_session_usage_marks_multi_request_aggregate_cost_unknown_without_request_usages() -> None:
+def test_session_usage_marks_multi_request_aggregate_cost_unknown_without_request_usages() -> (
+    None
+):
     usage = SessionUsage()
 
     usage.add_run(

--- a/tests/test_config/test_database.py
+++ b/tests/test_config/test_database.py
@@ -109,6 +109,7 @@ class TestDatabaseConfig:
             "ssl_cert": None,
             "ssl_key": None,
             "exclude_schemas": [],
+            "description": None,
         }
 
     def test_config_from_dict(self):
@@ -130,6 +131,39 @@ class TestDatabaseConfig:
         assert config.username == "admin"
         assert config.database == "production"
         assert config.exclude_schemas == []
+        assert config.description is None
+
+    def test_config_description_roundtrip(self):
+        """Description field survives to_dict/from_dict, defaults to None."""
+        config = DatabaseConfig(
+            name="warehouse",
+            type="postgresql",
+            host="localhost",
+            port=5432,
+            username="user",
+            database="db",
+            description="analytics warehouse, read-only replica",
+        )
+
+        as_dict = config.to_dict()
+        assert as_dict["description"] == "analytics warehouse, read-only replica"
+
+        rebuilt = DatabaseConfig.from_dict(as_dict)
+        assert rebuilt.description == "analytics warehouse, read-only replica"
+
+    def test_config_from_dict_missing_description(self):
+        """Loading legacy configs (no `description` key) defaults to None."""
+        data = {
+            "name": "legacy",
+            "type": "sqlite",
+            "host": None,
+            "port": None,
+            "username": None,
+            "database": "/tmp/legacy.db",
+        }
+
+        config = DatabaseConfig.from_dict(data)
+        assert config.description is None
 
 
 class TestDatabaseConfigManager:

--- a/tests/test_database/test_registry.py
+++ b/tests/test_database/test_registry.py
@@ -1,0 +1,119 @@
+"""Tests for the multi-database registry that backs a SQLSaber session."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sqlsaber.database.registry import (
+    DatabaseEntry,
+    DatabaseRegistry,
+    UnknownDatabaseError,
+)
+from sqlsaber.database.resolver import ResolvedDatabase
+from sqlsaber.database.sqlite import SQLiteConnection
+
+
+def _entry(name: str, *, description: str | None = None) -> DatabaseEntry:
+    connection = SQLiteConnection("sqlite:///:memory:")
+    return DatabaseEntry.from_connection(
+        name=name,
+        connection=connection,
+        description=description,
+        excluded_schemas=[],
+    )
+
+
+class TestDatabaseRegistry:
+    def test_single_entry_basics(self):
+        entry = _entry("solo")
+        registry = DatabaseRegistry([entry])
+
+        assert len(registry) == 1
+        assert registry.names() == ["solo"]
+        assert registry.primary() == "solo"
+        assert "solo" in registry
+        assert registry.get("solo") is entry
+        assert registry.connection("solo") is entry.connection
+        assert registry.schema_manager("solo") is entry.schema_manager
+        assert registry.dialect("solo") == "sqlite"
+
+    def test_ordered_names_match_construction(self):
+        registry = DatabaseRegistry([_entry("prod"), _entry("staging"), _entry("dev")])
+        assert registry.names() == ["prod", "staging", "dev"]
+        assert registry.primary() == "prod"
+
+    def test_get_unknown_raises_with_valid_names(self):
+        registry = DatabaseRegistry([_entry("prod"), _entry("staging")])
+        with pytest.raises(UnknownDatabaseError) as exc:
+            registry.get("nope")
+        assert "nope" in str(exc.value)
+        assert "prod" in str(exc.value)
+        assert "staging" in str(exc.value)
+
+    def test_catalog_includes_metadata(self):
+        registry = DatabaseRegistry(
+            [
+                _entry("prod", description="production OLTP"),
+                _entry("warehouse"),
+            ]
+        )
+        catalog = registry.catalog()
+        assert catalog[0]["name"] == "prod"
+        assert catalog[0]["dialect"] == "sqlite"
+        assert catalog[0]["description"] == "production OLTP"
+        assert catalog[1]["name"] == "warehouse"
+        assert catalog[1]["description"] is None
+
+    def test_duplicate_names_rejected(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            DatabaseRegistry([_entry("prod"), _entry("prod")])
+
+    def test_empty_registry_rejected(self):
+        with pytest.raises(ValueError, match="at least one"):
+            DatabaseRegistry([])
+
+    @pytest.mark.asyncio
+    async def test_close_closes_every_connection(self):
+        entry_a = _entry("a")
+        entry_b = _entry("b")
+        entry_a.connection.close = AsyncMock()
+        entry_b.connection.close = AsyncMock()
+
+        registry = DatabaseRegistry([entry_a, entry_b])
+        await registry.close()
+
+        entry_a.connection.close.assert_awaited_once()
+        entry_b.connection.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_aggregates_errors_but_still_closes_all(self):
+        entry_a = _entry("a")
+        entry_b = _entry("b")
+        entry_c = _entry("c")
+        entry_a.connection.close = AsyncMock(side_effect=RuntimeError("boom"))
+        entry_b.connection.close = AsyncMock()
+        entry_c.connection.close = AsyncMock()
+
+        registry = DatabaseRegistry([entry_a, entry_b, entry_c])
+        with pytest.raises(RuntimeError, match="boom"):
+            await registry.close()
+
+        entry_a.connection.close.assert_awaited_once()
+        entry_b.connection.close.assert_awaited_once()
+        entry_c.connection.close.assert_awaited_once()
+
+
+class TestDatabaseRegistryFromResolved:
+    def test_from_resolved_builds_connections(self):
+        resolved = [
+            ResolvedDatabase(
+                name="solo",
+                connection_string="sqlite:///:memory:",
+                excluded_schemas=[],
+                description="local sqlite",
+            )
+        ]
+        registry = DatabaseRegistry.from_resolved(resolved)
+        assert registry.names() == ["solo"]
+        assert registry.dialect("solo") == "sqlite"
+        assert registry.catalog()[0]["description"] == "local sqlite"

--- a/tests/test_database/test_registry.py
+++ b/tests/test_database/test_registry.py
@@ -1,5 +1,6 @@
 """Tests for the multi-database registry that backs a SQLSaber session."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -21,6 +22,12 @@ def _entry(name: str, *, description: str | None = None) -> DatabaseEntry:
         description=description,
         excluded_schemas=[],
     )
+
+
+def _mock_close(entry: DatabaseEntry, side_effect: object = None) -> AsyncMock:
+    close_mock = AsyncMock(side_effect=side_effect)
+    setattr(entry.connection, "close", close_mock)
+    return close_mock
 
 
 class TestDatabaseRegistry:
@@ -76,31 +83,48 @@ class TestDatabaseRegistry:
     async def test_close_closes_every_connection(self):
         entry_a = _entry("a")
         entry_b = _entry("b")
-        entry_a.connection.close = AsyncMock()
-        entry_b.connection.close = AsyncMock()
+        close_a = _mock_close(entry_a)
+        close_b = _mock_close(entry_b)
 
         registry = DatabaseRegistry([entry_a, entry_b])
         await registry.close()
 
-        entry_a.connection.close.assert_awaited_once()
-        entry_b.connection.close.assert_awaited_once()
+        close_a.assert_awaited_once()
+        close_b.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_close_aggregates_errors_but_still_closes_all(self):
         entry_a = _entry("a")
         entry_b = _entry("b")
         entry_c = _entry("c")
-        entry_a.connection.close = AsyncMock(side_effect=RuntimeError("boom"))
-        entry_b.connection.close = AsyncMock()
-        entry_c.connection.close = AsyncMock()
+        close_a = _mock_close(entry_a, RuntimeError("boom"))
+        close_b = _mock_close(entry_b)
+        close_c = _mock_close(entry_c)
 
         registry = DatabaseRegistry([entry_a, entry_b, entry_c])
         with pytest.raises(RuntimeError, match="boom"):
             await registry.close()
 
-        entry_a.connection.close.assert_awaited_once()
-        entry_b.connection.close.assert_awaited_once()
-        entry_c.connection.close.assert_awaited_once()
+        close_a.assert_awaited_once()
+        close_b.assert_awaited_once()
+        close_c.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_propagates_cancellation_without_swallowing_it(self):
+        entry_a = _entry("a")
+        entry_b = _entry("b")
+        entry_c = _entry("c")
+        close_a = _mock_close(entry_a, RuntimeError("boom"))
+        close_b = _mock_close(entry_b, asyncio.CancelledError())
+        close_c = _mock_close(entry_c)
+
+        registry = DatabaseRegistry([entry_a, entry_b, entry_c])
+        with pytest.raises(asyncio.CancelledError):
+            await registry.close()
+
+        close_a.assert_awaited_once()
+        close_b.assert_awaited_once()
+        close_c.assert_not_awaited()
 
 
 class TestDatabaseRegistryFromResolved:

--- a/tests/test_database_resolver.py
+++ b/tests/test_database_resolver.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from sqlsaber.config.database import DatabaseConfig
-from sqlsaber.database.resolver import DatabaseResolutionError, resolve_database
+from sqlsaber.database.resolver import (
+    DatabaseResolutionError,
+    resolve_database,
+    resolve_databases,
+)
 
 
 class TestDatabaseResolver:
@@ -120,12 +124,35 @@ class TestDatabaseResolver:
         db_config.name = "mydb"
         db_config.to_connection_string.return_value = "postgresql://localhost:5432/mydb"
         db_config.exclude_schemas = ["foo"]
+        db_config.description = None
         config_mgr.get_database.return_value = db_config
 
         result = resolve_database("mydb", config_mgr)
         assert result.name == "mydb"
         assert result.connection_string == "postgresql://localhost:5432/mydb"
         assert result.excluded_schemas == ["foo"]
+        assert result.description is None
+
+    def test_configured_database_description_propagates(self):
+        """Description on the configured DB should appear on ResolvedDatabase."""
+        config_mgr = Mock()
+        db_config = Mock(spec=DatabaseConfig)
+        db_config.name = "analytics"
+        db_config.to_connection_string.return_value = (
+            "postgresql://localhost:5432/analytics"
+        )
+        db_config.exclude_schemas = []
+        db_config.description = "warehouse, read-only"
+        config_mgr.get_database.return_value = db_config
+
+        result = resolve_database("analytics", config_mgr)
+        assert result.description == "warehouse, read-only"
+
+    def test_connection_string_resolution_has_no_description(self):
+        """Ad-hoc connection-string DBs have no description by default."""
+        config_mgr = Mock()
+        result = resolve_database("sqlite:///test.db", config_mgr)
+        assert result.description is None
 
     def test_configured_database_not_found(self):
         """Test error when configured database doesn't exist."""
@@ -181,3 +208,84 @@ class TestDatabaseResolver:
         result = resolve_database("duckdb://", config_mgr)
         assert result.name == "database"
         assert result.excluded_schemas == []
+
+
+class TestResolveDatabases:
+    """Test the multi-DB resolution helper used to bootstrap sessions."""
+
+    def test_none_returns_default_singleton(self):
+        config_mgr = Mock()
+        db_config = Mock(spec=DatabaseConfig)
+        db_config.name = "default"
+        db_config.to_connection_string.return_value = "sqlite:///:memory:"
+        db_config.exclude_schemas = []
+        db_config.description = None
+        config_mgr.get_default_database.return_value = db_config
+
+        result = resolve_databases(None, config_mgr)
+        assert len(result) == 1
+        assert result[0].name == "default"
+
+    def test_single_connection_string_returns_one(self):
+        config_mgr = Mock()
+        result = resolve_databases("sqlite:///test.db", config_mgr)
+        assert len(result) == 1
+        assert result[0].name == "test"
+
+    def test_single_element_list_returns_one(self):
+        config_mgr = Mock()
+        result = resolve_databases(["sqlite:///test.db"], config_mgr)
+        assert len(result) == 1
+        assert result[0].name == "test"
+
+    @patch("pathlib.Path.exists")
+    def test_all_csv_paths_merge_into_one_csvs_connection(self, mock_exists):
+        mock_exists.return_value = True
+        config_mgr = Mock()
+
+        result = resolve_databases(["a.csv", "b.csv"], config_mgr)
+        assert len(result) == 1
+        assert result[0].connection_string.startswith("csvs:///?")
+
+    def test_mixed_specs_resolve_independently(self):
+        config_mgr = Mock()
+        result = resolve_databases(
+            ["sqlite:///one.db", "postgresql://user:pass@host:5432/two"],
+            config_mgr,
+        )
+        assert len(result) == 2
+        assert result[0].name == "one"
+        assert result[0].connection_string == "sqlite:///one.db"
+        assert result[1].name == "two"
+        assert result[1].connection_string == "postgresql://user:pass@host:5432/two"
+
+    def test_duplicate_names_raise(self):
+        config_mgr = Mock()
+        with pytest.raises(DatabaseResolutionError, match="duplicate"):
+            resolve_databases(
+                ["sqlite:///foo.db", "sqlite:///foo.db"],
+                config_mgr,
+            )
+
+    def test_empty_list_raises(self):
+        config_mgr = Mock()
+        with pytest.raises(DatabaseResolutionError, match="Empty"):
+            resolve_databases([], config_mgr)
+
+    def test_configured_names_resolve(self):
+        config_mgr = Mock()
+
+        def fake_get_database(name):
+            cfg = Mock(spec=DatabaseConfig)
+            cfg.name = name
+            cfg.to_connection_string.return_value = f"sqlite:///{name}.db"
+            cfg.exclude_schemas = []
+            cfg.description = f"{name} desc"
+            return cfg
+
+        config_mgr.get_database.side_effect = fake_get_database
+
+        result = resolve_databases(["prod", "staging"], config_mgr)
+        assert [r.name for r in result] == ["prod", "staging"]
+        assert result[0].description == "prod desc"
+        assert result[1].description == "staging desc"

--- a/tests/test_knowledge/test_tool.py
+++ b/tests/test_knowledge/test_tool.py
@@ -55,3 +55,82 @@ async def test_search_knowledge_tool_handles_store_errors(temp_dir, monkeypatch)
 
     data = json.loads(await tool.execute("revenue"))
     assert data["error"] == "Error searching knowledge: storage unavailable"
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_tool_routes_by_db_name(temp_dir):
+    """With a registry attached, the tool searches the named DB's partition."""
+    from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
+    from sqlsaber.database.sqlite import SQLiteConnection
+
+    manager = KnowledgeManager(store=SQLiteKnowledgeStore(db_path=temp_dir / "tool.db"))
+    await manager.add_knowledge(
+        database_name="prod",
+        name="Revenue",
+        description="prod revenue note",
+    )
+    await manager.add_knowledge(
+        database_name="staging",
+        name="Revenue",
+        description="staging revenue note",
+    )
+
+    registry = DatabaseRegistry(
+        [
+            DatabaseEntry.from_connection(
+                name="prod",
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            ),
+            DatabaseEntry.from_connection(
+                name="staging",
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            ),
+        ]
+    )
+
+    tool = SearchKnowledgeTool()
+    tool.set_registry(registry)
+    tool.knowledge_manager = manager
+
+    data = json.loads(await tool.execute("revenue", db_name="prod"))
+    assert data["total_results"] == 1
+    assert data["results"][0]["description"] == "prod revenue note"
+
+    data = json.loads(await tool.execute("revenue", db_name="staging"))
+    assert data["total_results"] == 1
+    assert data["results"][0]["description"] == "staging revenue note"
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_tool_requires_db_name_in_multi(temp_dir):
+    from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
+    from sqlsaber.database.sqlite import SQLiteConnection
+
+    manager = KnowledgeManager(store=SQLiteKnowledgeStore(db_path=temp_dir / "tool.db"))
+    registry = DatabaseRegistry(
+        [
+            DatabaseEntry.from_connection(
+                name="prod",
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            ),
+            DatabaseEntry.from_connection(
+                name="staging",
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            ),
+        ]
+    )
+    tool = SearchKnowledgeTool()
+    tool.set_registry(registry)
+    tool.knowledge_manager = manager
+
+    data = json.loads(await tool.execute("revenue"))
+    assert "error" in data
+    assert "db_name" in data["error"].lower()

--- a/tests/test_tools/test_sql_tools.py
+++ b/tests/test_tools/test_sql_tools.py
@@ -6,9 +6,11 @@ from types import SimpleNamespace
 import pytest
 
 from sqlsaber.database import SQLiteConnection
+from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
 from sqlsaber.tools.sql_tools import (
     ExecuteSQLTool,
     IntrospectSchemaTool,
+    ListDatabasesTool,
     ListTablesTool,
 )
 
@@ -307,3 +309,124 @@ class TestExecuteSQLTool:
 
         assert "error" in data
         assert "unknown_table" in data["error"]
+
+
+def _entry(name: str, mock_db: MockDatabaseConnection) -> DatabaseEntry:
+    """Build a registry entry from a mock connection + matching mock schema manager."""
+    return DatabaseEntry(
+        name=name,
+        connection=mock_db,
+        schema_manager=MockSchemaManager(mock_db),
+        description=None,
+        excluded_schemas=[],
+    )
+
+
+class TestMultiDatabaseRouting:
+    """Tools routed by `db_name` against a `DatabaseRegistry`."""
+
+    @pytest.mark.asyncio
+    async def test_list_tables_uses_resolved_schema_manager(self):
+        db_a = MockDatabaseConnection()
+        db_b = MockDatabaseConnection()
+        registry = DatabaseRegistry([_entry("a", db_a), _entry("b", db_b)])
+
+        tool = ListTablesTool()
+        tool.set_registry(registry)
+
+        result = await tool.execute(db_name="b")
+        data = json.loads(result)
+        assert "tables" in data
+        # Confirm we routed to db_b's schema manager (each MockSchemaManager wraps
+        # its db; the result is the same shape but came from the right one).
+        assert tool._resolve("b").connection is db_b
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_routes_to_named_db(self):
+        db_a = MockDatabaseConnection()
+        db_b = MockDatabaseConnection()
+        registry = DatabaseRegistry([_entry("a", db_a), _entry("b", db_b)])
+
+        tool = ExecuteSQLTool()
+        tool.set_registry(registry)
+
+        await tool.execute(
+            SimpleNamespace(tool_call_id=None),
+            "SELECT * FROM users",
+            db_name="b",
+        )
+        assert db_b.queries  # query went to b
+        assert not db_a.queries
+
+    @pytest.mark.asyncio
+    async def test_missing_db_name_in_multi_returns_tool_error(self):
+        db_a = MockDatabaseConnection()
+        db_b = MockDatabaseConnection()
+        registry = DatabaseRegistry([_entry("a", db_a), _entry("b", db_b)])
+
+        tool = ListTablesTool()
+        tool.set_registry(registry)
+
+        result = await tool.execute(db_name=None)
+        data = json.loads(result)
+        assert "error" in data
+        assert "db_name" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_db_name_returns_tool_error_listing_valid(self):
+        db_a = MockDatabaseConnection()
+        db_b = MockDatabaseConnection()
+        registry = DatabaseRegistry([_entry("a", db_a), _entry("b", db_b)])
+
+        tool = ListTablesTool()
+        tool.set_registry(registry)
+
+        result = await tool.execute(db_name="nope")
+        data = json.loads(result)
+        assert "error" in data
+        assert "a" in data["error"]
+        assert "b" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_introspect_schema_routes_to_named_db(self):
+        db_a = MockDatabaseConnection()
+        db_b = MockDatabaseConnection()
+        registry = DatabaseRegistry([_entry("a", db_a), _entry("b", db_b)])
+
+        tool = IntrospectSchemaTool()
+        tool.set_registry(registry)
+
+        result = await tool.execute(db_name="b", table_pattern="users")
+        data = json.loads(result)
+        assert "users" in data
+
+
+class TestListDatabasesTool:
+    def test_tool_properties(self):
+        tool = ListDatabasesTool()
+        assert tool.name == "list_dbs"
+        assert tool.multi_db_only is True
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_catalog(self):
+        registry = DatabaseRegistry(
+            [
+                _entry("prod", MockDatabaseConnection()),
+                _entry("staging", MockDatabaseConnection()),
+            ]
+        )
+        tool = ListDatabasesTool()
+        tool.set_registry(registry)
+
+        result = await tool.execute()
+        data = json.loads(result)
+        assert "databases" in data
+        names = [item["name"] for item in data["databases"]]
+        assert names == ["prod", "staging"]
+
+    @pytest.mark.asyncio
+    async def test_execute_without_registry_returns_error(self):
+        tool = ListDatabasesTool()
+        result = await tool.execute()
+        data = json.loads(result)
+        assert "error" in data

--- a/tests/threads/test_threads_manager.py
+++ b/tests/threads/test_threads_manager.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
@@ -12,12 +13,13 @@ from pydantic_ai.messages import (
 )
 
 from sqlsaber.threads.manager import ThreadManager
+from sqlsaber.threads.metadata import encode_thread_extra_metadata
 from sqlsaber.threads.storage import ThreadStorage
 
 
 def _messages_bytes(user_text: str, assistant_text: str | None = None) -> bytes:
     parts = [UserPromptPart(user_text)]
-    msgs = [ModelRequest(parts=parts)]
+    msgs: list[ModelMessage] = [ModelRequest(parts=parts)]
     if assistant_text:
         msgs.append(ModelResponse(parts=[TextPart(assistant_text)]))
     return ModelMessagesTypeAdapter.dump_json(msgs)
@@ -138,6 +140,32 @@ async def test_save_run_new_thread(thread_manager, temp_storage):
     # Verify messages can be read back
     msgs = await temp_storage.get_thread_messages(thread_id)
     assert len(msgs) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_run_persists_resume_metadata(thread_manager, temp_storage):
+    """Test saving structured resume metadata for multi-database sessions."""
+    json_bytes = _messages_bytes("hello")
+    extra_metadata = encode_thread_extra_metadata(database_selector=["prod", "staging"])
+
+    run_result = MagicMock()
+    run_result.all_messages_json.return_value = json_bytes
+    run_result.all_messages.return_value = ["msg1"]
+
+    await thread_manager.save_run(
+        run_result=run_result,
+        database_name="prod,staging",
+        user_query="hello",
+        model_name="gpt-4",
+        extra_metadata=extra_metadata,
+    )
+
+    thread_id = thread_manager.current_thread_id
+    assert thread_id is not None
+    thread = await temp_storage.get_thread(thread_id)
+    assert thread is not None
+    assert thread.database_name == "prod,staging"
+    assert thread.extra_metadata == extra_metadata
 
 
 @pytest.mark.asyncio

--- a/tests/threads/test_threads_storage.py
+++ b/tests/threads/test_threads_storage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
@@ -12,11 +13,16 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
+from sqlsaber.threads.metadata import (
+    encode_thread_extra_metadata,
+    encode_thread_resume_disabled_metadata,
+    resolve_thread_database_selector,
+)
 from sqlsaber.threads.storage import ThreadStorage
 
 
 def _messages_bytes(user_text: str, *assistant_texts: str) -> bytes:
-    msgs = [ModelRequest(parts=[UserPromptPart(user_text)])]
+    msgs: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(user_text)])]
     for t in assistant_texts:
         msgs.append(ModelResponse(parts=[TextPart(t)]))
     return ModelMessagesTypeAdapter.dump_json(msgs)
@@ -51,6 +57,49 @@ async def test_thread_create_and_roundtrip():
         assert len(msgs2) == 3
         # Verify user prompt remains the same
         assert isinstance(msgs2[0], ModelRequest)
+
+
+@pytest.mark.asyncio
+async def test_thread_multi_database_resume_metadata_roundtrip():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ThreadStorage()
+        store.db_path = Path(tmp) / "threads.db"
+        extra_metadata = encode_thread_extra_metadata(
+            database_selector=["prod", "staging"]
+        )
+
+        thread_id = await store.save_snapshot(
+            messages_json=_messages_bytes("Hello"),
+            database_name="prod,staging",
+            extra_metadata=extra_metadata,
+        )
+
+        thread = await store.get_thread(thread_id)
+        assert thread is not None
+        assert thread.extra_metadata == extra_metadata
+        assert resolve_thread_database_selector(
+            database_name=thread.database_name,
+            extra_metadata=thread.extra_metadata,
+        ) == ["prod", "staging"]
+
+
+def test_legacy_comma_joined_thread_requires_explicit_database_selector():
+    with pytest.raises(ValueError, match="repeated --database"):
+        resolve_thread_database_selector(
+            database_name="prod,staging",
+            extra_metadata=None,
+        )
+
+
+def test_resume_disabled_metadata_requires_explicit_database_selector():
+    extra_metadata = encode_thread_resume_disabled_metadata(
+        reason="Only configured database names are saved for automatic resume."
+    )
+    with pytest.raises(ValueError, match="explicit --database"):
+        resolve_thread_database_selector(
+            database_name="app",
+            extra_metadata=extra_metadata,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR adds comprehensive multi-database support to SQLSaber, allowing users to connect to and query multiple databases in a single session. The agent intelligently routes tool calls to the correct database via a new `DatabaseRegistry` abstraction, while maintaining backward compatibility with single-database workflows.

## Key Changes

### Core Infrastructure
- **New `DatabaseRegistry` class** (`src/sqlsaber/database/registry.py`): Manages multiple database connections with name-based lookup, metadata tracking, and lifecycle management. Validates uniqueness and provides catalog serialization for prompts.
- **`DatabaseEntry` dataclass**: Wraps a connection with its schema manager, dialect, and metadata (name, description, excluded schemas).
- **Multi-database resolver** (`resolve_databases` in `resolver.py`): Extends single-DB resolution to handle lists of connection specs, merging all-CSV lists while keeping mixed specs separate.

### Agent & Tool Routing
- **SQLSaberAgent refactoring**: Now accepts optional `registry` parameter instead of requiring a single `db_connection`. Maintains backward compatibility by wrapping single connections in a registry.
- **Tool signature wrapping**:
  - `_wrap_strip_db_name()`: Removes `db_name` from tool signatures in single-DB mode (preserves today's JSON schema).
  - `_wrap_add_db_name()`: Adds `db_name` as a required `Literal[...]` parameter in multi-DB mode, constraining the LLM to valid database names at schema validation time.
- **Tool resolution logic** (`SQLTool._resolve()`): Routes each tool call to the correct database based on registry attachment and `db_name` parameter.

### Knowledge Tool Integration
- `SearchKnowledgeTool` now supports `db_name` parameter and routes knowledge searches to the correct database partition when a registry is attached.

### System Prompts
- **New multi-DB prompts** (`CLAUDE_MULTI`, `GPT_5_MULTI`): Include database catalog and explicit instructions for multi-DB queries (no cross-DB joins, always pass `db_name`).
- **Catalog rendering** (`_build_db_catalog()`): Formats registry entries as markdown for inclusion in system prompts.
- **Docstring enhancement** (`_docstring_with_db_name()`): Injects `db_name` documentation into tool docstrings for multi-DB mode.

### Configuration & CLI
- **DatabaseConfig**: Added optional `description` field for human-readable database metadata.
- **CLI `db add` command**: Now accepts `--description` flag to annotate databases.
- **API exposure**: `SQLSaber` now exposes `registry`, `db_names`, and `connections` properties for programmatic access.

### New Tools
- **`ListDatabasesTool`**: Multi-DB-only tool that returns the catalog of connected databases (marked with `multi_db_only=True`).

## Implementation Details

- **Backward compatibility**: Single-database workflows are wrapped in a single-entry registry transparently; tool signatures remain unchanged.
- **Error handling**: Invalid `db_name` values are caught at schema validation time (via `Literal` constraints) rather than runtime, improving LLM reliability.
- **Docstring parsing**: Custom dedenting and splicing logic ensures `db_name` documentation integrates cleanly with existing tool docstrings.
- **Lifecycle management**: Registry provides async `close()` that closes all connections and aggregates errors.

## Tests

- Comprehensive test coverage for registry operations, tool routing, schema generation, and prompt selection.
- Multi-database agent tests verify correct tool schema generation and database routing.
- Knowledge tool tests confirm partition-based search routing.
- CLI and API tests validate end-to-end multi-database session creation.

https://claude.ai/code/session_01LsQuJWo3TimqEonj8wrTRb