### PR TITLE
feat: publish capabilities SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+Or compose SQLsaber's tools into an agent you own:
+
+```python
+from pydantic_ai import Agent
+from sqlsaber import SqlTools
+
+sql = SqlTools(database="sqlite:///my.db")
+agent = Agent(
+    "anthropic:claude-sonnet-4-6",
+    instructions="You are my analytics copilot.",
+    capabilities=[sql],
+)
+
+async with agent:  # opens and closes connections owned by SqlTools
+    result = await agent.run("Top 5 customers by revenue")
+```
+
+See the [Capabilities guide](https://sqlsaber.com/sdk/capabilities/) for multi-database use, knowledge search, custom capabilities, and lifecycle details.
+
 ## How it works
 
 1. **Discovery** — Lists tables and identifies relevant ones based on your question.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -100,6 +100,7 @@ export default defineConfig({
 					items: [
 						{ label: "Overview", slug: "sdk/overview" },
 						{ label: "Configuration", slug: "sdk/configuration" },
+						{ label: "Capabilities", slug: "sdk/capabilities" },
 						{
 							label: "Credentials & Models",
 							slug: "sdk/credentials-and-models",

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,16 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+#### Pydantic AI capabilities migration
+
+- Requires `pydantic-ai>=2.9,<3`. Model names must include a provider prefix and pydantic-ai's graceful end strategy is now the default.
+- Adds public `SqlTools` and `Knowledge` capabilities, plus `SQLSaberOptions.extra_capabilities`, for composing SQLsaber with other pydantic-ai agents.
+- Replaces the `sqlsaber.tools` plugin entry-point group with `sqlsaber.capabilities`. Plugin authors must export a `capability(context)` factory; see the [plugin porting guide](/guides/plugins#building-a-plugin).
+- Removes `ToolRegistry`, `ToolRunDeps`, and the unused `SQLSaberOptions.tools`, `providers`, and `hooks` placeholders. Tool overrides remain available through `SQLSaberOptions.tool_overrides` and are delivered when plugin capabilities are constructed.
+- Delivers the system prompt as non-persisted pydantic-ai instructions and uses one provider-neutral persona. Existing custom system prompts still replace SQLsaber's built-in persona and SQL guidance.
+- Maps thinking levels through pydantic-ai's unified `Thinking` capability. Anthropic thinking budgets may differ from earlier SQLsaber versions because provider-specific token budgets are no longer set by SQLsaber.
+- Inherits pydantic-ai v2's graceful end strategy: function calls emitted beside a final text response execute instead of being skipped.
+
 ---
 
 ## [0.68.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-v0.67.0...sqlsaber-v0.68.0) (2026-05-29)

--- a/docs/src/content/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/guides/plugins.mdx
@@ -96,21 +96,39 @@ You can install multiple plugins at once:
 uv tool install --with sqlsaber-viz,sqlsaber-sandbox sqlsaber
 ```
 
-## Registering Custom Tools in a Django App
+## Building a plugin
 
-You can register custom tools directly in a Django app using `AppConfig.ready`:
+Plugins ship pydantic-ai capabilities through an entry point:
+
+```toml
+[project.entry-points."sqlsaber.capabilities"]
+my_plugin = "my_plugin:capability"
+```
+
+A typical one-tool plugin is small:
 
 ```python
-# myapp/apps.py
-from django.apps import AppConfig
-
-from sqlsaber.tools.registry import tool_registry
-from myapp.tools import MyCustomTool
+from pydantic_ai.capabilities import Capability
+from sqlsaber.capabilities.plugins import PluginContext
 
 
-class MyAppConfig(AppConfig):
-    name = "myapp"
+def my_tool(value: str) -> str:
+    """Process a value using my application."""
+    return value
 
-    def ready(self):
-        tool_registry.register(MyCustomTool)
+
+def capability(context: PluginContext):
+    return Capability(
+        id="my-plugin",
+        description="Process values with my application.",
+        tools=[my_tool],
+    )
 ```
+
+The factory receives a `PluginContext` containing SQLsaber's database registry,
+knowledge manager, dangerous-mode setting, and normalized tool model overrides.
+It can return one capability or a sequence. See the [Capabilities SDK guide](/sdk/capabilities) for standalone composition and lifecycle details.
+
+:::caution[Plugin API change]
+The former `sqlsaber.tools` entry-point group and global `ToolRegistry` no longer load. Existing plugins should keep their execution function or `Tool` class, wrap it in a capability, and export a `capability(context)` factory through `sqlsaber.capabilities`.
+:::

--- a/docs/src/content/docs/sdk/capabilities.mdx
+++ b/docs/src/content/docs/sdk/capabilities.mdx
@@ -1,0 +1,131 @@
+---
+title: Capabilities
+description: "Compose SQLsaber SQL and knowledge tools into your own pydantic-ai agents, or extend SQLsaber with custom capabilities."
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+SQLsaber exposes its database behavior as [pydantic-ai capabilities](https://ai.pydantic.dev/capabilities/). You can attach SQLsaber to an agent you own, or add your capabilities to SQLsaber's managed agent.
+
+## Add SQL tools to your agent
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+from sqlsaber import SqlTools
+
+
+async def main() -> None:
+    sql = SqlTools(database="postgresql://user:password@localhost/analytics")
+    agent = Agent(
+        "anthropic:claude-sonnet-4-6",
+        instructions="You are our analytics copilot.",
+        capabilities=[sql],
+    )
+
+    async with agent:
+        result = await agent.run("Top 5 customers by revenue")
+        print(result.output)
+
+
+asyncio.run(main())
+```
+
+`SqlTools` provides `list_tables`, `introspect_schema`, and `execute_sql`. Multi-database agents also receive `list_dbs`, and SQL tool schemas require a valid `db_name`.
+
+<Aside type="caution" title="Close owned connections">
+When `SqlTools` receives `database=`, it owns the resulting connections. Enter the agent with `async with agent:` as shown above, or call `await sql.close()` explicitly. A registry passed with `registry=` is borrowed and is never closed by the capability.
+</Aside>
+
+### Multiple databases
+
+Pass configured database names or DSNs as a sequence:
+
+```python
+sql = SqlTools(database=["production", "warehouse"])
+agent = Agent("openai:gpt-5.2", capabilities=[sql])
+```
+
+SQLsaber includes a database catalog in the capability instructions. Cross-database joins are not attempted; the model queries each database separately.
+
+### Allow writes
+
+SQL execution is read-only by default. Enable guarded write operations explicitly:
+
+```python
+sql = SqlTools(database="production", allow_dangerous=True)
+```
+
+Dangerous mode still blocks destructive and administrative operations such as `DROP`, `TRUNCATE`, and role management. Only enable it for agents and users you trust.
+
+## Add knowledge search
+
+`Knowledge` exposes saved SQL patterns and domain definitions. Share a manager when your application already owns one:
+
+```python
+from pydantic_ai import Agent
+from sqlsaber import Knowledge, SqlTools
+from sqlsaber.knowledge.manager import KnowledgeManager
+
+manager = KnowledgeManager()
+sql = SqlTools(database="postgresql://localhost/analytics")
+knowledge = Knowledge(
+    knowledge_manager=manager,
+    registry=sql.registry,
+)
+agent = Agent(
+    "anthropic:claude-sonnet-4-6",
+    capabilities=[sql, knowledge],
+)
+
+async with agent:
+    result = await agent.run("How do we define active customers?")
+
+await manager.close()
+```
+
+A supplied `KnowledgeManager` is borrowed. If omitted, `Knowledge` creates and closes its own manager when the agent context exits (or when `await knowledge.close()` is called).
+
+## Use your capabilities inside SQLsaber
+
+Pass pydantic-ai capabilities through `SQLSaberOptions.extra_capabilities`:
+
+```python
+from pydantic_ai.capabilities import WebSearch
+from sqlsaber import SQLSaber, SQLSaberOptions
+
+options = SQLSaberOptions(
+    database="analytics",
+    extra_capabilities=[WebSearch()],
+)
+
+async with SQLSaber(options=options) as saber:
+    result = await saber.query("Compare our latest revenue with public guidance")
+```
+
+Extra capabilities are appended to SQLsaber's SQL, knowledge, and installed plugin capabilities. They remain free to use their own dependency type when attached directly to your agent; SQLsaber's built-in capabilities do not claim `ctx.deps`.
+
+## Build a plugin capability
+
+Third-party plugins expose a factory through the `sqlsaber.capabilities` entry-point group:
+
+```toml
+[project.entry-points."sqlsaber.capabilities"]
+my_plugin = "my_plugin:capability"
+```
+
+```python
+from pydantic_ai.capabilities import Capability
+from sqlsaber.capabilities.plugins import PluginContext
+
+
+def capability(context: PluginContext):
+    return Capability(
+        id="my-plugin",
+        description="Use my application's specialist tool.",
+        tools=[my_tool],
+    )
+```
+
+`PluginContext` supplies the database registry, knowledge manager, dangerous-mode flag, and normalized tool model overrides. A factory may return one capability or a sequence of capabilities.

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -31,6 +31,7 @@ options = SQLSaberOptions(
 | `settings`          | `Config \| None`                              | `None`  | Inject a `Config` (e.g. `Config.in_memory(...)`). Defaults to file-backed `Config.default()`. |
 | `knowledge_manager` | `KnowledgeManager \| None`                    | `None`  | Inject your own knowledge base (see [Advanced](/sdk/advanced)).                              |
 | `thread_manager`    | `ThreadManager \| None`                       | `None`  | Persist conversation history across runs (see [Advanced](/sdk/advanced)).                    |
+| `extra_capabilities` | `Sequence[AbstractCapability[Any]]`           | `()`    | Add pydantic-ai capabilities to the managed agent (see [Capabilities](/sdk/capabilities)).   |
 | `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)).                            |
 | `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL (see [Advanced](/sdk/advanced)).       |
 

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -10,13 +10,17 @@ queries against your databases directly from Python code, instead of through the
 `saber` CLI. It is the same agent that powers the CLI, exposed as an `async`
 interface you can embed in scripts, notebooks, web backends, or data pipelines.
 
-The SDK exposes three names from the top-level `sqlsaber` package:
+The SDK exposes five names from the top-level `sqlsaber` package:
 
 | Export            | Purpose                                                       |
 | ----------------- | ------------------------------------------------------------- |
 | `SQLSaber`        | Main entry point — runs queries and owns the DB connection.   |
 | `SQLSaberOptions` | Typed options bag used to configure a `SQLSaber` session.     |
 | `ModelOverides`   | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)). |
+| `SqlTools`        | SQL capability for composing with your own pydantic-ai agent. |
+| `Knowledge`       | Database-scoped knowledge search capability.                  |
+
+See [Capabilities](/sdk/capabilities) to use SQLsaber inside your own agent or add your capabilities to its managed agent.
 
 ## Installation
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,23 +1,53 @@
 # SQLsaber Plugins
 
-SQLsaber supports optional tools distributed as plugins via entry points.
+SQLsaber plugins are pydantic-ai capabilities distributed through entry points.
 
 ## Create a plugin
 
 1. Create a package under `plugins/<name>/` with its own `pyproject.toml`.
-2. Expose tools via entry points under `sqlsaber.tools`:
+2. Expose a capability factory:
 
 ```toml
-[project.entry-points."sqlsaber.tools"]
-my_tool = "my_plugin.module:MyToolClass"
+[project.entry-points."sqlsaber.capabilities"]
+my_plugin = "my_plugin:capability"
 ```
 
-You can also expose a factory if tool registration is conditional:
+```python
+from collections.abc import Mapping
+from typing import Any
 
-```toml
-[project.entry-points."sqlsaber.tools"]
-my_plugin = "my_plugin:register_tools"
+from pydantic_ai.toolsets import FunctionToolset
+from sqlsaber.capabilities.base import SqlSaberCapability
+from sqlsaber.capabilities.plugins import PluginContext
+from sqlsaber.tools.base import Tool
+
+
+class MyCapability(SqlSaberCapability):
+    id = "my-plugin"
+    description = "Use my specialist tool."
+
+    def __init__(self, context: PluginContext):
+        self.tool = MyTool(context.registry)
+        self.toolset = FunctionToolset[Any](id=self.id)
+        self.toolset.add_function(self.tool.execute, name=self.tool.name)
+
+    def get_toolset(self):
+        return self.toolset
+
+    @property
+    def display_specs(self) -> Mapping[str, Tool]:
+        return {self.tool.name: self.tool}
+
+
+def capability(context: PluginContext):
+    return MyCapability(context)
 ```
+
+Factories receive the active database registry, knowledge manager, dangerous-mode flag, and normalized tool overrides. They may return one capability, a sequence, or an empty sequence when conditionally disabled.
+
+## Porting a legacy tool plugin
+
+The old `sqlsaber.tools` group and global `ToolRegistry` are removed. Keep your existing `Tool.execute` and rendering methods, put the instance in a `FunctionToolset`, expose it through `display_specs`, and change the entry point to `sqlsaber.capabilities`. Model overrides should be read from `context.tool_overrides` during construction rather than `ctx.deps`.
 
 ## Install a plugin locally
 

--- a/src/sqlsaber/__init__.py
+++ b/src/sqlsaber/__init__.py
@@ -4,10 +4,11 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .api import SQLSaber
+    from .capabilities import Knowledge, SqlTools
     from .options import SQLSaberOptions
     from .overrides import ModelOverides
 
-__all__ = ["SQLSaber", "SQLSaberOptions", "ModelOverides"]
+__all__ = ["SQLSaber", "SQLSaberOptions", "ModelOverides", "SqlTools", "Knowledge"]
 
 
 def __getattr__(name: str):
@@ -24,4 +25,12 @@ def __getattr__(name: str):
         from .overrides import ModelOverides
 
         return ModelOverides
+    if name == "SqlTools":
+        from .capabilities import SqlTools
+
+        return SqlTools
+    if name == "Knowledge":
+        from .capabilities import Knowledge
+
+        return Knowledge
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -54,6 +54,7 @@ class SQLSaberAgent:
         allow_dangerous: bool = False,
         system_prompt: str | None = None,
         tool_overides: ToolOveridesInput | None = None,
+        extra_capabilities: Sequence[AbstractCapability[Any]] = (),
     ) -> None:
         if registry is None:
             if db_connection is None:
@@ -79,6 +80,7 @@ class SQLSaberAgent:
         self.db_type = self.db_connection.display_name
         self.allow_dangerous = allow_dangerous
         self._tool_overides = normalize_tool_overides(tool_overides)
+        self._extra_capabilities = tuple(extra_capabilities)
         self.schema_manager: SchemaManager = primary.schema_manager
         self.thinking_enabled = (
             thinking_enabled
@@ -141,6 +143,7 @@ class SQLSaberAgent:
                 )
             )
         )
+        capabilities.extend(self._extra_capabilities)
         if self.thinking_enabled:
             capabilities.append(
                 Thinking(effort=UNIFIED_EFFORT_MAP[self.thinking_level])

--- a/src/sqlsaber/options.py
+++ b/src/sqlsaber/options.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlsaber.config.settings import ThinkingLevel
 from sqlsaber.overrides import ToolOveridesInput
 
 if TYPE_CHECKING:
+    from pydantic_ai.capabilities import AbstractCapability
+
     from sqlsaber.config.settings import Config
     from sqlsaber.knowledge.manager import KnowledgeManager
     from sqlsaber.threads.manager import ThreadManager
@@ -34,11 +36,9 @@ class SQLSaberOptions:
 
     # Injectable components
     settings: Config | None = None
-    tools: object | None = None
-    providers: object | None = None
     knowledge_manager: KnowledgeManager | None = None
     thread_manager: ThreadManager | None = None
-    hooks: Sequence[object] = ()
+    extra_capabilities: Sequence[AbstractCapability[Any]] = ()
 
     # Tool overrides
     tool_overrides: ToolOveridesInput | None = None

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -81,6 +81,7 @@ class SQLSaberSession:
             allow_dangerous=options.allow_dangerous,
             system_prompt=system_prompt_text,
             tool_overides=options.tool_overrides,
+            extra_capabilities=options.extra_capabilities,
         )
 
     async def query(

--- a/tests/test_api/test_options.py
+++ b/tests/test_api/test_options.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pytest
+from pydantic_ai.capabilities import Capability
 
-from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber import Knowledge, SQLSaber, SQLSaberOptions, SqlTools
 from sqlsaber.config.settings import Config
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.knowledge.sqlite_store import SQLiteKnowledgeStore
@@ -12,6 +13,11 @@ def test_api_options_are_required() -> None:
     kwargs: dict[str, object] = {}
     with pytest.raises(TypeError, match="options"):
         SQLSaber(**kwargs)
+
+
+def test_capabilities_are_exported_from_top_level() -> None:
+    assert SqlTools.__name__ == "SqlTools"
+    assert Knowledge.__name__ == "Knowledge"
 
 
 @pytest.mark.parametrize(
@@ -33,6 +39,24 @@ def test_api_legacy_constructor_kwargs_are_rejected(
     kwargs: dict[str, object] = {legacy_kw: value}
     with pytest.raises(TypeError, match=legacy_kw):
         SQLSaber(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_extra_capabilities_are_appended_to_managed_agent() -> None:
+    extra = Capability(id="custom", instructions="Custom capability")
+    saber = SQLSaber(
+        options=SQLSaberOptions(
+            database="sqlite:///:memory:",
+            settings=Config.in_memory(
+                model_name="anthropic:claude-3-5-sonnet",
+                api_keys={"anthropic": "test-key"},
+            ),
+            extra_capabilities=[extra],
+        )
+    )
+
+    assert extra in saber.agent.capabilities
+    await saber.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- export `SqlTools` and `Knowledge` from the public package
- add `SQLSaberOptions.extra_capabilities`
- document standalone composition, lifecycle, multi-database use, and plugin porting
- add migration release notes and bump the capabilities documentation surface

## Stack
Part 5 of 12. Base: `migration/plugin-capabilities`; child: `fix/provider-extras`.

## Validation
- pytest
- Ruff
- ty check
- Astro documentation build
- CLI startup check