### PR TITLE
fix: require capabilities-compatible plugin core

### DIFF
--- a/plugins/sandbox/pyproject.toml
+++ b/plugins/sandbox/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "SQLsaber sandbox tool plugin"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["sqlsaber>=0.54.0", "cased-sandboxes>=0.5.0"]
+dependencies = ["sqlsaber>=0.69.0", "cased-sandboxes>=0.5.0"]
 
 [project.entry-points."sqlsaber.capabilities"]
 sandbox = "sqlsaber_sandbox:capability"

--- a/plugins/viz/pyproject.toml
+++ b/plugins/viz/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 description = "SQLsaber terminal visualization plugin"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["sqlsaber>=0.55.1", "plotext>=5.3.0"]
+dependencies = ["sqlsaber>=0.69.0", "plotext>=5.3.0"]
 
 [project.entry-points."sqlsaber.capabilities"]
 viz = "sqlsaber_viz:capability"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SQLsaber project configuration
 [project]
 name = "sqlsaber"
-version = "0.68.0"
+version = "0.69.0"
 description = "SQLsaber - Open-source agentic SQL assistant"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_capabilities/test_plugin_metadata.py
+++ b/tests/test_capabilities/test_plugin_metadata.py
@@ -1,0 +1,28 @@
+"""Compatibility checks for in-repository capability plugins."""
+
+import tomllib
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).parents[2]
+
+
+def _project_metadata(path: Path) -> dict:
+    with path.open("rb") as file:
+        return tomllib.load(file)["project"]
+
+
+def test_plugins_require_capabilities_compatible_sqlsaber() -> None:
+    core = _project_metadata(_REPOSITORY_ROOT / "pyproject.toml")
+    core_version = tuple(int(part) for part in core["version"].split("."))
+    assert core_version >= (0, 69, 0)
+
+    for plugin in ("sandbox", "viz"):
+        metadata = _project_metadata(
+            _REPOSITORY_ROOT / "plugins" / plugin / "pyproject.toml"
+        )
+        sqlsaber_requirements = [
+            requirement
+            for requirement in metadata["dependencies"]
+            if requirement.startswith("sqlsaber")
+        ]
+        assert sqlsaber_requirements == ["sqlsaber>=0.69.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -3002,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "sqlsaber"
-version = "0.68.0"
+version = "0.69.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiomysql" },
@@ -3075,7 +3075,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cased-sandboxes", specifier = ">=0.5.0" },
-    { name = "sqlsaber", specifier = ">=0.54.0" },
+    { name = "sqlsaber", specifier = ">=0.69.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3096,7 +3096,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "plotext", specifier = ">=5.3.0" },
-    { name = "sqlsaber", specifier = ">=0.55.1" },
+    { name = "sqlsaber", specifier = ">=0.69.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- bump the core package to 0.69.0
- require `sqlsaber>=0.69.0` from the migrated sandbox and visualization plugins
- add plugin compatibility metadata coverage

## Stack
Part 8 of 12. Base: `fix/multi-db-knowledge`; child: `fix/sql-toolset-lifecycle`.

## Validation
- pytest
- Ruff
- ty check
- uv lock check