### PR TITLE
fix: reference-count SQL toolset lifecycle

### DIFF
--- a/src/sqlsaber/capabilities/sql_tools.py
+++ b/src/sqlsaber/capabilities/sql_tools.py
@@ -36,27 +36,31 @@ class _SqlToolset(FunctionToolset[Any]):
         super().__init__(id="sqlsaber-sql")
         self._registry = registry
         self._owned = owned
-        self._closed = False
+        self._entry_count = 0
 
     async def __aenter__(self) -> Self:
         await super().__aenter__()
-        if self._owned:
+        if self._owned and self._entry_count == 0:
             for entry in self._registry:
                 await entry.connection.get_pool()
+        self._entry_count += 1
         return self
 
     async def __aexit__(self, *args: Any) -> bool | None:
+        if self._entry_count <= 0:
+            raise RuntimeError("SQL toolset context exited without a matching entry.")
+
+        self._entry_count -= 1
         try:
-            if self._owned and not self._closed:
+            if self._owned and self._entry_count == 0:
                 await self._registry.close()
-                self._closed = True
         finally:
-            return await super().__aexit__(*args)
+            super_result = await super().__aexit__(*args)
+        return super_result
 
     async def close(self) -> None:
-        if self._owned and not self._closed:
+        if self._owned:
             await self._registry.close()
-            self._closed = True
 
 
 class SqlTools(SqlSaberCapability):

--- a/tests/test_capabilities/test_sql_tools.py
+++ b/tests/test_capabilities/test_sql_tools.py
@@ -80,6 +80,56 @@ async def test_owned_registry_closes_with_agent_context(
 
 
 @pytest.mark.asyncio
+async def test_owned_registry_stays_open_across_nested_agent_runs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database_path = tmp_path / "nested.sqlite"
+    database_path.touch()
+    capability = SqlTools(database=str(database_path))
+    connection = capability.registry.get(capability.registry.primary()).connection
+    lifecycle_events: list[str] = []
+
+    async def tracked_get_pool() -> str:
+        lifecycle_events.append("open")
+        return str(database_path)
+
+    async def tracked_close() -> None:
+        lifecycle_events.append("close")
+
+    monkeypatch.setattr(connection, "get_pool", tracked_get_pool)
+    monkeypatch.setattr(connection, "close", tracked_close)
+    agent = Agent(TestModel(call_tools=[]), capabilities=[capability])
+
+    async with agent:
+        assert lifecycle_events == ["open"]
+        await agent.run("First query")
+        await agent.run("Second query")
+        assert lifecycle_events == ["open"]
+
+    assert lifecycle_events == ["open", "close"]
+
+
+@pytest.mark.asyncio
+async def test_owned_registry_cleanup_errors_propagate(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database_path = tmp_path / "cleanup-error.sqlite"
+    database_path.touch()
+    capability = SqlTools(database=str(database_path))
+    connection = capability.registry.get(capability.registry.primary()).connection
+
+    async def failing_close() -> None:
+        raise RuntimeError("database cleanup failed")
+
+    monkeypatch.setattr(connection, "close", failing_close)
+    agent = Agent(TestModel(call_tools=[]), capabilities=[capability])
+
+    with pytest.raises(RuntimeError, match="database cleanup failed"):
+        async with agent:
+            await agent.run("Hello")
+
+
+@pytest.mark.asyncio
 async def test_borrowed_registry_is_not_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- reference-count nested pydantic-ai toolset entries
- keep owned registries open across repeated runs inside an agent context
- close only on the outermost exit and propagate cleanup errors

## Stack
Part 9 of 12. Base: `fix/plugin-version-floor`; child: `fix/sql-toolset-init-cleanup`.

## Validation
- pytest
- Ruff
- ty check