### PR TITLE
harden read-only SQL guard: file-path targets, missing functions, fail-closed dialects

### DIFF
--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -30,13 +30,13 @@ from sqlsaber.cli.usage import (
 )
 from sqlsaber.config.logging import get_logger
 from sqlsaber.database import (
-    CSVConnection,
-    CSVsConnection,
     DuckDBConnection,
     MySQLConnection,
     PostgreSQLConnection,
     SQLiteConnection,
 )
+from sqlsaber.database.csv import CSVConnection
+from sqlsaber.database.csvs import CSVsConnection
 from sqlsaber.database.schema import SchemaManager
 from sqlsaber.theme.manager import get_theme_manager
 

--- a/src/sqlsaber/database/__init__.py
+++ b/src/sqlsaber/database/__init__.py
@@ -12,8 +12,6 @@ from .base import (
     QueryTimeoutError,
     SchemaInfo,
 )
-from .csv import CSVConnection, CSVSchemaIntrospector
-from .csvs import CSVsConnection
 from .duckdb import DuckDBConnection, DuckDBSchemaIntrospector
 from .mysql import MySQLConnection, MySQLSchemaIntrospector
 from .postgresql import PostgreSQLConnection, PostgreSQLSchemaIntrospector
@@ -34,8 +32,12 @@ def DatabaseConnection(
     elif connection_string.startswith("duckdb://"):
         conn = DuckDBConnection(connection_string)
     elif connection_string.startswith("csv:///"):
+        from .csv import CSVConnection
+
         conn = CSVConnection(connection_string)
     elif connection_string.startswith("csvs://"):
+        from .csvs import CSVsConnection
+
         conn = CSVsConnection(connection_string)
     else:
         raise ValueError(
@@ -61,13 +63,10 @@ __all__ = [
     "MySQLConnection",
     "SQLiteConnection",
     "DuckDBConnection",
-    "CSVConnection",
-    "CSVsConnection",
     "PostgreSQLSchemaIntrospector",
     "MySQLSchemaIntrospector",
     "SQLiteSchemaIntrospector",
     "DuckDBSchemaIntrospector",
-    "CSVSchemaIntrospector",
     # Factory function and manager
     "DatabaseConnection",
     "SchemaManager",

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -10,6 +10,7 @@ import duckdb
 from .base import DEFAULT_QUERY_TIMEOUT, BaseDatabaseConnection, QueryTimeoutError
 from .duckdb import (
     DuckDBSchemaIntrospector,
+    _duckdb_interrupt_timer,
     _execute_duckdb_transaction,
     apply_read_only_lockdown,
 )
@@ -17,8 +18,6 @@ from .duckdb import (
 __all__ = [
     "CSVConnection",
     "CSVSchemaIntrospector",
-    "_execute_duckdb_transaction",
-    "apply_read_only_lockdown",
 ]
 
 
@@ -122,12 +121,15 @@ class CSVConnection(BaseDatabaseConnection):
         def _run_query() -> list[dict[str, Any]]:
             conn = duckdb.connect(":memory:")
             try:
-                self._create_table(conn)
-                if read_only:
-                    apply_read_only_lockdown(conn)
-                return _execute_duckdb_transaction(
-                    conn, query, args_tuple, commit, timeout=effective_timeout
-                )
+                with _duckdb_interrupt_timer(conn, effective_timeout):
+                    self._create_table(conn)
+                    if read_only:
+                        apply_read_only_lockdown(conn)
+                    return _execute_duckdb_transaction(
+                        conn, query, args_tuple, commit, timeout=effective_timeout
+                    )
+            except duckdb.InterruptException as exc:
+                raise QueryTimeoutError(effective_timeout or 0) from exc
             finally:
                 conn.close()
 

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -8,45 +8,18 @@ from urllib.parse import parse_qs, urlparse
 import duckdb
 
 from .base import DEFAULT_QUERY_TIMEOUT, BaseDatabaseConnection, QueryTimeoutError
-from .duckdb import DuckDBSchemaIntrospector
+from .duckdb import (
+    DuckDBSchemaIntrospector,
+    _execute_duckdb_transaction,
+    apply_read_only_lockdown,
+)
 
-
-def _execute_duckdb_transaction(
-    conn: duckdb.DuckDBPyConnection,
-    query: str,
-    args: tuple[Any, ...],
-    commit: bool = False,
-) -> list[dict[str, Any]]:
-    """Run a DuckDB query inside a transaction and return list of dicts.
-
-    If commit=True, commits on success instead of rolling back.
-    """
-    conn.execute("BEGIN TRANSACTION")
-    success = False
-    try:
-        if args:
-            conn.execute(query, args)
-        else:
-            conn.execute(query)
-
-        if conn.description is None:
-            rows: list[dict[str, Any]] = []
-        else:
-            columns = [col[0] for col in conn.description]
-            data = conn.fetchall()
-            rows = [dict(zip(columns, row)) for row in data]
-
-        success = True
-        return rows
-    except Exception:
-        conn.execute("ROLLBACK")
-        raise
-    finally:
-        if success:
-            if commit:
-                conn.execute("COMMIT")
-            else:
-                conn.execute("ROLLBACK")
+__all__ = [
+    "CSVConnection",
+    "CSVSchemaIntrospector",
+    "_execute_duckdb_transaction",
+    "apply_read_only_lockdown",
+]
 
 
 class CSVConnection(BaseDatabaseConnection):
@@ -103,7 +76,14 @@ class CSVConnection(BaseDatabaseConnection):
             return None
         return encoding.replace("-", "").replace("_", "").upper()
 
-    def _create_view(self, conn: duckdb.DuckDBPyConnection) -> None:
+    def _create_table(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """Materialize the CSV into a real table.
+
+        A materialized table (rather than a view over read_csv_auto) lets the
+        session lock down external file access afterwards while still serving the
+        intended data — a view would re-read the file on every query and break
+        under the lockdown.
+        """
         header_literal = "TRUE" if self.has_header else "FALSE"
         option_parts: list[str] = [f"HEADER={header_literal}"]
 
@@ -122,11 +102,11 @@ class CSVConnection(BaseDatabaseConnection):
             f"read_csv_auto({self._quote_literal(self.csv_path)}{options_sql})"
         )
 
-        create_view_sql = (
-            f"CREATE VIEW {self._quote_identifier(self.table_name)} AS "
+        create_table_sql = (
+            f"CREATE TABLE {self._quote_identifier(self.table_name)} AS "
             f"SELECT * FROM {base_relation_sql}"
         )
-        conn.execute(create_view_sql)
+        conn.execute(create_table_sql)
 
     async def execute_query(
         self,
@@ -142,14 +122,21 @@ class CSVConnection(BaseDatabaseConnection):
         def _run_query() -> list[dict[str, Any]]:
             conn = duckdb.connect(":memory:")
             try:
-                self._create_view(conn)
-                return _execute_duckdb_transaction(conn, query, args_tuple, commit)
+                self._create_table(conn)
+                if read_only:
+                    apply_read_only_lockdown(conn)
+                return _execute_duckdb_transaction(
+                    conn, query, args_tuple, commit, timeout=effective_timeout
+                )
             finally:
                 conn.close()
 
         try:
+            wait_timeout = (
+                effective_timeout + 5 if effective_timeout else effective_timeout
+            )
             return await asyncio.wait_for(
-                asyncio.to_thread(_run_query), timeout=effective_timeout
+                asyncio.to_thread(_run_query), timeout=wait_timeout
             )
         except asyncio.TimeoutError as exc:
             raise QueryTimeoutError(effective_timeout or 0) from exc

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -9,16 +9,12 @@ import duckdb
 
 from .base import DEFAULT_QUERY_TIMEOUT, BaseDatabaseConnection, QueryTimeoutError
 from .duckdb import (
-    DuckDBSchemaIntrospector,
     _duckdb_interrupt_timer,
     _execute_duckdb_transaction,
     apply_read_only_lockdown,
 )
 
-__all__ = [
-    "CSVConnection",
-    "CSVSchemaIntrospector",
-]
+__all__ = ["CSVConnection"]
 
 
 class CSVConnection(BaseDatabaseConnection):
@@ -142,9 +138,3 @@ class CSVConnection(BaseDatabaseConnection):
             )
         except asyncio.TimeoutError as exc:
             raise QueryTimeoutError(effective_timeout or 0) from exc
-
-
-class CSVSchemaIntrospector(DuckDBSchemaIntrospector):
-    """CSV-specific schema introspection using DuckDB backend."""
-
-    pass

--- a/src/sqlsaber/database/csvs.py
+++ b/src/sqlsaber/database/csvs.py
@@ -11,7 +11,11 @@ from urllib.parse import parse_qs, urlparse
 import duckdb
 
 from .base import DEFAULT_QUERY_TIMEOUT, BaseDatabaseConnection, QueryTimeoutError
-from .csv import CSVConnection, _execute_duckdb_transaction
+from .csv import (
+    CSVConnection,
+    _execute_duckdb_transaction,
+    apply_read_only_lockdown,
+)
 
 
 class CSVsConnection(BaseDatabaseConnection):
@@ -83,14 +87,21 @@ class CSVsConnection(BaseDatabaseConnection):
             conn = duckdb.connect(":memory:")
             try:
                 for src in self.csv_sources:
-                    src._create_view(conn)
-                return _execute_duckdb_transaction(conn, query, args_tuple, commit)
+                    src._create_table(conn)
+                if read_only:
+                    apply_read_only_lockdown(conn)
+                return _execute_duckdb_transaction(
+                    conn, query, args_tuple, commit, timeout=effective_timeout
+                )
             finally:
                 conn.close()
 
         try:
+            wait_timeout = (
+                effective_timeout + 5 if effective_timeout else effective_timeout
+            )
             return await asyncio.wait_for(
-                asyncio.to_thread(_run_query), timeout=effective_timeout
+                asyncio.to_thread(_run_query), timeout=wait_timeout
             )
         except asyncio.TimeoutError as exc:
             raise QueryTimeoutError(effective_timeout or 0) from exc

--- a/src/sqlsaber/database/csvs.py
+++ b/src/sqlsaber/database/csvs.py
@@ -11,8 +11,9 @@ from urllib.parse import parse_qs, urlparse
 import duckdb
 
 from .base import DEFAULT_QUERY_TIMEOUT, BaseDatabaseConnection, QueryTimeoutError
-from .csv import (
-    CSVConnection,
+from .csv import CSVConnection
+from .duckdb import (
+    _duckdb_interrupt_timer,
     _execute_duckdb_transaction,
     apply_read_only_lockdown,
 )
@@ -86,13 +87,16 @@ class CSVsConnection(BaseDatabaseConnection):
         def _run_query() -> list[dict[str, Any]]:
             conn = duckdb.connect(":memory:")
             try:
-                for src in self.csv_sources:
-                    src._create_table(conn)
-                if read_only:
-                    apply_read_only_lockdown(conn)
-                return _execute_duckdb_transaction(
-                    conn, query, args_tuple, commit, timeout=effective_timeout
-                )
+                with _duckdb_interrupt_timer(conn, effective_timeout):
+                    for src in self.csv_sources:
+                        src._create_table(conn)
+                    if read_only:
+                        apply_read_only_lockdown(conn)
+                    return _execute_duckdb_transaction(
+                        conn, query, args_tuple, commit, timeout=effective_timeout
+                    )
+            except duckdb.InterruptException as exc:
+                raise QueryTimeoutError(effective_timeout or 0) from exc
             finally:
                 conn.close()
 

--- a/src/sqlsaber/database/duckdb.py
+++ b/src/sqlsaber/database/duckdb.py
@@ -1,6 +1,7 @@
 """DuckDB database connection and schema introspection."""
 
 import asyncio
+import threading
 from typing import Any
 
 import duckdb
@@ -12,17 +13,37 @@ from .base import (
     QueryTimeoutError,
 )
 
+# Engine-level lockdown applied to read-only DuckDB sessions. Disabling external
+# access blocks replacement scans (e.g. SELECT * FROM '/etc/passwd'), file-reading
+# table functions, httpfs/SSRF, and ATTACH; the extension flags prevent loading
+# code at runtime. This is defense-in-depth behind the AST guard.
+READ_ONLY_DUCKDB_CONFIG: dict[str, Any] = {
+    "enable_external_access": False,
+    "autoinstall_known_extensions": False,
+    "autoload_known_extensions": False,
+}
+
 
 def _execute_duckdb_transaction(
     conn: duckdb.DuckDBPyConnection,
     query: str,
     args: tuple[Any, ...],
     commit: bool = False,
+    timeout: float | None = None,
 ) -> list[dict[str, Any]]:
     """Run a DuckDB query inside a transaction and return list of dicts.
 
-    If commit=True, commits on success instead of rolling back.
+    If commit=True, commits on success instead of rolling back. If timeout is set,
+    a watchdog thread interrupts the engine when it elapses so a runaway query is
+    actually cancelled (not merely abandoned); the interrupt is surfaced as
+    QueryTimeoutError.
     """
+    timer: threading.Timer | None = None
+    if timeout:
+        timer = threading.Timer(timeout, conn.interrupt)
+        timer.daemon = True
+        timer.start()
+
     conn.execute("BEGIN TRANSACTION")
     success = False
     try:
@@ -40,15 +61,39 @@ def _execute_duckdb_transaction(
 
         success = True
         return rows
+    except duckdb.InterruptException as exc:
+        _safe_rollback(conn)
+        raise QueryTimeoutError(timeout or 0) from exc
     except Exception:
-        conn.execute("ROLLBACK")
+        _safe_rollback(conn)
         raise
     finally:
+        if timer is not None:
+            timer.cancel()
         if success:
             if commit:
                 conn.execute("COMMIT")
             else:
                 conn.execute("ROLLBACK")
+
+
+def _safe_rollback(conn: duckdb.DuckDBPyConnection) -> None:
+    """Best-effort ROLLBACK that never masks the original error."""
+    try:
+        conn.execute("ROLLBACK")
+    except Exception:
+        pass
+
+
+def apply_read_only_lockdown(conn: duckdb.DuckDBPyConnection) -> None:
+    """Disable external access/extension loading on an already-open connection.
+
+    Used by the CSV connections, which must read their source file(s) with
+    external access enabled before locking the session down for the user query.
+    """
+    conn.execute("SET autoinstall_known_extensions=false")
+    conn.execute("SET autoload_known_extensions=false")
+    conn.execute("SET enable_external_access=false")
 
 
 class DuckDBConnection(BaseDatabaseConnection):
@@ -104,18 +149,28 @@ class DuckDBConnection(BaseDatabaseConnection):
 
         def _run_query() -> list[dict[str, Any]]:
             connect_kwargs: dict[str, Any] = {}
-            if read_only and self.database_path != ":memory:":
-                connect_kwargs["read_only"] = True
+            if read_only:
+                # In-memory databases cannot be opened read_only, but the config
+                # lockdown still applies and the transaction is rolled back.
+                connect_kwargs["config"] = dict(READ_ONLY_DUCKDB_CONFIG)
+                if self.database_path != ":memory:":
+                    connect_kwargs["read_only"] = True
 
             conn = duckdb.connect(self.database_path, **connect_kwargs)
             try:
-                return _execute_duckdb_transaction(conn, query, args_tuple, commit)
+                return _execute_duckdb_transaction(
+                    conn, query, args_tuple, commit, timeout=effective_timeout
+                )
             finally:
                 conn.close()
 
         try:
+            # Backstop the engine-side interrupt with a slightly longer wall clock.
+            wait_timeout = (
+                effective_timeout + 5 if effective_timeout else effective_timeout
+            )
             return await asyncio.wait_for(
-                asyncio.to_thread(_run_query), timeout=effective_timeout
+                asyncio.to_thread(_run_query), timeout=wait_timeout
             )
         except asyncio.TimeoutError as exc:
             raise QueryTimeoutError(effective_timeout or 0) from exc

--- a/src/sqlsaber/database/duckdb.py
+++ b/src/sqlsaber/database/duckdb.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import duckdb
@@ -24,6 +26,24 @@ READ_ONLY_DUCKDB_CONFIG: dict[str, Any] = {
 }
 
 
+@contextmanager
+def _duckdb_interrupt_timer(
+    conn: duckdb.DuckDBPyConnection, timeout: float | None
+) -> Iterator[None]:
+    """Interrupt the DuckDB connection if the timeout elapses."""
+    timer: threading.Timer | None = None
+    if timeout:
+        timer = threading.Timer(timeout, conn.interrupt)
+        timer.daemon = True
+        timer.start()
+
+    try:
+        yield
+    finally:
+        if timer is not None:
+            timer.cancel()
+
+
 def _execute_duckdb_transaction(
     conn: duckdb.DuckDBPyConnection,
     query: str,
@@ -38,29 +58,24 @@ def _execute_duckdb_transaction(
     actually cancelled (not merely abandoned); the interrupt is surfaced as
     QueryTimeoutError.
     """
-    timer: threading.Timer | None = None
-    if timeout:
-        timer = threading.Timer(timeout, conn.interrupt)
-        timer.daemon = True
-        timer.start()
-
-    conn.execute("BEGIN TRANSACTION")
     success = False
     try:
-        if args:
-            conn.execute(query, args)
-        else:
-            conn.execute(query)
+        with _duckdb_interrupt_timer(conn, timeout):
+            conn.execute("BEGIN TRANSACTION")
+            if args:
+                conn.execute(query, args)
+            else:
+                conn.execute(query)
 
-        if conn.description is None:
-            rows: list[dict[str, Any]] = []
-        else:
-            columns = [col[0] for col in conn.description]
-            data = conn.fetchall()
-            rows = [dict(zip(columns, row)) for row in data]
+            if conn.description is None:
+                rows: list[dict[str, Any]] = []
+            else:
+                columns = [col[0] for col in conn.description]
+                data = conn.fetchall()
+                rows = [dict(zip(columns, row)) for row in data]
 
-        success = True
-        return rows
+            success = True
+            return rows
     except duckdb.InterruptException as exc:
         _safe_rollback(conn)
         raise QueryTimeoutError(timeout or 0) from exc
@@ -68,8 +83,6 @@ def _execute_duckdb_transaction(
         _safe_rollback(conn)
         raise
     finally:
-        if timer is not None:
-            timer.cancel()
         if success:
             if commit:
                 conn.execute("COMMIT")

--- a/src/sqlsaber/database/sqlite.py
+++ b/src/sqlsaber/database/sqlite.py
@@ -25,6 +25,11 @@ def _never_abort() -> int:
     return 0
 
 
+def _is_sqlite_interrupt(exc: sqlite3.OperationalError) -> bool:
+    """Return True when SQLite reports an engine interrupt."""
+    return getattr(exc, "sqlite_errorcode", None) == sqlite3.SQLITE_INTERRUPT
+
+
 class SQLiteConnection(BaseDatabaseConnection):
     """SQLite database connection using aiosqlite."""
 
@@ -114,7 +119,7 @@ class SQLiteConnection(BaseDatabaseConnection):
             except asyncio.TimeoutError as exc:
                 raise QueryTimeoutError(effective_timeout or 0) from exc
             except sqlite3.OperationalError as exc:
-                if "interrupted" in str(exc).lower():
+                if _is_sqlite_interrupt(exc):
                     raise QueryTimeoutError(effective_timeout or 0) from exc
                 raise
             finally:

--- a/src/sqlsaber/database/sqlite.py
+++ b/src/sqlsaber/database/sqlite.py
@@ -18,6 +18,15 @@ from .base import (
 # enough to abort a runaway query promptly, large enough to add negligible
 # overhead to normal queries.
 _PROGRESS_HANDLER_INSTRUCTIONS = 10_000
+_SQLITE_BUSY_TIMEOUT_ERROR_CODES: set[int] = {sqlite3.SQLITE_BUSY}
+for _busy_code_name in (
+    "SQLITE_BUSY_RECOVERY",
+    "SQLITE_BUSY_SNAPSHOT",
+    "SQLITE_BUSY_TIMEOUT",
+):
+    _busy_code = getattr(sqlite3, _busy_code_name, None)
+    if isinstance(_busy_code, int):
+        _SQLITE_BUSY_TIMEOUT_ERROR_CODES.add(_busy_code)
 
 
 def _never_abort() -> int:
@@ -28,6 +37,18 @@ def _never_abort() -> int:
 def _is_sqlite_interrupt(exc: sqlite3.OperationalError) -> bool:
     """Return True when SQLite reports an engine interrupt."""
     return getattr(exc, "sqlite_errorcode", None) == sqlite3.SQLITE_INTERRUPT
+
+
+def _is_sqlite_busy_timeout(exc: sqlite3.OperationalError) -> bool:
+    """Return True when SQLite reports that its busy timeout elapsed."""
+    return getattr(exc, "sqlite_errorcode", None) in _SQLITE_BUSY_TIMEOUT_ERROR_CODES
+
+
+def _busy_timeout_ms(timeout: float | None) -> int:
+    """Convert a query timeout in seconds to SQLite busy_timeout milliseconds."""
+    if timeout is None or timeout <= 0:
+        return 0
+    return max(1, int(timeout * 1000))
 
 
 class SQLiteConnection(BaseDatabaseConnection):
@@ -72,54 +93,57 @@ class SQLiteConnection(BaseDatabaseConnection):
         If commit=True, the transaction will be committed on success.
         """
         effective_timeout = timeout or DEFAULT_QUERY_TIMEOUT
+        busy_timeout_ms = _busy_timeout_ms(effective_timeout)
 
-        async with aiosqlite.connect(self.database_path) as conn:
+        async with aiosqlite.connect(
+            self.database_path, timeout=busy_timeout_ms / 1000
+        ) as conn:
             conn.row_factory = aiosqlite.Row
-
-            if read_only:
-                await conn.execute("PRAGMA query_only = ON")
-            else:
-                await conn.execute("PRAGMA query_only = OFF")
-
-            # SQLite has no server-side timeout, and asyncio.wait_for cannot
-            # cancel the C-level execute running on the aiosqlite worker thread.
-            # A progress handler lets the engine itself abort once the deadline
-            # passes, so a runaway query is actually stopped rather than leaked.
-            if effective_timeout:
-                deadline = time.monotonic() + effective_timeout
-
-                def _abort_when_expired() -> int:
-                    return 1 if time.monotonic() > deadline else 0
-
-                await conn.set_progress_handler(
-                    _abort_when_expired, _PROGRESS_HANDLER_INSTRUCTIONS
-                )
-
-            await conn.execute("BEGIN")
+            transaction_started = False
             success = False
+
             try:
-                # Backstop the engine-side abort with a slightly longer wall clock.
-                wait_timeout = (
-                    effective_timeout + 5 if effective_timeout else effective_timeout
-                )
-                if wait_timeout:
-                    cursor = await asyncio.wait_for(
-                        conn.execute(query, args if args else ()),
-                        timeout=wait_timeout,
+                await conn.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+
+                if read_only:
+                    await conn.execute("PRAGMA query_only = ON")
+                else:
+                    await conn.execute("PRAGMA query_only = OFF")
+
+                # SQLite has no server-side timeout, and asyncio.wait_for cannot
+                # cancel the C-level execute running on the aiosqlite worker thread.
+                # A progress handler lets the engine itself abort once the deadline
+                # passes, so a runaway query is actually stopped rather than leaked.
+                if effective_timeout:
+                    deadline = time.monotonic() + effective_timeout
+
+                    def _abort_when_expired() -> int:
+                        return 1 if time.monotonic() > deadline else 0
+
+                    await conn.set_progress_handler(
+                        _abort_when_expired, _PROGRESS_HANDLER_INSTRUCTIONS
                     )
+
+                await conn.execute("BEGIN")
+                transaction_started = True
+
+                async def _execute_and_fetch() -> list[Any]:
+                    cursor = await conn.execute(query, args if args else ())
+                    return list(await cursor.fetchall())
+
+                if effective_timeout:
                     rows = await asyncio.wait_for(
-                        cursor.fetchall(), timeout=wait_timeout
+                        _execute_and_fetch(), timeout=effective_timeout
                     )
                 else:
-                    cursor = await conn.execute(query, args if args else ())
-                    rows = await cursor.fetchall()
+                    rows = await _execute_and_fetch()
 
                 success = True
                 return [dict(row) for row in rows]
             except asyncio.TimeoutError as exc:
                 raise QueryTimeoutError(effective_timeout or 0) from exc
             except sqlite3.OperationalError as exc:
-                if _is_sqlite_interrupt(exc):
+                if _is_sqlite_interrupt(exc) or _is_sqlite_busy_timeout(exc):
                     raise QueryTimeoutError(effective_timeout or 0) from exc
                 raise
             finally:
@@ -128,10 +152,11 @@ class SQLiteConnection(BaseDatabaseConnection):
                     await conn.set_progress_handler(
                         _never_abort, _PROGRESS_HANDLER_INSTRUCTIONS
                     )
-                if success and commit:
-                    await conn.commit()
-                else:
-                    await conn.rollback()
+                if transaction_started:
+                    if success and commit:
+                        await conn.commit()
+                    else:
+                        await conn.rollback()
 
 
 class SQLiteSchemaIntrospector(BaseSchemaIntrospector):

--- a/src/sqlsaber/database/sqlite.py
+++ b/src/sqlsaber/database/sqlite.py
@@ -1,6 +1,8 @@
 """SQLite database connection and schema introspection."""
 
 import asyncio
+import sqlite3
+import time
 from typing import Any
 
 import aiosqlite
@@ -11,6 +13,16 @@ from .base import (
     BaseSchemaIntrospector,
     QueryTimeoutError,
 )
+
+# Number of SQLite VM instructions between progress-handler callbacks. Small
+# enough to abort a runaway query promptly, large enough to add negligible
+# overhead to normal queries.
+_PROGRESS_HANDLER_INSTRUCTIONS = 10_000
+
+
+def _never_abort() -> int:
+    """Progress handler that never aborts (used to clear the deadline handler)."""
+    return 0
 
 
 class SQLiteConnection(BaseDatabaseConnection):
@@ -64,17 +76,34 @@ class SQLiteConnection(BaseDatabaseConnection):
             else:
                 await conn.execute("PRAGMA query_only = OFF")
 
+            # SQLite has no server-side timeout, and asyncio.wait_for cannot
+            # cancel the C-level execute running on the aiosqlite worker thread.
+            # A progress handler lets the engine itself abort once the deadline
+            # passes, so a runaway query is actually stopped rather than leaked.
+            if effective_timeout:
+                deadline = time.monotonic() + effective_timeout
+
+                def _abort_when_expired() -> int:
+                    return 1 if time.monotonic() > deadline else 0
+
+                await conn.set_progress_handler(
+                    _abort_when_expired, _PROGRESS_HANDLER_INSTRUCTIONS
+                )
+
             await conn.execute("BEGIN")
             success = False
             try:
-                # Execute query with client-side timeout (SQLite has no server-side timeout)
-                if effective_timeout:
+                # Backstop the engine-side abort with a slightly longer wall clock.
+                wait_timeout = (
+                    effective_timeout + 5 if effective_timeout else effective_timeout
+                )
+                if wait_timeout:
                     cursor = await asyncio.wait_for(
                         conn.execute(query, args if args else ()),
-                        timeout=effective_timeout,
+                        timeout=wait_timeout,
                     )
                     rows = await asyncio.wait_for(
-                        cursor.fetchall(), timeout=effective_timeout
+                        cursor.fetchall(), timeout=wait_timeout
                     )
                 else:
                     cursor = await conn.execute(query, args if args else ())
@@ -84,7 +113,16 @@ class SQLiteConnection(BaseDatabaseConnection):
                 return [dict(row) for row in rows]
             except asyncio.TimeoutError as exc:
                 raise QueryTimeoutError(effective_timeout or 0) from exc
+            except sqlite3.OperationalError as exc:
+                if "interrupted" in str(exc).lower():
+                    raise QueryTimeoutError(effective_timeout or 0) from exc
+                raise
             finally:
+                if effective_timeout:
+                    # Clear the deadline handler so it cannot abort commit/rollback.
+                    await conn.set_progress_handler(
+                        _never_abort, _PROGRESS_HANDLER_INSTRUCTIONS
+                    )
                 if success and commit:
                     await conn.commit()
                 else:

--- a/src/sqlsaber/tools/sql_guard.py
+++ b/src/sqlsaber/tools/sql_guard.py
@@ -87,6 +87,27 @@ DANGEROUS_FUNCTIONS_BY_DIALECT: dict[str, set[str]] = {
         "pg_current_logfile",
         "lo_import",
         "lo_export",
+        "lo_get",
+        "lo_put",
+        "loread",
+        "lowrite",
+        # Arbitrary SQL execution via XML mapping functions (the query string is
+        # opaque to AST analysis, so these must be blocked outright)
+        "query_to_xml",
+        "query_to_xmlschema",
+        "query_to_xml_and_xmlschema",
+        "table_to_xml",
+        "table_to_xmlschema",
+        "table_to_xml_and_xmlschema",
+        "cursor_to_xml",
+        "cursor_to_xmlschema",
+        # Sequence side effects (exempt from SET TRANSACTION READ ONLY)
+        "nextval",
+        "setval",
+        "currval",
+        "lastval",
+        # Logical replication message emission (side effect)
+        "pg_logical_emit_message",
         # External execution / remote calls
         "dblink",
         "dblink_exec",
@@ -161,6 +182,8 @@ DANGEROUS_FUNCTIONS_BY_DIALECT: dict[str, set[str]] = {
         "writefile",
         # Extension loading
         "load_extension",
+        # FTS3 tokenizer pointer primitive (memory corruption / code execution)
+        "fts3_tokenizer",
     },
     "duckdb": {
         # File-reading table functions
@@ -188,12 +211,21 @@ DANGEROUS_FUNCTIONS_BY_DIALECT: dict[str, set[str]] = {
         "read_ndjson_objects",
         # Filesystem enumeration
         "glob",
+        # CSV sniffing (reads files)
+        "sniff_csv",
         # External database access
         "sqlite_scan",
         "postgres_scan",
         "mysql_scan",
         "postgres_query",
         "mysql_query",
+        # Secret / session-variable disclosure
+        "duckdb_secrets",
+        "which_secret",
+        "getvariable",
+        # Sequence side effects
+        "nextval",
+        "currval",
         # Extension management
         "load_extension",
         "install_extension",
@@ -3603,8 +3635,19 @@ def _display_function_name(fn: exp.Func) -> str:
 
 def has_dangerous_functions(stmt: exp.Expression, dialect: str) -> str | None:
     """Check for dangerous functions that can read files or execute commands."""
-    deny_set = DANGEROUS_FUNCTIONS_BY_DIALECT.get(dialect, set())
-    deny_prefix_set = DANGEROUS_FUNCTION_PREFIXES_BY_DIALECT.get(dialect, set())
+    known_dialect = (
+        dialect in DANGEROUS_FUNCTIONS_BY_DIALECT
+        or dialect in DANGEROUS_FUNCTION_PREFIXES_BY_DIALECT
+    )
+    if known_dialect:
+        deny_set = DANGEROUS_FUNCTIONS_BY_DIALECT.get(dialect, set())
+        deny_prefix_set = DANGEROUS_FUNCTION_PREFIXES_BY_DIALECT.get(dialect, set())
+    else:
+        # Unknown dialect: fail closed against the union of every known denylist
+        # rather than allowing all functions through.
+        deny_set = set().union(*DANGEROUS_FUNCTIONS_BY_DIALECT.values())
+        deny_prefix_set = set().union(*DANGEROUS_FUNCTION_PREFIXES_BY_DIALECT.values())
+
     if not deny_set and not deny_prefix_set:
         return None
 
@@ -3640,6 +3683,67 @@ def has_dangerous_functions(stmt: exp.Expression, dialect: str) -> str | None:
                 "is not allowed"
             )
 
+    return None
+
+
+# Dialects whose engines treat a bare quoted string in FROM as a file path
+# (DuckDB "replacement scans"). For these, a path/URL/glob table reference reads
+# arbitrary files with no function call and must be rejected.
+FILE_PATH_TARGET_DIALECTS: set[str] = {"duckdb"}
+
+# Data-file extensions that, as a table reference suffix, indicate a file read.
+FILE_PATH_DATA_EXTENSIONS: tuple[str, ...] = (
+    ".csv",
+    ".tsv",
+    ".txt",
+    ".parquet",
+    ".json",
+    ".jsonl",
+    ".ndjson",
+    ".arrow",
+    ".feather",
+    ".ipc",
+    ".avro",
+    ".xml",
+    ".xlsx",
+    ".xls",
+    ".gz",
+    ".zst",
+    ".db",
+    ".sqlite",
+    ".duckdb",
+)
+
+
+def _looks_like_file_path(name: str) -> bool:
+    """Heuristically detect a file path, URL, or glob used as a table reference."""
+    lowered = name.strip().lower()
+    if not lowered:
+        return False
+    if "://" in lowered:  # URLs: http(s), s3, gcs, azure, etc.
+        return True
+    if "/" in lowered or "\\" in lowered:  # path separators
+        return True
+    if "*" in lowered or "?" in lowered:  # globs
+        return True
+    return lowered.endswith(FILE_PATH_DATA_EXTENSIONS)
+
+
+def has_file_path_target(stmt: exp.Expression, dialect: str) -> str | None:
+    """Reject file-path/URL/glob table references for replacement-scan dialects."""
+    if dialect not in FILE_PATH_TARGET_DIALECTS:
+        return None
+
+    for table in stmt.find_all(exp.Table):
+        ident = table.this
+        if not isinstance(ident, exp.Identifier):
+            continue
+        name = ident.name or ""
+        if _looks_like_file_path(name):
+            return (
+                "Reading from a file path or URL is not allowed "
+                f"(table reference: {name!r})"
+            )
     return None
 
 
@@ -3749,6 +3853,11 @@ def validate_read_only(sql: str, dialect: str = "ansi") -> GuardResult:
     if reason:
         return GuardResult(False, reason)
 
+    # Block file-path/URL/glob table references (DuckDB replacement scans)
+    reason = has_file_path_target(stmt, dialect)
+    if reason:
+        return GuardResult(False, reason)
+
     return GuardResult(
         True,
         None,
@@ -3810,6 +3919,11 @@ def validate_sql(
         with _analysis_session():
             # Enforce function-level sandbox in dangerous mode too
             reason = has_dangerous_functions(stmt, dialect)
+            if reason:
+                return GuardResult(False, reason)
+
+            # Block file-path/URL/glob table references (DuckDB replacement scans)
+            reason = has_file_path_target(stmt, dialect)
             if reason:
                 return GuardResult(False, reason)
 

--- a/tests/test_database/test_connection.py
+++ b/tests/test_database/test_connection.py
@@ -1,5 +1,7 @@
 """Tests for database connection module."""
 
+from urllib.parse import urlencode
+
 import pytest
 
 from sqlsaber.database import (
@@ -9,10 +11,22 @@ from sqlsaber.database import (
     PostgreSQLConnection,
     SQLiteConnection,
 )
+from sqlsaber.database.csv import CSVConnection
+from sqlsaber.database.csvs import CSVsConnection
 
 
 class TestDatabaseConnectionFactory:
     """Test the DatabaseConnection factory function."""
+
+    def test_csv_compatibility_exports_are_removed(self):
+        """CSV implementation classes should be imported from their modules."""
+        import sqlsaber.database as database
+        import sqlsaber.database.csv as csv_module
+
+        assert not hasattr(database, "CSVConnection")
+        assert not hasattr(database, "CSVsConnection")
+        assert not hasattr(database, "CSVSchemaIntrospector")
+        assert not hasattr(csv_module, "CSVSchemaIntrospector")
 
     def test_postgresql_connection(self):
         """Test creating a PostgreSQL connection."""
@@ -43,6 +57,26 @@ class TestDatabaseConnectionFactory:
         assert isinstance(conn, DuckDBConnection)
         assert conn.connection_string == conn_string
         assert conn.database_path == "path/to/data.duckdb"
+
+    def test_csv_connection(self):
+        """Test creating a CSV connection."""
+        conn_string = "csv:///path/to/data.csv"
+        conn = DatabaseConnection(conn_string)
+        assert isinstance(conn, CSVConnection)
+        assert conn.connection_string == conn_string
+        assert conn.csv_path == "path/to/data.csv"
+
+    def test_csvs_connection(self):
+        """Test creating a multi-CSV connection."""
+        specs = ["csv:///path/to/users.csv", "csv:///path/to/orders.csv"]
+        conn_string = f"csvs:///?{urlencode({'spec': specs}, doseq=True)}"
+        conn = DatabaseConnection(conn_string)
+        assert isinstance(conn, CSVsConnection)
+        assert conn.connection_string == conn_string
+        assert [source.csv_path for source in conn.csv_sources] == [
+            "path/to/users.csv",
+            "path/to/orders.csv",
+        ]
 
     def test_unsupported_database(self):
         """Test error for unsupported database type."""

--- a/tests/test_database/test_csv_connection.py
+++ b/tests/test_database/test_csv_connection.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sqlsaber.database import CSVConnection
+from sqlsaber.database.csv import CSVConnection
 from sqlsaber.database.schema import SchemaManager
 
 

--- a/tests/test_database/test_csv_module.py
+++ b/tests/test_database/test_csv_module.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from sqlsaber.database.csv import CSVConnection, CSVSchemaIntrospector
+from sqlsaber.database.csv import CSVConnection
+from sqlsaber.database.duckdb import DuckDBSchemaIntrospector
 
 
 class TestCSVConnection:
@@ -190,8 +191,8 @@ class TestCSVConnection:
         await conn.close()
 
 
-class TestCSVSchemaIntrospector:
-    """Test CSV schema introspection (uses DuckDB backend)."""
+class TestCSVDuckDBSchemaIntrospection:
+    """Test CSV schema introspection using the DuckDB introspector."""
 
     @pytest.mark.asyncio
     async def test_csv_table_listing(self, tmp_path):
@@ -200,7 +201,7 @@ class TestCSVSchemaIntrospector:
         csv_path.write_text("id,name,price\n1,Laptop,999.99\n2,Mouse,29.99\n")
 
         conn = CSVConnection(f"csv:///{csv_path}")
-        introspector = CSVSchemaIntrospector()
+        introspector = DuckDBSchemaIntrospector()
 
         tables = await introspector.list_tables_info(conn)
 
@@ -219,7 +220,7 @@ class TestCSVSchemaIntrospector:
         )
 
         conn = CSVConnection(f"csv:///{csv_path}")
-        introspector = CSVSchemaIntrospector()
+        introspector = DuckDBSchemaIntrospector()
 
         tables = await introspector.get_tables_info(conn)
         columns = await introspector.get_columns_info(conn, tables)
@@ -250,7 +251,7 @@ class TestCSVSchemaIntrospector:
         )
 
         conn = CSVConnection(f"csv:///{csv_path}")
-        introspector = CSVSchemaIntrospector()
+        introspector = DuckDBSchemaIntrospector()
 
         # Test that we can introspect tables with null values
         tables = await introspector.get_tables_info(conn)
@@ -274,7 +275,7 @@ class TestCSVSchemaIntrospector:
         )
 
         conn = CSVConnection(f"csv:///{csv_path}")
-        introspector = CSVSchemaIntrospector()
+        introspector = DuckDBSchemaIntrospector()
 
         tables = await introspector.get_tables_info(conn)
         columns = await introspector.get_columns_info(conn, tables)
@@ -327,7 +328,7 @@ class TestCSVSchemaIntrospector:
         single_col_path.write_text("value\n1\n2\n3\n")
 
         conn = CSVConnection(f"csv:///{single_col_path}")
-        introspector = CSVSchemaIntrospector()
+        introspector = DuckDBSchemaIntrospector()
 
         tables = await introspector.get_tables_info(conn)
         columns = await introspector.get_columns_info(conn, tables)

--- a/tests/test_database/test_csvs_connection.py
+++ b/tests/test_database/test_csvs_connection.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from sqlsaber.database import CSVsConnection
+from sqlsaber.database.csvs import CSVsConnection
 from sqlsaber.database.schema import SchemaManager
 
 

--- a/tests/test_database/test_read_only_enforcement.py
+++ b/tests/test_database/test_read_only_enforcement.py
@@ -6,13 +6,13 @@ import pytest
 
 from sqlsaber.database import (
     BaseDatabaseConnection,
-    CSVConnection,
-    CSVsConnection,
     DuckDBConnection,
     MySQLConnection,
     PostgreSQLConnection,
     SQLiteConnection,
 )
+from sqlsaber.database.csv import CSVConnection
+from sqlsaber.database.csvs import CSVsConnection
 
 
 def test_base_connection_contract_exposes_read_only_flag():

--- a/tests/test_database/test_read_only_hardening.py
+++ b/tests/test_database/test_read_only_hardening.py
@@ -6,6 +6,8 @@ read-only mode, and runaway queries must be cancelled at the engine when the
 timeout elapses.
 """
 
+import time
+
 import pytest
 
 from sqlsaber.database.base import QueryTimeoutError
@@ -130,6 +132,47 @@ class TestCSVFileReadLockdown:
 
 
 class TestQueryCancellation:
+    @pytest.mark.asyncio
+    async def test_csv_materialization_times_out_promptly(self, tmp_path, monkeypatch):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a\n1\n", encoding="utf-8")
+        conn = CSVConnection(f"csv:///{csv_path}")
+
+        def slow_materialization(duck_conn) -> None:
+            duck_conn.execute(RECURSIVE_BOMB)
+
+        monkeypatch.setattr(conn, "_create_table", slow_materialization)
+        started = time.monotonic()
+        try:
+            with pytest.raises(QueryTimeoutError):
+                await conn.execute_query("SELECT 1", timeout=0.2)
+        finally:
+            await conn.close()
+
+        assert time.monotonic() - started < 2
+
+    @pytest.mark.asyncio
+    async def test_csvs_materialization_times_out_promptly(self, tmp_path, monkeypatch):
+        from urllib.parse import urlencode
+
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a\n1\n", encoding="utf-8")
+        specs = [f"csv:///{csv_path}"]
+        conn = CSVsConnection(f"csvs:///?{urlencode({'spec': specs}, doseq=True)}")
+
+        def slow_materialization(duck_conn) -> None:
+            duck_conn.execute(RECURSIVE_BOMB)
+
+        monkeypatch.setattr(conn.csv_sources[0], "_create_table", slow_materialization)
+        started = time.monotonic()
+        try:
+            with pytest.raises(QueryTimeoutError):
+                await conn.execute_query("SELECT 1", timeout=0.2)
+        finally:
+            await conn.close()
+
+        assert time.monotonic() - started < 2
+
     @pytest.mark.asyncio
     async def test_duckdb_recursive_bomb_times_out(self):
         conn = DuckDBConnection(":memory:")

--- a/tests/test_database/test_read_only_hardening.py
+++ b/tests/test_database/test_read_only_hardening.py
@@ -1,0 +1,149 @@
+"""Engine-level read-only hardening tests.
+
+These exercise the database connections directly (bypassing the AST guard) to
+verify defense-in-depth: arbitrary file reads must fail at the DuckDB engine in
+read-only mode, and runaway queries must be cancelled at the engine when the
+timeout elapses.
+"""
+
+import pytest
+
+from sqlsaber.database.base import QueryTimeoutError
+from sqlsaber.database.csv import CSVConnection
+from sqlsaber.database.csvs import CSVsConnection
+from sqlsaber.database.duckdb import DuckDBConnection
+from sqlsaber.database.sqlite import SQLiteConnection
+
+RECURSIVE_BOMB = (
+    "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t) "
+    "SELECT count(*) FROM t"
+)
+
+
+def _write_valid_csv(path) -> None:
+    """Write a small, valid CSV that DuckDB can read via a replacement scan."""
+    path.write_text("x\n1\n2\n", encoding="utf-8")
+
+
+class TestDuckDBFileReadLockdown:
+    @pytest.mark.asyncio
+    async def test_memory_read_only_blocks_readable_file(self, tmp_path):
+        evil = tmp_path / "evil.csv"
+        _write_valid_csv(evil)
+        conn = DuckDBConnection(":memory:")
+        try:
+            # Without lockdown the file is genuinely readable...
+            rows = await conn.execute_query(f"SELECT * FROM '{evil}'", read_only=False)
+            assert rows == [{"x": 1}, {"x": 2}]
+            # ...but read-only mode must block the read at the engine.
+            with pytest.raises(Exception):
+                await conn.execute_query(f"SELECT * FROM '{evil}'", read_only=True)
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_memory_read_only_allows_normal_query(self):
+        conn = DuckDBConnection(":memory:")
+        try:
+            rows = await conn.execute_query("SELECT 42 AS answer", read_only=True)
+            assert rows == [{"answer": 42}]
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_file_read_only_blocks_readable_file(self, tmp_path):
+        evil = tmp_path / "evil.csv"
+        _write_valid_csv(evil)
+        db_path = tmp_path / "t.duckdb"
+        conn = DuckDBConnection(str(db_path))
+        # Materialize a table so the file DB exists for the read-only reopen.
+        await conn.execute_query("CREATE TABLE t AS SELECT 1 AS x")
+        try:
+            with pytest.raises(Exception):
+                await conn.execute_query(f"SELECT * FROM '{evil}'", read_only=True)
+        finally:
+            await conn.close()
+
+
+class TestCSVFileReadLockdown:
+    @pytest.mark.asyncio
+    async def test_csv_legit_query_still_works(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+        conn = CSVConnection(f"csv:///{csv_path}")
+        try:
+            rows = await conn.execute_query(
+                'SELECT * FROM "data" ORDER BY a', read_only=True
+            )
+            assert rows == [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_csv_read_only_blocks_other_readable_file(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n", encoding="utf-8")
+        evil = tmp_path / "evil.csv"
+        _write_valid_csv(evil)
+        conn = CSVConnection(f"csv:///{csv_path}")
+        try:
+            with pytest.raises(Exception):
+                await conn.execute_query(f"SELECT * FROM '{evil}'", read_only=True)
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_csvs_legit_query_still_works(self, tmp_path):
+        from urllib.parse import urlencode
+
+        users = tmp_path / "users.csv"
+        orders = tmp_path / "orders.csv"
+        users.write_text("id,name\n1,Alice\n", encoding="utf-8")
+        orders.write_text("id,user_id,total\n10,1,9.99\n", encoding="utf-8")
+        specs = [f"csv:///{users}", f"csv:///{orders}"]
+        conn = CSVsConnection(f"csvs:///?{urlencode({'spec': specs}, doseq=True)}")
+        try:
+            rows = await conn.execute_query(
+                'SELECT u.name, o.total FROM "users" u '
+                'JOIN "orders" o ON u.id = o.user_id',
+                read_only=True,
+            )
+            assert rows == [{"name": "Alice", "total": 9.99}]
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_csvs_read_only_blocks_other_readable_file(self, tmp_path):
+        from urllib.parse import urlencode
+
+        users = tmp_path / "users.csv"
+        users.write_text("id,name\n1,Alice\n", encoding="utf-8")
+        evil = tmp_path / "evil.csv"
+        _write_valid_csv(evil)
+        specs = [f"csv:///{users}"]
+        conn = CSVsConnection(f"csvs:///?{urlencode({'spec': specs}, doseq=True)}")
+        try:
+            with pytest.raises(Exception):
+                await conn.execute_query(f"SELECT * FROM '{evil}'", read_only=True)
+        finally:
+            await conn.close()
+
+
+class TestQueryCancellation:
+    @pytest.mark.asyncio
+    async def test_duckdb_recursive_bomb_times_out(self):
+        conn = DuckDBConnection(":memory:")
+        try:
+            with pytest.raises(QueryTimeoutError):
+                await conn.execute_query(RECURSIVE_BOMB, timeout=0.5)
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_sqlite_recursive_bomb_times_out(self):
+        conn = SQLiteConnection("sqlite:///:memory:")
+        try:
+            with pytest.raises(QueryTimeoutError):
+                await conn.execute_query(RECURSIVE_BOMB, timeout=0.5)
+        finally:
+            await conn.close()

--- a/tests/test_database/test_schema_display.py
+++ b/tests/test_database/test_schema_display.py
@@ -7,7 +7,8 @@ import duckdb
 import pytest
 
 from sqlsaber.cli.display import DisplayManager
-from sqlsaber.database import CSVConnection, DuckDBConnection, SQLiteConnection
+from sqlsaber.database import DuckDBConnection, SQLiteConnection
+from sqlsaber.database.csv import CSVConnection
 from sqlsaber.database.duckdb import DuckDBSchemaIntrospector
 from sqlsaber.database.schema import SchemaManager
 from sqlsaber.database.sqlite import SQLiteSchemaIntrospector

--- a/tests/test_database/test_sqlite_module.py
+++ b/tests/test_database/test_sqlite_module.py
@@ -1,12 +1,15 @@
 """Comprehensive tests for SQLite database module."""
 
 import sqlite3
+import time
 
 import pytest
 
+from sqlsaber.database.base import QueryTimeoutError
 from sqlsaber.database.sqlite import (
     SQLiteConnection,
     SQLiteSchemaIntrospector,
+    _is_sqlite_busy_timeout,
     _is_sqlite_interrupt,
 )
 
@@ -23,6 +26,16 @@ class TestSQLiteConnection:
         not_interrupt = sqlite3.OperationalError("interrupted")
         not_interrupt.sqlite_errorcode = sqlite3.SQLITE_ERROR
         assert not _is_sqlite_interrupt(not_interrupt)
+
+    def test_busy_timeout_detection_uses_sqlite_error_code(self):
+        """Lock timeout classification should use SQLite result codes."""
+        busy = sqlite3.OperationalError("localized lock timeout")
+        busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+        assert _is_sqlite_busy_timeout(busy)
+
+        not_busy = sqlite3.OperationalError("database is locked")
+        not_busy.sqlite_errorcode = sqlite3.SQLITE_ERROR
+        assert not _is_sqlite_busy_timeout(not_busy)
 
     def test_connection_string_parsing(self):
         """Test SQLite connection string parsing."""
@@ -56,6 +69,34 @@ class TestSQLiteConnection:
             await conn.execute_query("SELECT * FROM non_existent_table")
 
         await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_locked_database_respects_query_timeout(self, tmp_path):
+        """SQLite lock waits should respect the requested query timeout."""
+        db_path = tmp_path / "locked.db"
+        with sqlite3.connect(db_path) as db_conn:
+            db_conn.execute(
+                "CREATE TABLE items (id INTEGER PRIMARY KEY, value INTEGER)"
+            )
+            db_conn.execute("INSERT INTO items (id, value) VALUES (1, 10)")
+            db_conn.commit()
+
+        locker = sqlite3.connect(db_path, timeout=0)
+        conn = SQLiteConnection(f"sqlite:///{db_path}")
+        try:
+            locker.execute("BEGIN IMMEDIATE")
+            started = time.monotonic()
+            with pytest.raises(QueryTimeoutError):
+                await conn.execute_query(
+                    "UPDATE items SET value = value + 1 WHERE id = 1",
+                    timeout=0.2,
+                    commit=True,
+                )
+            assert time.monotonic() - started < 1.5
+        finally:
+            locker.rollback()
+            locker.close()
+            await conn.close()
 
 
 class TestSQLiteSchemaIntrospector:

--- a/tests/test_database/test_sqlite_module.py
+++ b/tests/test_database/test_sqlite_module.py
@@ -4,11 +4,25 @@ import sqlite3
 
 import pytest
 
-from sqlsaber.database.sqlite import SQLiteConnection, SQLiteSchemaIntrospector
+from sqlsaber.database.sqlite import (
+    SQLiteConnection,
+    SQLiteSchemaIntrospector,
+    _is_sqlite_interrupt,
+)
 
 
 class TestSQLiteConnection:
     """Test SQLite connection functionality."""
+
+    def test_interrupt_detection_uses_sqlite_error_code(self):
+        """Interrupt classification should not depend on exception text."""
+        interrupt = sqlite3.OperationalError("localized engine stop")
+        interrupt.sqlite_errorcode = sqlite3.SQLITE_INTERRUPT
+        assert _is_sqlite_interrupt(interrupt)
+
+        not_interrupt = sqlite3.OperationalError("interrupted")
+        not_interrupt.sqlite_errorcode = sqlite3.SQLITE_ERROR
+        assert not _is_sqlite_interrupt(not_interrupt)
 
     def test_connection_string_parsing(self):
         """Test SQLite connection string parsing."""

--- a/tests/test_tools/test_sql_guard_security_regressions.py
+++ b/tests/test_tools/test_sql_guard_security_regressions.py
@@ -7,7 +7,7 @@ These tests intentionally codify stricter security expectations:
 
 import pytest
 
-from sqlsaber.tools.sql_guard import validate_sql
+from sqlsaber.tools.sql_guard import validate_read_only, validate_sql
 
 SAFE_MODE_SIDE_EFFECT_CASES = [
     # PostgreSQL side-effectful/admin/file/process functions
@@ -101,6 +101,41 @@ SAFE_MODE_SIDE_EFFECT_CASES = [
     ("duckdb", "SELECT * FROM excel_scan('file.xlsx')"),
     ("duckdb", "SELECT * FROM read_xlsx('file.xlsx')"),
     ("duckdb", "SELECT * FROM st_read('file.geojson')"),
+    # DuckDB replacement scans: a bare quoted path/URL/glob in FROM reads files
+    # with no function call (parses as Table -> Identifier).
+    ("duckdb", "SELECT * FROM '/etc/passwd'"),
+    ("duckdb", "SELECT * FROM 'secrets.parquet'"),
+    ("duckdb", "SELECT * FROM '/data/*.csv'"),
+    ("duckdb", "SELECT * FROM 'https://evil.example.com/x.csv'"),
+    ("duckdb", "SELECT a.x FROM '/etc/passwd' AS a"),
+    (
+        "duckdb",
+        "SELECT * FROM read_csv_auto('/etc/passwd') UNION SELECT * FROM '/etc/passwd'",
+    ),
+    # DuckDB readers/secrets/session functions missing from the denylist.
+    ("duckdb", "SELECT * FROM sniff_csv('/etc/passwd')"),
+    ("duckdb", "SELECT * FROM duckdb_secrets()"),
+    ("duckdb", "SELECT which_secret('s3://bucket/key', 's3')"),
+    ("duckdb", "SELECT getvariable('my_secret')"),
+    # PostgreSQL: functions that execute arbitrary SQL strings or read large objects.
+    ("postgres", "SELECT query_to_xml('DELETE FROM users', true, true, '')"),
+    ("postgres", "SELECT query_to_xmlschema('SELECT 1', true, true, '')"),
+    ("postgres", "SELECT query_to_xml_and_xmlschema('SELECT 1', true, true, '')"),
+    ("postgres", "SELECT table_to_xml('users', true, true, '')"),
+    ("postgres", "SELECT cursor_to_xml('mycursor', 0, true, true, '')"),
+    ("postgres", "SELECT lo_get(1234)"),
+    ("postgres", "SELECT loread(0, 100)"),
+    ("postgres", "SELECT lo_put(1234, 0, 'abc')"),
+    ("postgres", "SELECT pg_logical_emit_message(true, 'p', 'msg')"),
+    # SQLite FTS3 tokenizer pointer primitive.
+    ("sqlite", "SELECT fts3_tokenizer('x', x'0000000000000000')"),
+    # Sequence side effects bypass SET TRANSACTION READ ONLY in Postgres.
+    ("postgres", "SELECT nextval('my_seq')"),
+    ("postgres", "SELECT setval('my_seq', 1)"),
+    ("postgres", "SELECT currval('my_seq')"),
+    ("postgres", "SELECT lastval()"),
+    ("duckdb", "SELECT nextval('my_seq')"),
+    ("duckdb", "SELECT currval('my_seq')"),
 ]
 
 
@@ -157,6 +192,28 @@ STRICT_DANGEROUS_MODE_BLOCK_CASES = [
     # SQLite statements that should not be in dangerous allowlist
     ("sqlite", "REINDEX"),
 ]
+
+
+UNKNOWN_DIALECT_FAIL_CLOSED_CASES = [
+    # Dangerous functions from any known dialect must be blocked even when the
+    # dialect is unrecognized (denylist must fail closed, not fail open).
+    ("ansi", "SELECT pg_sleep(30)"),
+    ("ansi", "SELECT load_file('/etc/passwd')"),
+    ("totally-made-up", "SELECT pg_read_file('/etc/passwd')"),
+    ("totally-made-up", "SELECT sys_eval('id')"),
+]
+
+
+@pytest.mark.parametrize(("dialect", "query"), UNKNOWN_DIALECT_FAIL_CLOSED_CASES)
+def test_unknown_dialect_fails_closed_on_dangerous_functions(
+    dialect: str,
+    query: str,
+):
+    """Unrecognized dialects must still block known dangerous functions."""
+    result = validate_read_only(query, dialect)
+
+    assert not result.allowed
+    assert result.reason
 
 
 @pytest.mark.parametrize(("dialect", "query"), STRICT_DANGEROUS_MODE_BLOCK_CASES)


### PR DESCRIPTION
Close several read-only-mode bypasses in the sqlglot AST guard:

- Block DuckDB replacement scans: a bare quoted path/URL/glob in FROM
  (e.g. SELECT * FROM '/etc/passwd') read arbitrary files with no function
  call. Add has_file_path_target() and wire it into validate_read_only and
  validate_sql.
- Add missing dangerous functions to the denylists: query_to_xml/table_to_xml/
  cursor_to_xml family (execute arbitrary SQL strings), lo_get/loread/lo_put/
  lowrite, pg_logical_emit_message (postgres); sniff_csv, duckdb_secrets,
  which_secret, getvariable (duckdb); fts3_tokenizer (sqlite).
- Block sequence side effects nextval/setval/currval/lastval (postgres) and
  nextval/currval (duckdb) — these bypass SET TRANSACTION READ ONLY.
- Make has_dangerous_functions fail closed for unrecognized dialects by
  scanning against the union of all known denylists instead of allowing all.

Adds regression cases covering each vector in both safe and dangerous mode.