### PR TITLE
docs: note adaptive Anthropic thinking support

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -14,7 +14,7 @@ All notable changes to SQLsaber will be documented here.
 - Replaces the `sqlsaber.tools` plugin entry-point group with `sqlsaber.capabilities`. Plugin authors must export a `capability(context)` factory; see the [plugin porting guide](/guides/plugins#building-a-plugin).
 - Removes `ToolRegistry`, `ToolRunDeps`, and the unused `SQLSaberOptions.tools`, `providers`, and `hooks` placeholders. Tool overrides remain available through `SQLSaberOptions.tool_overrides` and are delivered when plugin capabilities are constructed.
 - Delivers the system prompt as non-persisted pydantic-ai instructions and uses one provider-neutral persona. Existing custom system prompts still replace SQLsaber's built-in persona and SQL guidance.
-- Maps thinking levels through pydantic-ai's unified `Thinking` capability. Anthropic thinking budgets may differ from earlier SQLsaber versions because provider-specific token budgets are no longer set by SQLsaber.
+- Maps thinking levels through pydantic-ai's unified `Thinking` capability. Anthropic support now targets newer models with adaptive thinking; SQLsaber no longer configures legacy `budget_tokens` or related `max_tokens` headroom itself.
 - Inherits pydantic-ai v2's graceful end strategy: function calls emitted beside a final text response execute instead of being skipped.
 
 ---


### PR DESCRIPTION
## Summary
- document that SQLSaber now targets newer Anthropic models with adaptive thinking
- clarify that SQLSaber no longer manages legacy thinking budgets or max-token headroom

## Stack
Part 12 of 12. Base: `fix/tui-display-registry`.

## Validation
- documentation diff check