### PR TITLE
fix(release): update lockfiles in release PRs

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,28 +6,76 @@
       "release-type": "python",
       "component": "sqlsaber",
       "changelog-path": "docs/src/content/docs/changelog.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber')].version"
+        },
+        {
+          "type": "toml",
+          "path": "plugins/notebook/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber')].version"
+        }
+      ]
     },
     "plugins/viz": {
       "package-name": "sqlsaber-viz",
       "release-type": "python",
       "component": "sqlsaber-viz",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-viz')].version"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-viz')].version"
+        }
+      ]
     },
     "plugins/notebook": {
       "package-name": "sqlsaber-notebook",
       "release-type": "python",
       "component": "sqlsaber-notebook",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-notebook')].version"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-notebook')].version"
+        }
+      ]
     },
     "plugins/sandbox": {
       "package-name": "sqlsaber-sandbox",
       "release-type": "python",
       "component": "sqlsaber-sandbox",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "/uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-sandbox')].version"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='sqlsaber-sandbox')].version"
+        }
+      ]
     }
   },
   "separate-pull-requests": true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,39 +49,3 @@ jobs:
             esac
             gh workflow run publish.yml -f tag="$TAG"
           done
-
-      - name: Install uv
-        if: steps.release.outputs.prs_created == 'true'
-        uses: astral-sh/setup-uv@v5
-
-      - name: Update lockfiles
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Get the PR branch name from the release-please output
-          PR_DATA='${{ steps.release.outputs.prs }}'
-          if [ -n "$PR_DATA" ] && [ "$PR_DATA" != "[]" ]; then
-            BRANCH=$(echo "$PR_DATA" | jq -r '.[0].headBranchName')
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-
-            # Update root lockfile
-            uv lock
-
-            # Update plugin lockfiles
-            for plugin_dir in plugins/*/; do
-              if [ -f "$plugin_dir/pyproject.toml" ]; then
-                (cd "$plugin_dir" && uv lock)
-              fi
-            done
-
-            # Commit and push if there are changes
-            if ! git diff --quiet; then
-              git config user.name "github-actions[bot]"
-              git config user.email "github-actions[bot]@users.noreply.github.com"
-              git add uv.lock plugins/*/uv.lock
-              git commit -m "chore: update lockfiles"
-              git push origin "$BRANCH"
-            fi
-          fi

--- a/tests/test_release_configuration.py
+++ b/tests/test_release_configuration.py
@@ -32,7 +32,7 @@ def test_release_please_updates_lockfiles_atomically() -> None:
             for extra_file in package["extra-files"]
         }
 
-        assert {str(path) for path in lockfile_entries} == expected_lockfiles
+        assert {path.as_posix() for path in lockfile_entries} == expected_lockfiles
 
         for lockfile_path, extra_file in lockfile_entries.items():
             assert extra_file["type"] == "toml"

--- a/tests/test_release_configuration.py
+++ b/tests/test_release_configuration.py
@@ -1,0 +1,51 @@
+import json
+import tomllib
+from pathlib import Path
+from typing import Any
+
+_REPOSITORY_ROOT = Path(__file__).parents[1]
+_CONFIG_PATH = _REPOSITORY_ROOT / ".github" / "release-please-config.json"
+_EXPECTED_LOCKFILES = {
+    ".": {"uv.lock", "plugins/notebook/uv.lock"},
+    "plugins/notebook": {"uv.lock", "plugins/notebook/uv.lock"},
+    "plugins/sandbox": {"uv.lock", "plugins/sandbox/uv.lock"},
+    "plugins/viz": {"uv.lock", "plugins/viz/uv.lock"},
+}
+
+
+def _repository_path(package_path: str, extra_file_path: str) -> Path:
+    if extra_file_path.startswith("/"):
+        return Path(extra_file_path.removeprefix("/"))
+    if package_path == ".":
+        return Path(extra_file_path)
+    return Path(package_path) / extra_file_path
+
+
+def test_release_please_updates_lockfiles_atomically() -> None:
+    config: dict[str, Any] = json.loads(_CONFIG_PATH.read_text())
+
+    for package_path, expected_lockfiles in _EXPECTED_LOCKFILES.items():
+        package = config["packages"][package_path]
+        package_name = package["package-name"]
+        lockfile_entries = {
+            _repository_path(package_path, extra_file["path"]): extra_file
+            for extra_file in package["extra-files"]
+        }
+
+        assert {str(path) for path in lockfile_entries} == expected_lockfiles
+
+        for lockfile_path, extra_file in lockfile_entries.items():
+            assert extra_file["type"] == "toml"
+            # release-please's formatting-preserving TOML parser wraps scalar
+            # values, so filters address the wrapped name through `.value`.
+            assert extra_file["jsonpath"] == (
+                f"$.package[?(@.name.value=='{package_name}')].version"
+            )
+
+            lockfile = tomllib.loads((_REPOSITORY_ROOT / lockfile_path).read_text())
+            matching_packages = [
+                locked_package
+                for locked_package in lockfile["package"]
+                if locked_package["name"] == package_name
+            ]
+            assert len(matching_packages) == 1


### PR DESCRIPTION
## Summary
- update package versions in root and package lockfiles as part of Release Please's generated commit
- remove the post-processing job that only handled the first release PR and attempted to resolve unpublished packages
- test every package-to-lockfile mapping

## Validation
- `uv run pytest -q` (1125 passed, 3 skipped)
- `uv run ruff check .`
- `uvx ty check tests/test_release_configuration.py`
- verified each configured TOML update with Release Please's GenericToml updater
