### PR TITLE
fix: wire knowledge manager for multiple databases

### DIFF
--- a/src/sqlsaber/capabilities/knowledge.py
+++ b/src/sqlsaber/capabilities/knowledge.py
@@ -63,6 +63,7 @@ class Knowledge(SqlSaberCapability):
         tool = SearchKnowledgeTool()
         if registry is not None and len(registry) > 1:
             tool.set_registry(registry)
+            tool.knowledge_manager = manager
         else:
             resolved_name = database_name
             if resolved_name is None and registry is not None:

--- a/tests/test_capabilities/test_knowledge.py
+++ b/tests/test_capabilities/test_knowledge.py
@@ -1,0 +1,55 @@
+"""Tests for the knowledge capability."""
+
+import json
+
+import pytest
+
+from sqlsaber.capabilities import Knowledge
+from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
+from sqlsaber.database.sqlite import SQLiteConnection
+from sqlsaber.knowledge.manager import KnowledgeManager
+from sqlsaber.knowledge.sqlite_store import SQLiteKnowledgeStore
+
+
+def _multi_db_registry() -> DatabaseRegistry:
+    return DatabaseRegistry(
+        [
+            DatabaseEntry.from_connection(
+                name=name,
+                connection=SQLiteConnection("sqlite:///:memory:"),
+                description=None,
+                excluded_schemas=[],
+            )
+            for name in ("prod", "staging")
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_db_knowledge_uses_supplied_manager(temp_dir) -> None:
+    manager = KnowledgeManager(
+        store=SQLiteKnowledgeStore(db_path=temp_dir / "knowledge.db")
+    )
+    await manager.add_knowledge(
+        database_name="prod",
+        name="Revenue",
+        description="production revenue definition",
+    )
+    await manager.add_knowledge(
+        database_name="staging",
+        name="Revenue",
+        description="staging revenue definition",
+    )
+    capability = Knowledge(
+        knowledge_manager=manager,
+        registry=_multi_db_registry(),
+    )
+    tool = capability.display_specs["search_knowledge"]
+
+    try:
+        result = json.loads(await tool.execute("revenue", db_name="prod"))
+    finally:
+        await manager.close()
+
+    assert result["total_results"] == 1
+    assert result["results"][0]["description"] == "production revenue definition"


### PR DESCRIPTION
## Summary
- attach the supplied knowledge manager when a capability uses a multi-database registry
- add an end-to-end database-scoped knowledge search regression test

## Stack
Part 7 of 12. Base: `fix/provider-extras`; child: `fix/plugin-version-floor`.

## Validation
- pytest
- Ruff
- ty check