### PR TITLE
fix: clean up partial database initialization

### DIFF
--- a/src/sqlsaber/capabilities/sql_tools.py
+++ b/src/sqlsaber/capabilities/sql_tools.py
@@ -40,9 +40,26 @@ class _SqlToolset(FunctionToolset[Any]):
 
     async def __aenter__(self) -> Self:
         await super().__aenter__()
-        if self._owned and self._entry_count == 0:
-            for entry in self._registry:
-                await entry.connection.get_pool()
+        try:
+            if self._owned and self._entry_count == 0:
+                for entry in self._registry:
+                    await entry.connection.get_pool()
+        except BaseException as init_error:
+            try:
+                await self._registry.close()
+            except BaseException as cleanup_error:
+                init_error.add_note(
+                    f"Database cleanup also failed: {cleanup_error!r}"
+                )
+            try:
+                await super().__aexit__(
+                    type(init_error), init_error, init_error.__traceback__
+                )
+            except BaseException as cleanup_error:
+                init_error.add_note(
+                    f"Toolset cleanup also failed: {cleanup_error!r}"
+                )
+            raise
         self._entry_count += 1
         return self
 

--- a/tests/test_capabilities/test_sql_tools.py
+++ b/tests/test_capabilities/test_sql_tools.py
@@ -110,6 +110,56 @@ async def test_owned_registry_stays_open_across_nested_agent_runs(
 
 
 @pytest.mark.asyncio
+async def test_partial_owned_registry_initialization_is_cleaned_up(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_path = tmp_path / "first.sqlite"
+    second_path = tmp_path / "second.sqlite"
+    first_path.touch()
+    second_path.touch()
+    capability = SqlTools(database=[str(first_path), str(second_path)])
+    first, second = list(capability.registry)
+    lifecycle_events: list[str] = []
+
+    class PoolInitializationError(RuntimeError):
+        pass
+
+    init_error = PoolInitializationError()
+
+    async def open_first() -> str:
+        lifecycle_events.append("open:first")
+        return str(first_path)
+
+    async def fail_second() -> str:
+        lifecycle_events.append("open:second")
+        raise init_error
+
+    async def close_first() -> None:
+        lifecycle_events.append("close:first")
+
+    async def close_second() -> None:
+        lifecycle_events.append("close:second")
+
+    monkeypatch.setattr(first.connection, "get_pool", open_first)
+    monkeypatch.setattr(first.connection, "close", close_first)
+    monkeypatch.setattr(second.connection, "get_pool", fail_second)
+    monkeypatch.setattr(second.connection, "close", close_second)
+    agent = Agent(TestModel(call_tools=[]), capabilities=[capability])
+
+    with pytest.raises(PoolInitializationError) as caught:
+        async with agent:
+            pass
+
+    assert caught.value is init_error
+    assert lifecycle_events == [
+        "open:first",
+        "open:second",
+        "close:first",
+        "close:second",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_owned_registry_cleanup_errors_propagate(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- close already-opened database pools when a later owned connection fails to initialize
- balance the underlying toolset context and preserve the original initialization error
- add partial multi-database initialization coverage

## Stack
Part 10 of 12. Base: `fix/sql-toolset-lifecycle`; child: `fix/tui-display-registry`.

## Validation
- pytest
- Ruff
- ty check