### PR TITLE
docs: add multi-database usage documentation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -87,6 +87,7 @@ export default defineConfig({
 					label: "Guides",
 					items: [
 						{ label: "Database Setup", slug: "guides/database-setup" },
+						{ label: "Multiple Databases", slug: "guides/multi-database" },
 						{ label: "Authentication", slug: "guides/authentication" },
 						{ label: "Models", slug: "guides/models" },
 						{ label: "Running Queries", slug: "guides/queries" },

--- a/docs/src/content/docs/guides/database-setup.mdx
+++ b/docs/src/content/docs/guides/database-setup.mdx
@@ -23,6 +23,14 @@ saber db add my-database
 
 This will prompt you for all necessary connection details.
 
+You can also attach an optional description to a connection. Descriptions are
+shown to the agent when [several databases are connected at once](/guides/multi-database)
+to help it pick the right one:
+
+```bash
+saber db add my-database --description "Production Postgres: orders and revenue"
+```
+
 ### Connection Strings
 
 SQLsaber supports direct connection strings for PostgreSQL and MySQL, plus file URIs for SQLite and DuckDB.
@@ -103,6 +111,18 @@ saber db test my-database
 ```bash
 saber db remove my-database
 ```
+
+### Connecting to Multiple Databases
+
+A single session can be connected to several databases at once by repeating the
+`-d` flag. The agent then queries each database separately and combines the
+results in its answer:
+
+```bash
+saber -d sales -d analytics "Compare revenue to web sessions"
+```
+
+See the [Multiple Databases guide](/guides/multi-database) for details.
 
 ### Security
 
@@ -195,4 +215,5 @@ After setting up your database connections:
 
 1. [Configure authentication](/guides/authentication) for AI providers
 2. [Start querying your data](/guides/getting-started)
-3. [Manage conversation threads](/guides/threads)
+3. [Connect to multiple databases at once](/guides/multi-database)
+4. [Manage conversation threads](/guides/threads)

--- a/docs/src/content/docs/guides/multi-database.mdx
+++ b/docs/src/content/docs/guides/multi-database.mdx
@@ -1,0 +1,152 @@
+---
+title: Multiple Databases
+description: "Connect a single SQLsaber session to several databases at once. Query each database separately and let the agent combine the results."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+A single SQLsaber session can be connected to more than one database at the same
+time. The agent picks which database to query for each step, runs the queries
+separately, and combines the results in its answer — so you can ask a question
+that spans several databases without switching sessions.
+
+<Aside type="note">
+  SQLsaber does **not** attempt cross-database JOINs. When multiple databases
+  are connected, the agent queries each one independently and stitches the
+  results together in plain language in its reply.
+</Aside>
+
+### Starting a Multi-Database Session
+
+Connect to multiple databases by repeating the `-d` / `--database` flag. Each
+value can be a configured connection name, a connection string, or a file path —
+and you can mix them freely.
+
+```bash
+# Two configured connections
+saber -d sales -d analytics "Compare last month's revenue to web sessions"
+
+# Mix a configured name with a connection string
+saber -d sales -d "postgresql://user:pass@host:5432/events" "..."
+
+# Start interactive mode across several databases
+saber -d sales -d analytics -d inventory
+```
+
+Everything works the same in single-query mode and interactive mode. In
+interactive mode the footer shows all connected databases:
+
+```
+DBs: sales, analytics, inventory | Model: ... | ...
+```
+
+<Aside type="caution">
+  Each connected database must resolve to a **unique name**. Connecting two
+  databases that resolve to the same name (for example the same connection used
+  twice) raises an error. Names come from the configured connection name, or are
+  derived from the database/file name for ad-hoc connection strings and paths.
+</Aside>
+
+#### CSV files are different
+
+Passing **multiple CSV files** does not create a multi-database session. Instead,
+all CSVs are merged into a single in-memory database with one table (view) per
+file, so you can join across them:
+
+```bash
+saber -d users.csv -d orders.csv "Join users and orders"
+```
+
+Multi-database mode kicks in only when more than one **non-CSV** target is
+provided (or a CSV combined with another database type).
+
+### Describing Connections
+
+When several databases are connected, the agent needs to decide which one holds
+the data for a given question. You can help it by attaching a short description
+to each connection. Descriptions are shown to the agent (and surfaced by the
+`list_dbs` tool) but are otherwise optional.
+
+```bash
+saber db add sales \
+  --description "Production Postgres: orders, customers, revenue"
+
+saber db add analytics \
+  --description "ClickHouse warehouse: web sessions, events, funnels"
+```
+
+You can add a description to any connection — see
+[Database Setup](/guides/database-setup) for the full `saber db add` flow.
+
+<Aside type="tip">
+  Clear, distinct descriptions noticeably improve how reliably the agent routes
+  a question to the right database. Mention the kind of data each connection
+  holds (tables, domains, environments).
+</Aside>
+
+### How the Agent Routes Queries
+
+When more than one database is connected, the agent's behavior changes in a few
+ways:
+
+- **`db_name` on every tool call.** The SQL and knowledge tools require a
+  `db_name` argument that names the target database. The agent must choose a
+  connected database for each `list_tables`, `introspect_schema`,
+  `execute_sql`, and knowledge-base call.
+- **A `list_dbs` tool.** A dedicated tool lists every connected database with
+  its name, dialect, and description, so the agent can see its options before
+  exploring schemas.
+- **Per-database knowledge.** [Knowledge entries](/guides/knowledge) remain
+  scoped per database, so each connection contributes its own context.
+
+In single-database sessions none of this is visible — the tool schemas and
+system prompt are identical to before, and there is no `db_name` argument or
+`list_dbs` tool.
+
+### Resuming Multi-Database Threads
+
+[Conversation threads](/guides/threads) created in a multi-database session
+record all of the connected databases. When you resume such a thread, SQLsaber
+reconnects to the same set automatically:
+
+```bash
+saber threads resume a1b2c3d4
+```
+
+<Aside type="note">
+  Automatic resume only works when **every** database in the thread is a saved
+  connection (added with `saber db add`). If a thread used an ad-hoc connection
+  string or file path, resume it with explicit `-d` flags:
+
+```bash
+saber threads resume a1b2c3d4 -d sales -d "postgresql://user:pass@host:5432/events"
+```
+
+</Aside>
+
+### Using the Python SDK
+
+The SDK exposes the same capability through `SQLSaberOptions`. Pass a list of
+targets to connect to multiple databases at once:
+
+```python
+from sqlsaber import SQLSaber
+from sqlsaber.options import SQLSaberOptions
+
+options = SQLSaberOptions(
+    database=["sales", "postgresql://user:pass@host:5432/events"],
+)
+
+saber = SQLSaber(options)
+print(saber.db_names)     # ["sales", "events"]
+print(saber.connections)  # {name: connection, ...}
+```
+
+See the [SDK Configuration guide](/sdk/configuration) for the full set of
+options.
+
+### What's Next?
+
+- [Database Setup](/guides/database-setup) — register and describe connections
+- [Knowledge Base](/guides/knowledge) — give each database extra context
+- [Conversation Threads](/guides/threads) — resume multi-database sessions

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -23,12 +23,15 @@ saber -d my-database "Show me recent orders"
 
 # With connection string
 saber -d "postgresql://user:pass@host:5432/db" "User statistics for 2024"
+
+# With multiple databases (repeat -d)
+saber -d sales -d analytics "Compare revenue to web sessions"
 ```
 
 **Parameters:**
 
 - `QUERY-TEXT` - SQL query in natural language (optional, starts interactive mode if not provided)
-- `-d, --database` - Database connection name, file path (CSV/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://)
+- `-d, --database` - Database connection name, file path (CSV/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://). Repeat the flag to connect to [multiple databases](/guides/multi-database) at once (or to merge multiple CSV files into one session).
 - `--thinking` / `--no-thinking` - Enable/disable extended thinking/reasoning mode
 - `--allow-dangerous` - Allow INSERT/UPDATE/DELETE and restricted DDL (CREATE TABLE/VIEW/INDEX, ALTER TABLE). DROP/TRUNCATE and admin/security operations remain blocked; UPDATE/DELETE require WHERE.
 - `--system-prompt` - Custom system prompt text or path to a file (overrides built-in prompt)
@@ -106,6 +109,7 @@ saber db add my-database [OPTIONS]
 - `--database, --db` - Database name
 - `-u, --username` - Username
 - `--exclude-schemas` - Comma-separated list of schemas to skip during introspection
+- `--description` - Short human-readable description of the connection. Shown to the agent in [multi-database sessions](/guides/multi-database) to help it pick the right database.
 - `--ssl-mode` - SSL mode (see SSL options below)
 - `--ssl-ca` - SSL CA certificate file path
 - `--ssl-cert` - SSL client certificate file path
@@ -493,14 +497,18 @@ saber threads resume a1b2c3d4 [OPTIONS]
 
 **Options:**
 
-- `-d, --database` - Use different database than original thread
+- `-d, --database` - Use a different database than the original thread. Repeat the flag to resume against multiple databases.
 
 **Features:**
 
 - Loads full conversation context
 - Uses same model as original thread
-- Connects to original database
+- Reconnects to the original database(s), including [multi-database](/guides/multi-database) threads
 - Continues where conversation left off in interactive mode
+
+:::note
+Automatic resume requires every database in the thread to be a saved connection. If a thread used an ad-hoc connection string or file path, resume it with explicit `-d` flags.
+:::
 
 #### `saber threads prune`
 

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -22,7 +22,7 @@ options = SQLSaberOptions(
 
 | Field               | Type                                          | Default | Description                                                                                  |
 | ------------------- | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, or a list of CSV paths.                    |
+| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, a list of CSV paths, or a list of targets for a [multi-database](/guides/multi-database) session. |
 | `model_name`        | `str \| None`                                 | `None`  | Model in `"provider:model"` form. Falls back to your configured/default model.               |
 | `api_key`           | `str \| None`                                 | `None`  | API key for the model's provider. Usually unnecessary — see [Credentials](/sdk/credentials-and-models). |
 | `thinking_enabled`  | `bool \| None`                                | `None`  | Toggle extended thinking on supported reasoning models.                                      |
@@ -64,10 +64,30 @@ SQLSaberOptions(database="./customers.csv")
 
 ### Multiple CSV files
 
-Pass a list (or tuple) of CSV paths to query across them together:
+Pass a list (or tuple) of CSV paths to query across them together. All CSVs are
+merged into a single in-memory database with one table per file:
 
 ```python
 SQLSaberOptions(database=["users.csv", "orders.csv"])
+```
+
+### Multiple databases
+
+Pass a list of non-CSV targets (configured names, connection strings, or file
+paths) to connect to [several databases](/guides/multi-database) in one session.
+The agent queries each one separately and combines the results:
+
+```python
+SQLSaberOptions(database=["sales", "postgresql://user:pass@host:5432/events"])
+```
+
+The resulting session exposes `db_names` and `connections` for the connected
+databases:
+
+```python
+saber = SQLSaber(options)
+saber.db_names     # ["sales", "events"]
+saber.connections  # {name: connection, ...}
 ```
 
 ### A configured database


### PR DESCRIPTION
Document the multi-database session feature added in the previous release:

- New "Multiple Databases" guide covering repeated -d connections, per-db
  routing via db_name, the list_dbs tool, --description for routing hints,
  multi-db thread resume, and the SDK list form.
- Database Setup guide: --description flag and a pointer to the new guide.
- Command reference: --description option, multi-db -d usage, and updated
  threads resume behavior.
- SDK Configuration: multiple-databases list form plus db_names/connections.
- Add the guide to the sidebar.