### PR TITLE
fix: resolve TUI display registry after agent rebuilds

### DIFF
--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -529,9 +529,9 @@ class InteractiveSession:
         self.streaming_handler = TUIStreamingQueryHandler(
             app,
             self.console,
-            getattr(self.sqlsaber_agent, "display_registry", None)
-            if hasattr(self, "sqlsaber_agent")
-            else None,
+            display_registry_provider=lambda: getattr(
+                getattr(self, "sqlsaber_agent", None), "display_registry", None
+            ),
         )
         self.show_welcome_message(app)
 

--- a/src/sqlsaber/cli/tui_streaming.py
+++ b/src/sqlsaber/cli/tui_streaming.py
@@ -41,6 +41,9 @@ class TUIStreamingQueryHandler:
         app: ChatApp,
         console: Console,
         display_registry: Mapping[str, Tool] | None = None,
+        *,
+        display_registry_provider: Callable[[], Mapping[str, Tool] | None]
+        | None = None,
     ):
         self.app = app
         self.console = console
@@ -52,6 +55,7 @@ class TUIStreamingQueryHandler:
         self._replay_messages: list | None = None
         self._cancellation_token: asyncio.Event | None = None
         self._display_registry = display_registry
+        self._display_registry_provider = display_registry_provider
 
     async def _event_stream_handler(
         self, ctx: RunContext, event_stream: AsyncIterable[AgentStreamEvent]
@@ -157,9 +161,14 @@ class TUIStreamingQueryHandler:
         if tool_name == "execute_sql":
             self.app.set_loading("Generating SQL...")
 
+    def _resolve_display_registry(self) -> Mapping[str, Tool] | None:
+        if self._display_registry_provider is not None:
+            return self._display_registry_provider()
+        return self._display_registry
+
     def _append_display(self, render: Callable[[DisplayManager], None]) -> None:
         def capture(console: Console) -> None:
-            display = DisplayManager(console, self._display_registry)
+            display = DisplayManager(console, self._resolve_display_registry())
             if self._replay_messages is not None:
                 display.set_replay_messages(self._replay_messages)
             render(display)

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -649,6 +649,23 @@ def test_user_message_render_reuses_cached_theme_styles(monkeypatch) -> None:
     assert component.render(80) == first
 
 
+def test_streaming_handler_resolves_current_display_registry() -> None:
+    terminal = FakeTerminal(columns=80, rows=12)
+    app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
+    first_registry = {}
+    second_registry = {}
+    current = {"registry": first_registry}
+    handler = TUIStreamingQueryHandler(
+        app,
+        create_console(file=StringIO(), width=80, legacy_windows=False),
+        display_registry_provider=lambda: current["registry"],
+    )
+
+    assert handler._resolve_display_registry() is first_registry
+    current["registry"] = second_registry
+    assert handler._resolve_display_registry() is second_registry
+
+
 @pytest.mark.asyncio
 async def test_streaming_handler_freezes_markdown_on_part_end(monkeypatch) -> None:
     terminal = FakeTerminal(columns=80, rows=12)


### PR DESCRIPTION
## Summary
- resolve display tools from the current managed agent at render time
- prevent stale stateful plugin renderers after changing thinking settings
- add dynamic display registry coverage

## Stack
Part 11 of 12. Base: `fix/sql-toolset-init-cleanup`; child: `docs/adaptive-anthropic-thinking`.

## Validation
- pytest
- Ruff
- ty check