### PR TITLE
feat: add durable query result storage

### DIFF
--- a/docs/src/content/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/guides/plugins.mdx
@@ -126,8 +126,12 @@ def capability(context: PluginContext):
 ```
 
 The factory receives a `PluginContext` containing SQLsaber's database registry,
-knowledge manager, dangerous-mode setting, normalized tool model overrides, and any
-application-owned artifact publisher.
+knowledge manager, dangerous-mode setting, normalized tool model overrides, the
+session's required `query_result_store`, and any application-owned artifact
+publisher. Plugins that consume SQL rows should use
+`query_result_references_from_messages()` and `resolve_query_result()` instead of
+parsing `execute_sql` content; this provides verified complete bytes, current-context
+authorization, and the compatibility-only legacy fallback.
 It can return one capability or a sequence. See the [Capabilities SDK guide](/sdk/capabilities) for standalone composition and lifecycle details.
 
 :::caution[Plugin API change]

--- a/docs/src/content/docs/guides/threads.md
+++ b/docs/src/content/docs/guides/threads.md
@@ -7,6 +7,18 @@ SQLsaber automatically saves your conversations locally so that you can view, re
 
 Threads allow you to pick up where you left off and track your analytical work over time.
 
+Complete SQL row results are stored separately under SQLsaber's private user-data
+`query-results` directory; thread messages retain only stable bounded model
+projections and opaque descriptors. Show, export, resume, visualization, sandbox,
+and notebook paths hydrate complete data from that store without rewriting thread
+history. Terminal and HTML views may still intentionally render a bounded table.
+
+Thread retention is the source of truth for CLI result retention. After pruning,
+SQLsaber removes unreferenced entries older than a 24-hour safety grace period.
+Normal saves run the same maintenance at most daily. If an entry was deleted or is
+corrupt, replay shows the bounded preview with a “complete result unavailable”
+notice rather than presenting the preview as complete.
+
 ### Show All Threads
 
 View all your conversation threads:

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -34,6 +34,7 @@ options = SQLSaberOptions(
 | `extra_capabilities` | `Sequence[AbstractCapability[Any]]`           | `()`    | Add pydantic-ai capabilities to the managed agent (see [Capabilities](/sdk/capabilities)).   |
 | `artifact_publisher` | `ArtifactPublisher \| None`                    | `None`  | Persist capability artifacts such as analysis notebooks and plots.                           |
 | `artifact_failure_mode` | `"required" \| "best_effort"`            | `"required"` | Fail the tool or retain its answer when artifact publication fails.                      |
+| `query_result_store` | `QueryResultStore \| None` | `None` | Store for complete SQL row results. Defaults to a session-owned in-memory store. Inject application storage for durable or tenant-scoped retrieval. |
 | `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)).                            |
 | `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL (see [Advanced](/sdk/advanced)).       |
 
@@ -42,6 +43,20 @@ options = SQLSaberOptions(
   have sensible defaults. For many use cases just `database` (plus credentials in
   your environment) is enough.
 </Aside>
+
+## Query result storage
+
+Every successful row-returning query writes its complete canonical JSON payload to
+`query_result_store`. The model and message history receive only a stable 12 KiB
+projection. An injected store is application-owned and SQLsaber does not close it.
+The SDK default is in-memory; the CLI explicitly uses private filesystem storage.
+A storage failure makes that row-returning tool call fail rather than silently
+claiming complete data is available.
+
+For web applications, implement `QueryResultStore.put/get` over a private database
+or object store. Authorize `get` from current identity in
+`QueryResultContext.metadata`; do not authorize solely from possession of a result
+ID, filename, or historical conversation metadata.
 
 ## Choosing a database
 

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -22,6 +22,10 @@ The SDK exposes its primary agent and capability building blocks from the top-le
 | `ArtifactPublisher` | Protocol for persisting notebooks, plots, and other capability artifacts. |
 | `FilesystemArtifactPublisher` | Local durable artifact publisher for servers and development. |
 | `InMemoryArtifactPublisher` | In-memory artifact publisher for tests and short-lived workflows. |
+| `QueryResultStore` | Protocol for private complete SQL result storage and retrieval. |
+| `InMemoryQueryResultStore` | Session-local SDK default and test implementation. |
+| `FilesystemQueryResultStore` | Durable private local implementation (the CLI uses this explicitly). |
+| `StoredQueryResult` / `LoadedQueryResult` | Serializable descriptor and verified complete result bytes. |
 
 See [Capabilities](/sdk/capabilities) to use SQLsaber inside your own agent or add your capabilities to its managed agent. See [Results & Streaming](/sdk/results-and-streaming#persisting-notebooks-and-plots) for artifact publishing.
 

--- a/docs/src/content/docs/sdk/results-and-streaming.mdx
+++ b/docs/src/content/docs/sdk/results-and-streaming.mdx
@@ -24,7 +24,40 @@ print(result.messages)   # messages from this run (incl. tool calls / SQL)
 | `.usage`        | Token usage statistics for the run.                                      |
 | `.messages`     | New messages produced by this run, including tool calls and SQL.         |
 | `.all_messages` | The full message history, including any prior turns you passed in.       |
+| `.query_results` | Durable complete-query-result descriptors created during this run.      |
 | `.artifacts`    | Durable artifact references published by capabilities during this run.   |
+
+## Retrieving complete query results
+
+Complete rows are deliberately absent from model history. Use the descriptors on
+the result and retrieve bytes through the configured store:
+
+```python
+result = await saber.query(
+    "Return daily revenue",
+    conversation_id="conversation-123",
+    metadata={"tenant_id": "acme"},
+)
+
+for descriptor in result.query_results:
+    loaded = await saber.get_query_result(
+        descriptor,
+        conversation_id="conversation-123",
+        metadata={"tenant_id": "acme"},
+    )
+    print(loaded.rows())
+```
+
+These are separate concepts:
+
+- **complete result availability** means every row returned by SQLsaber remains
+  retrievable through the store;
+- **UI rendering policy** may show a bounded terminal or HTML table; and
+- **model projection** is a deterministic, byte-bounded preview and must not be
+  used for whole-dataset statistics when marked truncated.
+
+Legacy threads containing embedded complete rows remain readable during the
+compatibility window, but are not automatically imported into durable storage.
 
 ## Persisting notebooks and plots
 
@@ -107,6 +140,8 @@ async def on_event(
 ) -> None:
     async for event in events:
         print(event)
+        # execute_sql FunctionToolResultEvent parts expose the bounded projection
+        # in part.content and the descriptor in part.metadata["query_result"].
 
 
 result = await saber.query(
@@ -120,6 +155,17 @@ result = await saber.query(
   <a href="https://ai.pydantic.dev/">pydantic-ai</a>, which powers SQLsaber's
   agent. Refer to its docs for the full event taxonomy.
 </Aside>
+
+A web backend can detect `part.metadata["query_result"]`, emit a
+`query-result-created` SSE event containing the ID/columns/row count, and serve an
+authorized paginated or download endpoint separately. SQLsaber never creates a
+public URL. A typical production store writes descriptor and tenant ownership
+columns to PostgreSQL and stores payload bytes in a private `bytea` column (or an
+object key for private blob storage). Its `get` implementation should query by both
+`result_id` and the current `tenant_id` from `QueryResultContext.metadata`, then
+raise `QueryResultUnavailable` for both missing and unauthorized rows. Apply
+application retention, encryption, audit, and deletion policies there; filesystem
+storage is not suitable for horizontally scaled web deployments.
 
 ## Multi-turn conversations
 

--- a/plugins/notebook/src/sqlsaber_notebook/capability.py
+++ b/plugins/notebook/src/sqlsaber_notebook/capability.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import io
-import json
 import re
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
@@ -29,6 +28,17 @@ from sqlsaber.artifacts import (
 )
 from sqlsaber.capabilities.base import SqlSaberCapability
 from sqlsaber.capabilities.plugins import PluginContext
+from sqlsaber.query_result_resolution import (
+    find_query_result_reference,
+    query_result_context_from_run,
+    query_result_references_from_messages,
+    resolve_query_result,
+)
+from sqlsaber.query_results import (
+    InMemoryQueryResultStore,
+    QueryResultStore,
+    QueryResultUnavailable,
+)
 from sqlsaber.tools.base import Tool
 from sqlsaber.utils.json_utils import json_dumps
 
@@ -93,7 +103,15 @@ class AnalyzeDataTool(Tool):
         """
 
         try:
-            workspace = build_workspace_from_history(ctx, only=files)
+            workspace = await build_workspace_from_history(
+                ctx,
+                only=files,
+                query_result_store=getattr(
+                    self._context,
+                    "query_result_store",
+                    InMemoryQueryResultStore(),
+                ),
+            )
             model_name, model, provider = self._context.resolve_subagent_model(
                 "notebook",
                 tool_name=self.name,
@@ -290,27 +308,13 @@ def _artifact_bundle(
     )
 
 
-def build_workspace_from_history(
+async def build_workspace_from_history(
     ctx: RunContext,
     only: list[str] | None,
+    *,
+    query_result_store: QueryResultStore,
 ) -> Workspace:
-    """Build a bounded workspace from successful execute_sql history."""
-
-    queries_by_id: dict[str, str] = {}
-    for message in ctx.messages:
-        for part in getattr(message, "parts", []):
-            if (
-                getattr(part, "part_kind", "") not in ("tool-call", "builtin-tool-call")
-                or getattr(part, "tool_name", "") != "execute_sql"
-            ):
-                continue
-            tool_call_id = getattr(part, "tool_call_id", None)
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                continue
-            args = _args_as_dict(part)
-            query = args.get("query")
-            if isinstance(query, str) and query.strip():
-                queries_by_id[tool_call_id] = query
+    """Build a bounded workspace from validated complete execute_sql results."""
 
     requested = _normalize_requested_files(only)
     if requested is not None and len(requested) > MAX_WORKSPACE_FILES:
@@ -320,76 +324,63 @@ def build_workspace_from_history(
             phase="input-validation",
         )
 
-    eligible: OrderedDict[str, tuple[bytes, ManifestEntry]] = OrderedDict()
-    eligible_bytes = 0
-    done = False
-    for message in reversed(ctx.messages):
-        for part in reversed(getattr(message, "parts", [])):
-            if (
-                getattr(part, "part_kind", "")
-                not in ("tool-return", "builtin-tool-return")
-                or getattr(part, "tool_name", "") != "execute_sql"
-            ):
-                continue
-            tool_call_id = getattr(part, "tool_call_id", None)
-            if not isinstance(tool_call_id, str) or not tool_call_id:
-                continue
-            payload = _payload_as_dict(getattr(part, "content", None))
-            if payload is None or payload.get("success") is not True:
-                continue
-            if "results" not in payload:
-                continue
-            key = payload.get("file")
-            expected_key = f"result_{tool_call_id}.json"
-            if (
-                not isinstance(key, str)
-                or key != expected_key
-                or not _RESULT_FILE_PATTERN.fullmatch(key)
-                or key in eligible
-                or (requested is not None and key not in requested)
-            ):
-                continue
-            data = json_dumps(payload).encode("utf-8")
-            _validate_file_size(key, data)
-            if eligible_bytes + len(data) > MAX_WORKSPACE_TOTAL_BYTES:
-                if requested is not None:
-                    raise NotebookLimitExceeded(
-                        f"Workspace exceeds {MAX_WORKSPACE_TOTAL_BYTES} total bytes",
-                        backend="notebook",
-                        phase="input-validation",
-                    )
-                done = True
-                break
-            eligible[key] = (
-                data,
-                ManifestEntry(file=key, sql=queries_by_id.get(tool_call_id)),
-            )
-            eligible_bytes += len(data)
-            done = (
-                len(eligible) >= MAX_DEFAULT_RESULTS
-                if requested is None
-                else len(eligible) == len(requested)
-            )
-            if done:
-                break
-        if done:
-            break
-
-    if requested is not None:
-        missing = [key for key in requested if key not in eligible]
+    if requested is None:
+        references = list(reversed(query_result_references_from_messages(ctx.messages)))
+        references = references[:MAX_DEFAULT_RESULTS]
+    else:
+        references = []
+        missing: list[str] = []
+        for file in requested:
+            reference = find_query_result_reference(ctx.messages, file)
+            if reference is None:
+                missing.append(file)
+            else:
+                references.append(reference)
         if missing:
             raise ValueError(
                 "Requested SQL result files were not found: " + ", ".join(missing)
             )
-        selected = [(key, *eligible[key]) for key in requested]
-    else:
-        selected = [(key, data, manifest) for key, (data, manifest) in eligible.items()]
 
-    if not selected:
+    if not references:
         raise ValueError(
             "No successful row-returning execute_sql results are available to analyze"
         )
 
+    selected: list[tuple[str, bytes, ManifestEntry]] = []
+    total_bytes = 0
+    for reference in references:
+        try:
+            resolved = await resolve_query_result(
+                reference,
+                store=query_result_store,
+                context=query_result_context_from_run(ctx),
+            )
+        except QueryResultUnavailable as exc:
+            raise ValueError(
+                f"Complete SQL result is unavailable: {reference.file}"
+            ) from exc
+        _validate_file_size(reference.file, resolved.data)
+        if total_bytes + len(resolved.data) > MAX_WORKSPACE_TOTAL_BYTES:
+            if requested is not None:
+                raise NotebookLimitExceeded(
+                    f"Workspace exceeds {MAX_WORKSPACE_TOTAL_BYTES} total bytes",
+                    backend="notebook",
+                    phase="input-validation",
+                )
+            break
+        selected.append(
+            (
+                reference.file,
+                resolved.data,
+                ManifestEntry(file=reference.file, sql=reference.query),
+            )
+        )
+        total_bytes += len(resolved.data)
+
+    if not selected:
+        raise ValueError(
+            "No complete execute_sql results fit within the notebook workspace limits"
+        )
     files = tuple(NotebookInput(key, data) for key, data, _ in selected)
     manifest = tuple(entry for _, _, entry in selected)
     _validate_workspace(files)
@@ -438,38 +429,6 @@ def _validate_file_size(key: str, data: bytes) -> None:
             backend="notebook",
             phase="input-validation",
         )
-
-
-def _args_as_dict(part: object) -> dict[str, Any]:
-    method = getattr(part, "args_as_dict", None)
-    if callable(method):
-        try:
-            value = method()
-        except ValueError:
-            return {}
-        return value if isinstance(value, dict) else {}
-    args = getattr(part, "args", None)
-    if isinstance(args, dict):
-        return args
-    if isinstance(args, str):
-        try:
-            parsed = json.loads(args)
-        except json.JSONDecodeError:
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
-
-
-def _payload_as_dict(content: object) -> dict[str, Any] | None:
-    if isinstance(content, dict):
-        return cast(dict[str, Any], content)
-    if not isinstance(content, str):
-        return None
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
 
 
 def _error_result(

--- a/plugins/notebook/tests/test_notebook_capability.py
+++ b/plugins/notebook/tests/test_notebook_capability.py
@@ -28,6 +28,7 @@ from sqlsaber_notebook.execution import NotebookBackendUnavailable
 from sqlsaber_notebook.result import AnalysisResult, ArtifactRef
 
 from sqlsaber.artifacts import InMemoryArtifactPublisher
+from sqlsaber.query_results import InMemoryQueryResultStore
 
 
 def _ctx(messages: list[Any], *, tool_call_id: str = "analysis-call") -> Any:
@@ -89,7 +90,8 @@ def _png_bytes() -> bytes:
     return buffer.getvalue()
 
 
-def test_workspace_selects_newest_successful_selects_and_pairs_sql() -> None:
+@pytest.mark.asyncio
+async def test_workspace_selects_newest_successful_selects_and_pairs_sql() -> None:
     messages = [
         *_sql_exchange(
             "old",
@@ -125,7 +127,11 @@ def test_workspace_selects_newest_successful_selects_and_pairs_sql() -> None:
         ),
     ]
 
-    workspace = build_workspace_from_history(_ctx(messages), only=None)
+    workspace = await build_workspace_from_history(
+        _ctx(messages),
+        only=None,
+        query_result_store=InMemoryQueryResultStore(),
+    )
 
     assert [item.name for item in workspace.files] == [
         "result_new.json",
@@ -138,7 +144,8 @@ def test_workspace_selects_newest_successful_selects_and_pairs_sql() -> None:
     assert json.loads(workspace.files[0].data)["results"] == [{"value": 2}]
 
 
-def test_workspace_explicit_selection_is_ordered_and_all_or_error() -> None:
+@pytest.mark.asyncio
+async def test_workspace_explicit_selection_is_ordered_and_all_or_error() -> None:
     messages = [
         *_sql_exchange(
             "one",
@@ -152,8 +159,10 @@ def test_workspace_explicit_selection_is_ordered_and_all_or_error() -> None:
         ),
     ]
 
-    workspace = build_workspace_from_history(
-        _ctx(messages), only=["result_one.json", "result_two.json"]
+    workspace = await build_workspace_from_history(
+        _ctx(messages),
+        only=["result_one.json", "result_two.json"],
+        query_result_store=InMemoryQueryResultStore(),
     )
     assert [item.name for item in workspace.files] == [
         "result_one.json",
@@ -161,12 +170,15 @@ def test_workspace_explicit_selection_is_ordered_and_all_or_error() -> None:
     ]
 
     with pytest.raises(ValueError, match="not found: result_missing.json"):
-        build_workspace_from_history(
-            _ctx(messages), only=["result_one.json", "result_missing.json"]
+        await build_workspace_from_history(
+            _ctx(messages),
+            only=["result_one.json", "result_missing.json"],
+            query_result_store=InMemoryQueryResultStore(),
         )
 
 
-def test_workspace_rejects_forged_or_invalid_requested_keys() -> None:
+@pytest.mark.asyncio
+async def test_workspace_rejects_invalid_requested_keys() -> None:
     messages = _sql_exchange(
         "real",
         "select 1",
@@ -176,11 +188,19 @@ def test_workspace_rejects_forged_or_invalid_requested_keys() -> None:
             "file": "result_different.json",
         },
     )
-    with pytest.raises(ValueError, match="No successful row-returning"):
-        build_workspace_from_history(_ctx(messages), only=None)
+    workspace = await build_workspace_from_history(
+        _ctx(messages),
+        only=None,
+        query_result_store=InMemoryQueryResultStore(),
+    )
+    assert [item.name for item in workspace.files] == ["result_different.json"]
 
     with pytest.raises(ValueError, match="Invalid SQL result file key"):
-        build_workspace_from_history(_ctx(messages), only=["../secret.json"])
+        await build_workspace_from_history(
+            _ctx(messages),
+            only=["../secret.json"],
+            query_result_store=InMemoryQueryResultStore(),
+        )
 
 
 @pytest.mark.asyncio

--- a/plugins/sandbox/src/sqlsaber_sandbox/capability.py
+++ b/plugins/sandbox/src/sqlsaber_sandbox/capability.py
@@ -18,8 +18,8 @@ class Sandbox(SqlSaberCapability):
     id = "sandbox"
     description = "Run Python analysis in a configured remote sandbox."
 
-    def __init__(self) -> None:
-        self.tool = RunPythonTool()
+    def __init__(self, context: PluginContext | None = None) -> None:
+        self.tool = RunPythonTool(getattr(context, "query_result_store", None))
         self._toolset = FunctionToolset[Any](id=self.id)
         self._toolset.add_function(
             self.tool.execute,
@@ -39,7 +39,6 @@ def capability(
     context: PluginContext,
 ) -> AbstractCapability[Any] | Sequence[AbstractCapability[Any]]:
     """Create sandbox tools only when a provider is configured."""
-    del context
     if not sandbox_providers_available():
         return ()
-    return Sandbox()
+    return Sandbox(context)

--- a/plugins/sandbox/src/sqlsaber_sandbox/tools.py
+++ b/plugins/sandbox/src/sqlsaber_sandbox/tools.py
@@ -1,7 +1,6 @@
 """Sandboxed Python execution tools."""
 
 import base64
-import json
 import os
 import re
 import shlex
@@ -10,6 +9,16 @@ from typing import Iterable
 
 from pydantic_ai import RunContext
 
+from sqlsaber.query_result_resolution import (
+    find_query_result_reference,
+    query_result_context_from_run,
+    resolve_query_result,
+)
+from sqlsaber.query_results import (
+    InMemoryQueryResultStore,
+    QueryResultStore,
+    QueryResultUnavailable,
+)
 from sqlsaber.tools.base import Tool
 from sqlsaber.tools.display import (
     DisplayMetadata,
@@ -77,6 +86,14 @@ class RunPythonTool(Tool):
     """Run Python code in a sandboxed environment."""
 
     requires_ctx = True
+
+    def __init__(self, query_result_store: QueryResultStore | None = None) -> None:
+        super().__init__()
+        self.query_result_store = (
+            query_result_store
+            if query_result_store is not None
+            else InMemoryQueryResultStore()
+        )
 
     display_spec = ToolDisplaySpec(
         executing=ExecutingConfig(
@@ -169,24 +186,28 @@ class RunPythonTool(Tool):
                                 "error": "Invalid data file key format.",
                             }
                         )
-                    tool_call_id = file.removeprefix("result_").removesuffix(".json")
-                    payload = _find_tool_output_payload(ctx, tool_call_id)
-                    if payload is None:
+                    try:
+                        reference = find_query_result_reference(ctx.messages, file)
+                        if reference is None:
+                            raise QueryResultUnavailable()
+                        resolved = await resolve_query_result(
+                            reference,
+                            store=self.query_result_store,
+                            context=query_result_context_from_run(ctx),
+                        )
+                    except QueryResultUnavailable:
                         return json_dumps(
-                            {
-                                "error": "Tool output not found in message history.",
-                            }
+                            {"error": "Complete SQL result is unavailable."}
                         )
                     remote_data_path = f"/tmp/{file}"
                     temp_path = None
                     try:
                         with tempfile.NamedTemporaryFile(
-                            mode="w",
+                            mode="wb",
                             suffix=".json",
                             delete=False,
-                            encoding="utf-8",
                         ) as temp_file:
-                            temp_file.write(json_dumps(payload))
+                            temp_file.write(resolved.data)
                             temp_path = temp_file.name
                         await sandbox.upload(temp_path, remote_data_path)
                     finally:
@@ -227,27 +248,3 @@ class RunPythonTool(Tool):
                 )
         except Exception as exc:  # pragma: no cover - defensive catch-all
             return json_dumps({"error": f"Python sandbox execution failed: {exc}"})
-
-
-def _find_tool_output_payload(ctx: RunContext, tool_call_id: str) -> dict | None:
-    for message in reversed(ctx.messages):
-        for part in getattr(message, "parts", []):
-            if getattr(part, "part_kind", "") not in (
-                "tool-return",
-                "builtin-tool-return",
-            ):
-                continue
-            if getattr(part, "tool_call_id", None) != tool_call_id:
-                continue
-            content = getattr(part, "content", None)
-            if isinstance(content, dict):
-                return content
-            if isinstance(content, str):
-                try:
-                    parsed = json.loads(content)
-                except json.JSONDecodeError:
-                    return {"result": content}
-                if isinstance(parsed, dict):
-                    return parsed
-                return {"result": parsed}
-    return None

--- a/plugins/viz/src/sqlsaber_viz/capability.py
+++ b/plugins/viz/src/sqlsaber_viz/capability.py
@@ -18,7 +18,7 @@ class Visualization(SqlSaberCapability):
     description = "Generate a chart from the result of an SQL query."
 
     def __init__(self, context: PluginContext) -> None:
-        self.tool = VizTool()
+        self.tool = VizTool(context.query_result_store)
         self.tool.model_overide = context.tool_overrides.get(self.tool.name)
         self._toolset = FunctionToolset[Any](id=self.id)
         self._toolset.add_function(

--- a/plugins/viz/src/sqlsaber_viz/tools.py
+++ b/plugins/viz/src/sqlsaber_viz/tools.py
@@ -14,6 +14,16 @@ from rich.console import Console
 from rich.text import Text
 
 from sqlsaber.overrides import ModelOverides
+from sqlsaber.query_result_resolution import (
+    find_query_result_reference,
+    query_result_context_from_run,
+    resolve_query_result,
+)
+from sqlsaber.query_results import (
+    InMemoryQueryResultStore,
+    QueryResultStore,
+    QueryResultUnavailable,
+)
 from sqlsaber.tools.base import Tool
 from sqlsaber.utils.json_utils import json_dumps
 
@@ -35,8 +45,13 @@ class VizTool(Tool):
 
     requires_ctx = True
 
-    def __init__(self):
+    def __init__(self, query_result_store: QueryResultStore | None = None):
         super().__init__()
+        self.query_result_store = (
+            query_result_store
+            if query_result_store is not None
+            else InMemoryQueryResultStore()
+        )
         self._last_ctx: RunContext | None = None
         self._last_rows: list[dict] | None = None
         self._last_file: str | None = None
@@ -77,10 +92,24 @@ class VizTool(Tool):
         if not file or not TOOL_OUTPUT_FILE_PATTERN.match(file):
             return json_dumps({"error": "Invalid result file key format."})
 
-        tool_call_id = file.removeprefix("result_").removesuffix(".json")
-        payload = find_tool_output_payload(ctx, tool_call_id)
-        if payload is None:
-            return json_dumps({"error": "Tool output not found in message history."})
+        try:
+            reference = find_query_result_reference(ctx.messages, file)
+            if reference is None:
+                # Compatibility for early ad-hoc histories that omitted execute_sql
+                # tool metadata but still embedded complete rows.
+                tool_call_id = file.removeprefix("result_").removesuffix(".json")
+                payload = find_tool_output_payload(ctx, tool_call_id)
+                if payload is None or not isinstance(payload.get("results"), list):
+                    raise QueryResultUnavailable()
+            else:
+                resolved = await resolve_query_result(
+                    reference,
+                    store=self.query_result_store,
+                    context=query_result_context_from_run(ctx),
+                )
+                payload = resolved.payload()
+        except QueryResultUnavailable:
+            return json_dumps({"error": "Complete SQL result is unavailable."})
 
         summary = extract_data_summary(payload)
         columns = summary.get("columns", [])

--- a/src/sqlsaber/__init__.py
+++ b/src/sqlsaber/__init__.py
@@ -17,6 +17,17 @@ if TYPE_CHECKING:
     from .capabilities import Knowledge, SqlTools
     from .options import SQLSaberOptions
     from .overrides import ModelOverides
+    from .query_results import (
+        FilesystemQueryResultStore,
+        InMemoryQueryResultStore,
+        LoadedQueryResult,
+        QueryResultContext,
+        QueryResultData,
+        QueryResultId,
+        QueryResultStore,
+        QueryResultUnavailable,
+        StoredQueryResult,
+    )
 
 __all__ = [
     "Artifact",
@@ -26,12 +37,21 @@ __all__ = [
     "ArtifactPublisher",
     "FilesystemArtifactPublisher",
     "InMemoryArtifactPublisher",
+    "FilesystemQueryResultStore",
+    "InMemoryQueryResultStore",
     "Knowledge",
+    "LoadedQueryResult",
     "ModelOverides",
+    "QueryResultContext",
+    "QueryResultData",
+    "QueryResultId",
+    "QueryResultStore",
+    "QueryResultUnavailable",
     "SQLSaber",
     "SQLSaberOptions",
     "SqlTools",
     "StoredArtifact",
+    "StoredQueryResult",
 ]
 
 
@@ -58,6 +78,20 @@ def __getattr__(name: str):
         from . import artifacts
 
         return getattr(artifacts, name)
+    if name in {
+        "FilesystemQueryResultStore",
+        "InMemoryQueryResultStore",
+        "LoadedQueryResult",
+        "QueryResultContext",
+        "QueryResultData",
+        "QueryResultId",
+        "QueryResultStore",
+        "QueryResultUnavailable",
+        "StoredQueryResult",
+    }:
+        from . import query_results
+
+        return getattr(query_results, name)
     if name == "ModelOverides":
         from .overrides import ModelOverides
 

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterable, Awaitable, Mapping, Sequence
 from typing import Any, Callable
 
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.capabilities import AbstractCapability, Thinking
+from pydantic_ai.capabilities import AbstractCapability, ProcessHistory, Thinking
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 
@@ -21,6 +21,8 @@ from sqlsaber.database.schema import SchemaManager
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.overrides import ToolOveridesInput, normalize_tool_overides
 from sqlsaber.prompts.persona import PERSONA
+from sqlsaber.query_result_resolution import compact_legacy_query_result_history
+from sqlsaber.query_results import InMemoryQueryResultStore, QueryResultStore
 from sqlsaber.tools.base import Tool
 
 
@@ -58,6 +60,7 @@ class SQLSaberAgent:
         extra_capabilities: Sequence[AbstractCapability[Any]] = (),
         artifact_publisher: ArtifactPublisher | None = None,
         artifact_failure_mode: ArtifactFailureMode = "required",
+        query_result_store: QueryResultStore | None = None,
     ) -> None:
         if registry is None:
             if db_connection is None:
@@ -86,6 +89,11 @@ class SQLSaberAgent:
         self._extra_capabilities = tuple(extra_capabilities)
         self._artifact_publisher = artifact_publisher
         self._artifact_failure_mode = artifact_failure_mode
+        self.query_result_store = (
+            query_result_store
+            if query_result_store is not None
+            else InMemoryQueryResultStore()
+        )
         self.schema_manager: SchemaManager = primary.schema_manager
         self.thinking_enabled = (
             thinking_enabled
@@ -137,6 +145,7 @@ class SQLSaberAgent:
                 registry=self.registry,
                 allow_dangerous=self.allow_dangerous,
                 include_catalog_instructions=include_guidance,
+                query_result_store=self.query_result_store,
             ),
         ]
         capabilities.extend(
@@ -151,10 +160,12 @@ class SQLSaberAgent:
                     main_api_key=api_key,
                     artifact_publisher=self._artifact_publisher,
                     artifact_failure_mode=self._artifact_failure_mode,
+                    query_result_store=self.query_result_store,
                 )
             )
         )
         capabilities.extend(self._extra_capabilities)
+        capabilities.append(ProcessHistory(compact_legacy_query_result_history))
         if self.thinking_enabled:
             capabilities.append(
                 Thinking(effort=UNIFIED_EFFORT_MAP[self.thinking_level])

--- a/src/sqlsaber/api.py
+++ b/src/sqlsaber/api.py
@@ -4,7 +4,7 @@ This module provides a simplified programmatic interface to SQLSaber's capabilit
 allowing you to run natural language queries against databases from Python code.
 """
 
-from collections.abc import AsyncIterable, Awaitable, Sequence
+from collections.abc import AsyncIterable, Awaitable, Mapping, Sequence
 from types import TracebackType
 from typing import Any, Callable, Protocol, Self
 
@@ -13,6 +13,13 @@ from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 
 from sqlsaber.artifacts import StoredArtifact, artifacts_from_metadata
 from sqlsaber.options import SQLSaberOptions
+from sqlsaber.query_result_resolution import query_result_references_from_messages
+from sqlsaber.query_results import (
+    LoadedQueryResult,
+    QueryResultContext,
+    QueryResultStore,
+    StoredQueryResult,
+)
 from sqlsaber.session import SQLSaberSession
 
 
@@ -56,6 +63,15 @@ class SQLSaberResult(str):
     def all_messages(self) -> list[ModelMessage]:
         """All messages including history."""
         return self.run_result.all_messages()
+
+    @property
+    def query_results(self) -> list[StoredQueryResult]:
+        """Durable query results created during this run, in execution order."""
+        return [
+            reference.descriptor
+            for reference in query_result_references_from_messages(self.messages)
+            if reference.descriptor is not None
+        ]
 
     @property
     def artifacts(self) -> list[StoredArtifact]:
@@ -108,6 +124,7 @@ class SQLSaber:
         self.db_name = self._session.db_name
         self.connection = self._session.connection
         self.agent = self._session.agent
+        self.query_result_store: QueryResultStore = self._session.query_result_store
 
     async def query(
         self,
@@ -154,6 +171,23 @@ class SQLSaber:
             content = str(result)
 
         return SQLSaberResult(content, result)
+
+    async def get_query_result(
+        self,
+        result: str | StoredQueryResult,
+        *,
+        conversation_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> LoadedQueryResult:
+        """Retrieve a complete result through the configured authorized store."""
+        result_id = result.id if isinstance(result, StoredQueryResult) else result
+        return await self.query_result_store.get(
+            result_id,
+            context=QueryResultContext(
+                conversation_id=conversation_id,
+                metadata=metadata or {},
+            ),
+        )
 
     async def close(self) -> None:
         """Close the database connection."""

--- a/src/sqlsaber/capabilities/plugins.py
+++ b/src/sqlsaber/capabilities/plugins.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +16,7 @@ from sqlsaber.config.settings import Config
 from sqlsaber.database.registry import DatabaseRegistry
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.overrides import ModelOverides
+from sqlsaber.query_results import InMemoryQueryResultStore, QueryResultStore
 
 if TYPE_CHECKING:
     from sqlsaber.artifacts import ArtifactFailureMode, ArtifactPublisher
@@ -34,6 +35,9 @@ class PluginContext:
     tool_overrides: Mapping[str, ModelOverides]
     config: Config
     main_model_name: str
+    query_result_store: QueryResultStore = field(
+        default_factory=InMemoryQueryResultStore
+    )
     main_api_key: str | None = None
     artifact_publisher: ArtifactPublisher | None = None
     artifact_failure_mode: ArtifactFailureMode = "required"

--- a/src/sqlsaber/capabilities/sql_tools.py
+++ b/src/sqlsaber/capabilities/sql_tools.py
@@ -19,6 +19,7 @@ from sqlsaber.database.registry import DatabaseRegistry
 from sqlsaber.database.resolver import resolve_databases
 from sqlsaber.prompts.dangerous_mode import DANGEROUS_MODE
 from sqlsaber.prompts.sql_guidance import SQL_GUIDANCE, SQL_GUIDANCE_MULTI
+from sqlsaber.query_results import InMemoryQueryResultStore, QueryResultStore
 from sqlsaber.tools.base import Tool
 from sqlsaber.tools.sql_tools import (
     ExecuteSQLTool,
@@ -48,17 +49,13 @@ class _SqlToolset(FunctionToolset[Any]):
             try:
                 await self._registry.close()
             except BaseException as cleanup_error:
-                init_error.add_note(
-                    f"Database cleanup also failed: {cleanup_error!r}"
-                )
+                init_error.add_note(f"Database cleanup also failed: {cleanup_error!r}")
             try:
                 await super().__aexit__(
                     type(init_error), init_error, init_error.__traceback__
                 )
             except BaseException as cleanup_error:
-                init_error.add_note(
-                    f"Toolset cleanup also failed: {cleanup_error!r}"
-                )
+                init_error.add_note(f"Toolset cleanup also failed: {cleanup_error!r}")
             raise
         self._entry_count += 1
         return self
@@ -95,6 +92,7 @@ class SqlTools(SqlSaberCapability):
         registry: DatabaseRegistry | None = None,
         allow_dangerous: bool = False,
         include_catalog_instructions: bool = True,
+        query_result_store: QueryResultStore | None = None,
     ) -> None:
         if registry is not None and database is not None:
             raise ValueError("Pass either `database` or `registry`, not both.")
@@ -111,6 +109,11 @@ class SqlTools(SqlSaberCapability):
             owned = False
 
         self.registry = registry
+        self.query_result_store = (
+            query_result_store
+            if query_result_store is not None
+            else InMemoryQueryResultStore()
+        )
         self.allow_dangerous = allow_dangerous
         self.include_catalog_instructions = include_catalog_instructions
         self._owned = owned
@@ -119,7 +122,7 @@ class SqlTools(SqlSaberCapability):
         tools: list[Tool] = [
             ListTablesTool(),
             IntrospectSchemaTool(),
-            ExecuteSQLTool(),
+            ExecuteSQLTool(query_result_store=self.query_result_store),
         ]
         if len(registry) > 1:
             tools.append(ListDatabasesTool())

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -162,6 +162,7 @@ def query(
         # This is only done to speed up startup time
         from sqlsaber.cli.display import DisplayManager
         from sqlsaber.cli.interactive import InteractiveSession
+        from sqlsaber.cli.query_results import cli_query_result_store
         from sqlsaber.cli.streaming import StreamingQueryHandler
         from sqlsaber.cli.usage import SessionUsage, request_usages_from_run_result
         from sqlsaber.database.resolver import DatabaseResolutionError
@@ -198,6 +199,7 @@ def query(
                     allow_dangerous=allow_dangerous,
                     system_prompt=system_prompt,
                     thread_manager=thread_manager,
+                    query_result_store=cli_query_result_store(),
                 )
             )
             db_name = session.db_name
@@ -214,7 +216,9 @@ def query(
             if actual_query:
                 # Single query mode with streaming
                 streaming_handler = StreamingQueryHandler(
-                    console, session.agent.display_registry
+                    console,
+                    session.agent.display_registry,
+                    session.query_result_store,
                 )
                 db_type = session.agent.db_type
                 model_name = session.agent.config.model.name

--- a/src/sqlsaber/cli/html_export.py
+++ b/src/sqlsaber/cli/html_export.py
@@ -83,7 +83,13 @@ def _human_readable_time(timestamp: float | None) -> str:
     return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp))
 
 
-def render_thread_html(thread: Thread, all_msgs: list[ModelMessage]) -> str:
+def render_thread_html(
+    thread: Thread,
+    all_msgs: list[ModelMessage],
+    *,
+    hydrated_results: dict[str, str] | None = None,
+    unavailable_results: set[str] | None = None,
+) -> str:
     """Generate a standalone HTML document for a thread transcript."""
     title = thread.title or f"SQLsaber thread {thread.id}"
     escaped_title = escape(title)
@@ -625,6 +631,8 @@ def render_thread_html(thread: Thread, all_msgs: list[ModelMessage]) -> str:
                     tool_name = str(getattr(part, "tool_name", "tool"))
                     call_id = getattr(part, "tool_call_id", None)
                     content = getattr(part, "content", None)
+                    if hydrated_results and call_id in hydrated_results:
+                        content = hydrated_results[call_id]
                     if isinstance(content, (dict, list)):
                         content_str = json.dumps(content, ensure_ascii=False, indent=2)
                     elif isinstance(content, str):
@@ -642,6 +650,11 @@ def render_thread_html(thread: Thread, all_msgs: list[ModelMessage]) -> str:
                     result_html = _render_tool_result_html(
                         display, tool_name, content_str, args=tool_args
                     )
+                    if unavailable_results and call_id in unavailable_results:
+                        result_html += (
+                            '<p class="sql-error">Complete query result unavailable; '
+                            "showing preview.</p>"
+                        )
 
                     tool_details_html.append(
                         f"""<details class="tool" open>

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -532,6 +532,9 @@ class InteractiveSession:
             display_registry_provider=lambda: getattr(
                 getattr(self, "sqlsaber_agent", None), "display_registry", None
             ),
+            query_result_store=getattr(
+                getattr(self, "session", None), "query_result_store", None
+            ),
         )
         self.show_welcome_message(app)
 

--- a/src/sqlsaber/cli/query_result_gc.py
+++ b/src/sqlsaber/cli/query_result_gc.py
@@ -1,0 +1,171 @@
+"""Thread-aware mark-and-sweep maintenance for CLI query results."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlsaber.config.logging import get_logger
+from sqlsaber.query_result_resolution import query_result_references_from_messages
+from sqlsaber.query_results import FilesystemQueryResultStore
+from sqlsaber.threads.storage import ThreadStorage
+
+logger = get_logger(__name__)
+DEFAULT_GRACE_SECONDS = 24 * 60 * 60
+SWEEP_INTERVAL_SECONDS = 24 * 60 * 60
+STALE_LOCK_SECONDS = 60 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class QueryResultGCResult:
+    deleted: int = 0
+    skipped: bool = False
+    complete: bool = True
+
+
+async def collect_cli_query_results(
+    thread_storage: ThreadStorage,
+    store: FilesystemQueryResultStore,
+    *,
+    force: bool = False,
+    grace_seconds: float = DEFAULT_GRACE_SECONDS,
+    now: float | None = None,
+) -> QueryResultGCResult:
+    """Delete old unreferenced entries, aborting on any snapshot parse failure."""
+    current = time.time() if now is None else now
+    lock_token = await asyncio.to_thread(_acquire_lock, store.root, current)
+    if lock_token is None:
+        return QueryResultGCResult(skipped=True)
+    return await _collect_locked(
+        thread_storage,
+        store,
+        force=force,
+        grace_seconds=grace_seconds,
+        now=current,
+        lock_token=lock_token,
+    )
+
+
+async def _collect_locked(
+    thread_storage: ThreadStorage,
+    store: FilesystemQueryResultStore,
+    *,
+    force: bool,
+    grace_seconds: float,
+    now: float,
+    lock_token: str,
+) -> QueryResultGCResult:
+    lock_path = store.root / ".maintenance.lock"
+    marker = store.root / ".last-successful-sweep"
+    try:
+        if not force and await asyncio.to_thread(_recent_marker, marker, now):
+            return QueryResultGCResult(skipped=True)
+        try:
+            snapshots = await thread_storage.get_all_thread_messages_strict()
+        except Exception as exc:
+            logger.warning("query_results.gc.snapshot_failed", error=str(exc))
+            return QueryResultGCResult(complete=False)
+
+        live: set[str] = set()
+        for messages in snapshots:
+            for reference in query_result_references_from_messages(messages):
+                if reference.descriptor is not None:
+                    live.add(reference.descriptor.id)
+
+        deleted = 0
+        cutoff = now - grace_seconds
+        for descriptor in await store.iter_descriptors():
+            created_at = descriptor.created_at
+            if descriptor.id in live or created_at is None or created_at >= cutoff:
+                continue
+            await store.delete(descriptor.id)
+            deleted += 1
+        await store.cleanup_stale_workdirs(older_than=cutoff)
+        await asyncio.to_thread(_write_marker, marker, now)
+        return QueryResultGCResult(deleted=deleted)
+    except Exception as exc:
+        logger.warning("query_results.gc.failed", error=str(exc))
+        return QueryResultGCResult(complete=False)
+    finally:
+        await asyncio.to_thread(_release_lock, lock_path, lock_token)
+
+
+def _acquire_lock(root: Path, now: float) -> str | None:
+    for component in [root, *root.parents]:
+        if component.is_symlink():
+            return None
+    if root.exists() and not root.is_dir():
+        return None
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock = root / ".maintenance.lock"
+    token = secrets.token_hex(16)
+    payload = json.dumps(
+        {"pid": os.getpid(), "created_at": now, "token": token}
+    ).encode()
+    for attempt in range(2):
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            if attempt or not _lock_is_stale(lock, now):
+                return None
+            try:
+                lock.unlink()
+            except OSError:
+                return None
+            continue
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        return token
+    return None
+
+
+def _lock_is_stale(path: Path, now: float) -> bool:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return False
+        value = json.loads(path.read_text(encoding="utf-8"))
+        created = value.get("created_at") if isinstance(value, dict) else None
+        return isinstance(created, (int, float)) and now - created > STALE_LOCK_SECONDS
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
+def _release_lock(path: Path, token: str) -> None:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict) or value.get("token") != token:
+            return
+        path.unlink()
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
+def _recent_marker(path: Path, now: float) -> bool:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return False
+        timestamp = float(path.read_text(encoding="ascii"))
+    except (OSError, ValueError):
+        return False
+    return now - timestamp < SWEEP_INTERVAL_SECONDS
+
+
+def _write_marker(path: Path, now: float) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, f"{now:.6f}".encode("ascii"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(temporary, path)

--- a/src/sqlsaber/cli/query_results.py
+++ b/src/sqlsaber/cli/query_results.py
@@ -1,0 +1,51 @@
+"""CLI query-result store construction and asynchronous hydration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import platformdirs
+from pydantic_ai.messages import ModelMessage
+
+from sqlsaber.query_result_resolution import (
+    query_result_references_from_messages,
+    resolve_query_result,
+)
+from sqlsaber.query_results import (
+    FilesystemQueryResultStore,
+    QueryResultContext,
+    QueryResultStore,
+    QueryResultUnavailable,
+)
+
+
+def cli_query_result_store() -> FilesystemQueryResultStore:
+    """Return the persistent store used by all CLI execution/replay paths."""
+    return FilesystemQueryResultStore(
+        Path(platformdirs.user_data_dir("sqlsaber")) / "query-results"
+    )
+
+
+async def hydrate_query_result_contents(
+    messages: list[ModelMessage],
+    *,
+    store: QueryResultStore,
+) -> tuple[dict[str, str], set[str]]:
+    """Preload canonical JSON by tool-call ID without mutating message history."""
+    hydrated: dict[str, str] = {}
+    unavailable: set[str] = set()
+    for reference in query_result_references_from_messages(messages):
+        try:
+            resolved = await resolve_query_result(
+                reference,
+                store=store,
+                context=QueryResultContext(),
+            )
+        except QueryResultUnavailable:
+            unavailable.add(reference.tool_call_id)
+            continue
+        try:
+            hydrated[reference.tool_call_id] = resolved.data.decode("utf-8")
+        except UnicodeDecodeError:
+            unavailable.add(reference.tool_call_id)
+    return hydrated, unavailable

--- a/src/sqlsaber/cli/streaming.py
+++ b/src/sqlsaber/cli/streaming.py
@@ -29,6 +29,13 @@ from rich.console import Console
 
 from sqlsaber.cli.display import DisplayManager
 from sqlsaber.config.logging import get_logger
+from sqlsaber.query_result_resolution import (
+    QueryResultReference,
+    query_result_context_from_run,
+    query_result_from_metadata,
+    resolve_query_result,
+)
+from sqlsaber.query_results import QueryResultStore, QueryResultUnavailable
 from sqlsaber.tools.base import Tool
 
 
@@ -43,10 +50,12 @@ class StreamingQueryHandler:
         self,
         console: Console,
         display_registry: Mapping[str, Tool] | None = None,
+        query_result_store: QueryResultStore | None = None,
     ):
         self.console = console
         self.display = DisplayManager(console, display_registry)
         self.log = get_logger(__name__)
+        self.query_result_store = query_result_store
         self._tool_call_names: dict[int, str] = {}
 
     async def _event_stream_handler(
@@ -134,12 +143,36 @@ class StreamingQueryHandler:
         content = event.part.content
         if tool_name is None:
             return
+        complete_unavailable = False
+        if tool_name == "execute_sql" and self.query_result_store is not None:
+            descriptor = query_result_from_metadata(
+                getattr(event.part, "metadata", None)
+            )
+            if descriptor is not None:
+                reference = QueryResultReference(
+                    tool_call_id=event.part.tool_call_id,
+                    file=descriptor.file,
+                    descriptor=descriptor,
+                )
+                try:
+                    resolved = await resolve_query_result(
+                        reference,
+                        store=self.query_result_store,
+                        context=query_result_context_from_run(ctx),
+                    )
+                    content = resolved.data.decode("utf-8")
+                except (QueryResultUnavailable, UnicodeDecodeError):
+                    complete_unavailable = True
         self.display.show_tool_result(
             tool_name,
             content,
             tool_call_id=event.part.tool_call_id,
             metadata=getattr(event.part, "metadata", None),
         )
+        if complete_unavailable:
+            self.console.print(
+                "[warning]Complete query result unavailable; showing preview.[/warning]"
+            )
         # Add a blank line after tool output to separate from next segment
         self.display.show_newline()
         # Show status while agent sends a follow-up request to the model

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -39,7 +39,12 @@ def _human_readable(timestamp: float | None) -> str:
 
 
 def _render_transcript(
-    console: Console, all_msgs: list[ModelMessage], last_n: int | None = None
+    console: Console,
+    all_msgs: list[ModelMessage],
+    last_n: int | None = None,
+    *,
+    hydrated_results: dict[str, str] | None = None,
+    unavailable_results: set[str] | None = None,
 ) -> None:
     """Render conversation turns from ModelMessage[] using DisplayManager."""
     # Lazy import to avoid pulling UI helpers at startup
@@ -143,13 +148,21 @@ def _render_transcript(
                 dm.show_tool_executing(name, args_dict)
             elif kind in ("tool-return", "builtin-tool-return"):
                 name = getattr(part, "tool_name", "tool")
+                tool_call_id = getattr(part, "tool_call_id", None)
                 content = getattr(part, "content", None)
+                if hydrated_results and tool_call_id in hydrated_results:
+                    content = hydrated_results[tool_call_id]
                 dm.show_tool_result(
                     name,
                     content,
-                    tool_call_id=getattr(part, "tool_call_id", None),
+                    tool_call_id=tool_call_id,
                     metadata=getattr(part, "metadata", None),
                 )
+                if unavailable_results and tool_call_id in unavailable_results:
+                    console.print(
+                        "[warning]Complete query result unavailable; "
+                        "showing preview.[/warning]"
+                    )
         # Thinking parts omitted
 
     for start_idx, end_idx in slices or [(0, len(all_msgs))]:
@@ -214,6 +227,24 @@ def show(
         logger.error("threads.cli.show.not_found", thread_id=thread_id)
         return
     msgs = asyncio.run(store.get_thread_messages(thread_id))
+    from sqlsaber.cli.query_results import (
+        cli_query_result_store,
+        hydrate_query_result_contents,
+    )
+
+    from sqlsaber.query_result_resolution import (
+        query_result_references_from_messages,
+    )
+
+    if any(
+        reference.descriptor is not None
+        for reference in query_result_references_from_messages(msgs)
+    ):
+        hydrated, unavailable = asyncio.run(
+            hydrate_query_result_contents(msgs, store=cli_query_result_store())
+        )
+    else:
+        hydrated, unavailable = {}, set()
     console.print(f"[bold]Thread: {thread.id}[/bold]")
     console.print("")
     console.print(f"Database: {thread.database_name}")
@@ -222,7 +253,16 @@ def show(
     console.print(f"Model: {thread.model_name}")
     console.print("")
 
-    _render_transcript(console, msgs, None)
+    if hydrated or unavailable:
+        _render_transcript(
+            console,
+            msgs,
+            None,
+            hydrated_results=hydrated,
+            unavailable_results=unavailable,
+        )
+    else:
+        _render_transcript(console, msgs, None)
     logger.info("threads.cli.show.complete", thread_id=thread_id)
 
 
@@ -246,6 +286,7 @@ def resume(
     async def _run() -> None:
         # Lazy imports to avoid heavy modules at CLI startup
         from sqlsaber.cli.interactive import InteractiveSession
+        from sqlsaber.cli.query_results import cli_query_result_store
         from sqlsaber.config.database import DatabaseConfigManager
         from sqlsaber.database.resolver import DatabaseResolutionError
         from sqlsaber.options import SQLSaberOptions
@@ -310,6 +351,7 @@ def resume(
                 SQLSaberOptions(
                     database=db_selector,
                     thread_manager=session_thread_manager,
+                    query_result_store=cli_query_result_store(),
                 )
             )
         except DatabaseResolutionError as e:
@@ -329,7 +371,33 @@ def resume(
                 )
             else:
                 console.print(f"# Thread: {thread.id}\n")
-            _render_transcript(console, history, None)
+            from sqlsaber.cli.query_results import hydrate_query_result_contents
+
+            from sqlsaber.query_result_resolution import (
+                query_result_references_from_messages,
+            )
+
+            if any(
+                reference.descriptor is not None
+                for reference in query_result_references_from_messages(history)
+            ):
+                result_store = getattr(
+                    sqlsaber_session,
+                    "query_result_store",
+                    cli_query_result_store(),
+                )
+                hydrated, unavailable = await hydrate_query_result_contents(
+                    history, store=result_store
+                )
+            else:
+                hydrated, unavailable = {}, set()
+            _render_transcript(
+                console,
+                history,
+                None,
+                hydrated_results=hydrated,
+                unavailable_results=unavailable,
+            )
             interactive_session = InteractiveSession(
                 console=console,
                 session=sqlsaber_session,
@@ -362,7 +430,22 @@ def prune(
     async def _run() -> None:
         deleted = await store.prune_threads(older_than_days=days)
         console.print(f"[success]✓ Pruned {deleted} thread(s).[/success]")
-        logger.info("threads.cli.prune.complete", deleted=deleted)
+        from sqlsaber.cli.query_result_gc import collect_cli_query_results
+        from sqlsaber.cli.query_results import cli_query_result_store
+
+        cleanup = await collect_cli_query_results(
+            store, cli_query_result_store(), force=True
+        )
+        if not cleanup.complete:
+            console.print(
+                "[warning]Thread pruning succeeded, but query result cleanup "
+                "was incomplete.[/warning]"
+            )
+        logger.info(
+            "threads.cli.prune.complete",
+            deleted=deleted,
+            query_results_deleted=cleanup.deleted,
+        )
 
     asyncio.run(_run())
 
@@ -397,7 +480,20 @@ def export(
             return
 
         messages = await store.get_thread_messages(thread_id)
-        html = render_thread_html(thread, messages)
+        from sqlsaber.cli.query_results import (
+            cli_query_result_store,
+            hydrate_query_result_contents,
+        )
+
+        hydrated, unavailable = await hydrate_query_result_contents(
+            messages, store=cli_query_result_store()
+        )
+        html = render_thread_html(
+            thread,
+            messages,
+            hydrated_results=hydrated,
+            unavailable_results=unavailable,
+        )
 
         out_path = output or (Path.cwd() / f"thread-{thread.id}.html")
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/sqlsaber/cli/tui_streaming.py
+++ b/src/sqlsaber/cli/tui_streaming.py
@@ -1,6 +1,7 @@
 """pydantic-ai streaming adapter for the persistent saber-tui chat UI."""
 
 import asyncio
+import json
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, AsyncIterable
@@ -27,9 +28,44 @@ from saber_tui.components import Markdown
 from sqlsaber.cli.display import DisplayManager
 from sqlsaber.cli.tui_chat import ChatApp
 from sqlsaber.config.logging import get_logger
+from sqlsaber.query_result_resolution import (
+    QueryResultReference,
+    query_result_context_from_run,
+    query_result_from_metadata,
+    resolve_query_result,
+)
+from sqlsaber.query_results import QueryResultStore, QueryResultUnavailable
 from sqlsaber.tools.base import Tool
-from sqlsaber.tools.sql_tools import ExecuteSQLTool
 from sqlsaber.utils.text_input import sanitize_terminal_text
+
+
+def _fallback_sql_markdown(content: object) -> str | None:
+    """Minimal fallback for embedding tests without a managed display registry."""
+    try:
+        payload = json.loads(content) if isinstance(content, str) else content
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value: dict[str, Any] = {str(key): item for key, item in payload.items()}
+    rows = value.get("results")
+    if not isinstance(rows, list):
+        return "✓ Query completed successfully" if value.get("success") else None
+    if not rows:
+        return "*0 rows returned*"
+    normalized = [row if isinstance(row, dict) else {"value": row} for row in rows]
+    columns = list(dict.fromkeys(key for row in normalized for key in row))
+    lines = [
+        f"**Results ({len(normalized)} rows):**",
+        "",
+        "| " + " | ".join(str(column) for column in columns) + " |",
+        "| " + " | ".join("---" for _ in columns) + " |",
+    ]
+    lines.extend(
+        "| " + " | ".join(str(row.get(column, "")) for column in columns) + " |"
+        for row in normalized[:20]
+    )
+    return "\n".join(lines)
 
 
 class _QueryInterrupted(Exception):
@@ -62,6 +98,7 @@ class TUIStreamingQueryHandler:
         *,
         display_registry_provider: Callable[[], Mapping[str, Tool] | None]
         | None = None,
+        query_result_store: QueryResultStore | None = None,
     ):
         self.app = app
         self.console = console
@@ -79,6 +116,7 @@ class TUIStreamingQueryHandler:
         self._cancellation_token: asyncio.Event | None = None
         self._display_registry = display_registry
         self._display_registry_provider = display_registry_provider
+        self.query_result_store = query_result_store
 
     async def _event_stream_handler(
         self, ctx: RunContext, event_stream: AsyncIterable[AgentStreamEvent]
@@ -90,12 +128,14 @@ class TUIStreamingQueryHandler:
                 messages = getattr(ctx, "messages", None)
                 if isinstance(messages, list):
                     self._replay_messages = messages
-                await self.on_event(event)
+                await self.on_event(event, ctx)
                 self._raise_if_cancelled()
         finally:
             self._reset_response_stream_state()
 
-    async def on_event(self, event: AgentStreamEvent) -> None:
+    async def on_event(
+        self, event: AgentStreamEvent, ctx: RunContext | None = None
+    ) -> None:
         if isinstance(event, PartStartEvent):
             self._on_part_start(event)
         elif isinstance(event, PartDeltaEvent):
@@ -110,7 +150,7 @@ class TUIStreamingQueryHandler:
         elif isinstance(event, FunctionToolCallEvent):
             self._on_tool_call(event)
         elif isinstance(event, FunctionToolResultEvent):
-            self._on_tool_result(event)
+            await self._on_tool_result(event, ctx)
 
     def _on_part_start(self, event: PartStartEvent) -> None:
         previous = self._take_replaced_component(event.index)
@@ -195,21 +235,57 @@ class TUIStreamingQueryHandler:
         if event.part.tool_name == "viz":
             self.app.set_loading("Generating visualization...")
 
-    def _on_tool_result(self, event: FunctionToolResultEvent) -> None:
+    async def _on_tool_result(
+        self, event: FunctionToolResultEvent, ctx: RunContext | None
+    ) -> None:
         tool_name = event.part.tool_name
         if tool_name is None:
             self.app.clear_status()
             return
+        content = event.part.content
+        complete_unavailable = False
+        if (
+            tool_name == "execute_sql"
+            and ctx is not None
+            and self.query_result_store is not None
+        ):
+            descriptor = query_result_from_metadata(
+                getattr(event.part, "metadata", None)
+            )
+            if descriptor is not None:
+                reference = QueryResultReference(
+                    tool_call_id=event.part.tool_call_id,
+                    file=descriptor.file,
+                    descriptor=descriptor,
+                )
+                try:
+                    resolved = await resolve_query_result(
+                        reference,
+                        store=self.query_result_store,
+                        context=query_result_context_from_run(ctx),
+                    )
+                    content = resolved.data.decode("utf-8")
+                except (QueryResultUnavailable, UnicodeDecodeError):
+                    complete_unavailable = True
         if tool_name == "execute_sql":
-            markdown = ExecuteSQLTool().render_result_markdown(event.part.content)
+            registry = self._resolve_display_registry() or {}
+            renderer = registry.get("execute_sql")
+            render_markdown = getattr(renderer, "render_result_markdown", None)
+            markdown = (
+                render_markdown(content)
+                if callable(render_markdown)
+                else _fallback_sql_markdown(content)
+            )
             if markdown is not None:
+                if complete_unavailable:
+                    markdown += "\n\n*Complete result unavailable; showing preview.*"
                 self.app.append_markdown(markdown)
                 self.app.set_loading("Crunching data...")
                 return
         self._append_display(
             lambda display: display.show_tool_result(
                 tool_name,
-                event.part.content,
+                content,
                 tool_call_id=event.part.tool_call_id,
                 metadata=getattr(event.part, "metadata", None),
             )

--- a/src/sqlsaber/options.py
+++ b/src/sqlsaber/options.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from sqlsaber.artifacts import ArtifactFailureMode, ArtifactPublisher
     from sqlsaber.config.settings import Config
     from sqlsaber.knowledge.manager import KnowledgeManager
+    from sqlsaber.query_results import QueryResultStore
     from sqlsaber.threads.manager import ThreadManager
 
 
@@ -42,6 +43,7 @@ class SQLSaberOptions:
     extra_capabilities: Sequence[AbstractCapability[Any]] = ()
     artifact_publisher: ArtifactPublisher | None = None
     artifact_failure_mode: ArtifactFailureMode = "required"
+    query_result_store: QueryResultStore | None = None
 
     # Tool overrides
     tool_overrides: ToolOveridesInput | None = None

--- a/src/sqlsaber/query_result_resolution.py
+++ b/src/sqlsaber/query_result_resolution.py
@@ -1,0 +1,321 @@
+"""Resolve complete SQL results from message-scoped, model-facing references."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Any, Literal
+
+from pydantic_ai.messages import ModelMessage
+
+from sqlsaber.query_results import (
+    QueryResultContext,
+    QueryResultStore,
+    QueryResultUnavailable,
+    StoredQueryResult,
+    build_model_projection,
+    descriptor_for_data,
+    logical_result_file,
+    validate_loaded_query_result,
+)
+from sqlsaber.utils.json_utils import json_dumps
+
+
+@dataclass(frozen=True, slots=True)
+class QueryResultReference:
+    tool_call_id: str
+    file: str
+    descriptor: StoredQueryResult | None
+    query: str | None = None
+    legacy_data: bytes | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedQueryResult:
+    reference: QueryResultReference
+    descriptor: StoredQueryResult | None
+    data: bytes
+    source: Literal["store", "legacy"]
+
+    def payload(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise QueryResultUnavailable() from exc
+        if not isinstance(value, dict):
+            raise QueryResultUnavailable()
+        return value
+
+
+def query_result_from_metadata(metadata: object) -> StoredQueryResult | None:
+    if not isinstance(metadata, dict) or "query_result" not in metadata:
+        return None
+    values: dict[str, object] = {str(key): value for key, value in metadata.items()}
+    return StoredQueryResult.from_dict(values.get("query_result"))
+
+
+def _args_as_dict(part: object) -> dict[str, Any]:
+    method = getattr(part, "args_as_dict", None)
+    if callable(method):
+        try:
+            value = method()
+        except (TypeError, ValueError):
+            return {}
+        return value if isinstance(value, dict) else {}
+    args = getattr(part, "args", None)
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        try:
+            value = json.loads(args)
+        except json.JSONDecodeError:
+            return {}
+        return value if isinstance(value, dict) else {}
+    return {}
+
+
+def _payload_as_dict(content: object) -> dict[str, Any] | None:
+    if isinstance(content, dict):
+        return {str(key): value for key, value in content.items()}
+    if not isinstance(content, str):
+        return None
+    try:
+        value = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def query_result_references_from_messages(
+    messages: Sequence[ModelMessage],
+) -> list[QueryResultReference]:
+    """Scan execute_sql returns in execution order and pair them to SQL calls."""
+
+    queries: dict[str, str] = {}
+    for message in messages:
+        for part in getattr(message, "parts", ()):
+            if (
+                getattr(part, "part_kind", "") not in ("tool-call", "builtin-tool-call")
+                or getattr(part, "tool_name", "") != "execute_sql"
+            ):
+                continue
+            call_id = getattr(part, "tool_call_id", None)
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            query = _args_as_dict(part).get("query")
+            if isinstance(query, str) and query.strip():
+                queries[call_id] = query
+
+    references: list[QueryResultReference] = []
+    seen_ids: set[str] = set()
+    seen_legacy_calls: set[str] = set()
+    for message in messages:
+        for part in getattr(message, "parts", ()):
+            if (
+                getattr(part, "part_kind", "")
+                not in ("tool-return", "builtin-tool-return")
+                or getattr(part, "tool_name", "") != "execute_sql"
+            ):
+                continue
+            call_id = getattr(part, "tool_call_id", None)
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            metadata = getattr(part, "metadata", None)
+            descriptor = query_result_from_metadata(metadata)
+            if isinstance(metadata, dict) and "query_result" in metadata:
+                # Descriptor-bearing metadata is authoritative. Malformed metadata is
+                # deliberately not interpreted as a legacy full result.
+                if descriptor is None or descriptor.id in seen_ids:
+                    continue
+                seen_ids.add(descriptor.id)
+                references.append(
+                    QueryResultReference(
+                        tool_call_id=call_id,
+                        file=descriptor.file,
+                        descriptor=descriptor,
+                        query=queries.get(call_id),
+                    )
+                )
+                continue
+
+            payload = _payload_as_dict(getattr(part, "content", None))
+            if (
+                payload is None
+                or payload.get("success") is not True
+                or not isinstance(payload.get("results"), list)
+                or call_id in seen_legacy_calls
+            ):
+                continue
+            file = payload.get("file")
+            if not isinstance(file, str):
+                file = logical_result_file(call_id, f"qr_{'0' * 32}")
+            try:
+                data = json_dumps(payload, ensure_ascii=False).encode("utf-8")
+            except (TypeError, ValueError):
+                continue
+            seen_legacy_calls.add(call_id)
+            references.append(
+                QueryResultReference(
+                    tool_call_id=call_id,
+                    file=file,
+                    descriptor=None,
+                    query=queries.get(call_id),
+                    legacy_data=data,
+                )
+            )
+    return references
+
+
+def find_query_result_reference(
+    messages: Sequence[ModelMessage],
+    selector: str,
+) -> QueryResultReference | None:
+    references = query_result_references_from_messages(messages)
+    matches = [
+        reference
+        for reference in references
+        if selector
+        in {
+            reference.tool_call_id,
+            reference.file,
+            reference.descriptor.id if reference.descriptor else "",
+        }
+    ]
+    if not matches:
+        return None
+    identities = {
+        reference.descriptor.id
+        if reference.descriptor is not None
+        else f"legacy:{reference.tool_call_id}"
+        for reference in matches
+    }
+    if len(identities) != 1:
+        raise QueryResultUnavailable()
+    return matches[-1]
+
+
+async def resolve_query_result(
+    reference: QueryResultReference,
+    *,
+    store: QueryResultStore,
+    context: QueryResultContext,
+) -> ResolvedQueryResult:
+    """Resolve and verify complete bytes without trusting historical auth context."""
+
+    descriptor = reference.descriptor
+    if descriptor is None:
+        if reference.legacy_data is None:
+            raise QueryResultUnavailable()
+        # Re-parse to ensure compatibility data still represents a successful,
+        # complete old payload.
+        try:
+            payload = json.loads(reference.legacy_data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise QueryResultUnavailable() from exc
+        if (
+            not isinstance(payload, dict)
+            or payload.get("success") is not True
+            or not isinstance(payload.get("results"), list)
+        ):
+            raise QueryResultUnavailable()
+        return ResolvedQueryResult(
+            reference=reference,
+            descriptor=None,
+            data=bytes(reference.legacy_data),
+            source="legacy",
+        )
+
+    try:
+        loaded = await store.get(descriptor.id, context=context)
+        validate_loaded_query_result(loaded, expected=descriptor)
+    except QueryResultUnavailable:
+        raise
+    except Exception as exc:
+        raise QueryResultUnavailable() from exc
+    return ResolvedQueryResult(
+        reference=reference,
+        descriptor=loaded.descriptor,
+        data=bytes(loaded.data),
+        source="store",
+    )
+
+
+def query_result_context_from_run(ctx: object) -> QueryResultContext:
+    metadata = getattr(ctx, "metadata", None)
+    return QueryResultContext(
+        run_id=getattr(ctx, "run_id", None),
+        conversation_id=getattr(ctx, "conversation_id", None),
+        tool_call_id=getattr(ctx, "tool_call_id", None),
+        metadata=metadata if isinstance(metadata, dict) else {},
+    )
+
+
+async def compact_legacy_query_result_history(
+    messages: list[ModelMessage],
+) -> list[ModelMessage]:
+    """Deterministically compact complete pre-store SQL returns for model requests."""
+
+    compacted: list[ModelMessage] = []
+    for message in messages:
+        changed = False
+        parts: list[Any] = []
+        for part in getattr(message, "parts", ()):
+            if (
+                getattr(part, "part_kind", "") != "tool-return"
+                or getattr(part, "tool_name", "") != "execute_sql"
+                or (
+                    isinstance(getattr(part, "metadata", None), dict)
+                    and "query_result" in getattr(part, "metadata")
+                )
+            ):
+                parts.append(part)
+                continue
+            payload = _payload_as_dict(getattr(part, "content", None))
+            rows = payload.get("results") if payload else None
+            if (
+                payload is None
+                or payload.get("success") is not True
+                or not isinstance(rows, list)
+            ):
+                parts.append(part)
+                continue
+            canonical = json_dumps(payload, ensure_ascii=False).encode("utf-8")
+            call_id = str(getattr(part, "tool_call_id", "legacy"))
+            digest = hashlib.sha256(call_id.encode() + b"\0" + canonical).hexdigest()
+            result_id = f"qr_{digest[:32]}"
+            file = payload.get("file")
+            if not isinstance(file, str):
+                file = logical_result_file(call_id, result_id)
+            columns: list[str] = []
+            seen: set[str] = set()
+            for row in rows:
+                keys = row.keys() if isinstance(row, dict) else ("value",)
+                for key in keys:
+                    name = str(key)
+                    if name not in seen:
+                        seen.add(name)
+                        columns.append(name)
+            descriptor = descriptor_for_data(
+                canonical,
+                result_id=result_id,
+                file=file,
+                row_count=len(rows),
+                columns=tuple(columns),
+                created_at=None,
+            )
+            projection = build_model_projection(payload, descriptor)
+            parts.append(
+                replace(
+                    part,
+                    content=json_dumps(
+                        projection,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                )
+            )
+            changed = True
+        compacted.append(replace(message, parts=parts) if changed else message)
+    return compacted

--- a/src/sqlsaber/query_results.py
+++ b/src/sqlsaber/query_results.py
@@ -1,0 +1,700 @@
+"""Durable, immutable storage for complete SQL query results."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from sqlsaber.utils.json_utils import json_dumps
+
+QueryResultId = str
+QUERY_RESULT_MEDIA_TYPE = "application/vnd.sqlsaber.query-result+json"
+QUERY_RESULT_SCHEMA_VERSION = 1
+MAX_MODEL_QUERY_RESULT_BYTES = 12 * 1024
+MAX_CANONICAL_QUERY_RESULT_BYTES = 100 * 1024 * 1024
+_RESULT_ID_RE = re.compile(r"^qr_[a-f0-9]{32}$")
+_RESULT_FILE_RE = re.compile(r"^result_[A-Za-z0-9._-]{1,180}\.json$")
+
+
+class QueryResultUnavailable(Exception):
+    """A query result is missing, unauthorized, malformed, or corrupt.
+
+    The intentionally uniform public message does not disclose whether an ID exists.
+    """
+
+    def __init__(self, message: str = "Query result is unavailable.") -> None:
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryResultContext:
+    run_id: str | None = None
+    conversation_id: str | None = None
+    tool_call_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryResultData:
+    data: bytes
+    media_type: str = QUERY_RESULT_MEDIA_TYPE
+
+
+@dataclass(frozen=True, slots=True)
+class StoredQueryResult:
+    id: str
+    file: str
+    media_type: str
+    size: int
+    sha256: str
+    row_count: int
+    columns: tuple[str, ...]
+    database_name: str | None = None
+    created_at: float | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "id": self.id,
+            "file": self.file,
+            "media_type": self.media_type,
+            "size": self.size,
+            "sha256": self.sha256,
+            "row_count": self.row_count,
+            "columns": list(self.columns),
+        }
+        if self.database_name is not None:
+            value["database_name"] = self.database_name
+        if self.created_at is not None:
+            value["created_at"] = self.created_at
+        return value
+
+    @classmethod
+    def from_dict(cls, value: object) -> StoredQueryResult | None:
+        if not isinstance(value, dict):
+            return None
+        raw: dict[str, object] = {str(key): item for key, item in value.items()}
+        try:
+            result_id = raw["id"]
+            file = raw["file"]
+            media_type = raw["media_type"]
+            size = raw["size"]
+            digest = raw["sha256"]
+            row_count = raw["row_count"]
+            columns = raw["columns"]
+        except KeyError:
+            return None
+        if not isinstance(result_id, str) or not valid_query_result_id(result_id):
+            return None
+        if not isinstance(file, str) or not valid_query_result_file(file):
+            return None
+        if not isinstance(media_type, str) or media_type != QUERY_RESULT_MEDIA_TYPE:
+            return None
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            return None
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(char not in "0123456789abcdef" for char in digest)
+        ):
+            return None
+        if (
+            not isinstance(row_count, int)
+            or isinstance(row_count, bool)
+            or row_count < 0
+        ):
+            return None
+        if not isinstance(columns, (list, tuple)) or any(
+            not isinstance(column, str) for column in columns
+        ):
+            return None
+        database_name = raw.get("database_name")
+        if database_name is not None and not isinstance(database_name, str):
+            return None
+        created_at = raw.get("created_at")
+        if created_at is not None and (
+            not isinstance(created_at, (int, float)) or isinstance(created_at, bool)
+        ):
+            return None
+        return cls(
+            id=result_id,
+            file=file,
+            media_type=media_type,
+            size=size,
+            sha256=digest,
+            row_count=row_count,
+            columns=tuple(str(column) for column in columns),
+            database_name=database_name,
+            created_at=float(created_at) if created_at is not None else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedQueryResult:
+    descriptor: StoredQueryResult
+    data: bytes
+
+    def payload(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise QueryResultUnavailable() from exc
+        if not isinstance(value, dict):
+            raise QueryResultUnavailable()
+        return value
+
+    def rows(self) -> list[dict[str, Any]]:
+        value = self.payload().get("results")
+        if not isinstance(value, list):
+            raise QueryResultUnavailable()
+        rows: list[dict[str, Any]] = []
+        for row in value:
+            if isinstance(row, dict):
+                rows.append({str(key): item for key, item in row.items()})
+            else:
+                rows.append({"value": row})
+        return rows
+
+
+@runtime_checkable
+class QueryResultStore(Protocol):
+    async def put(
+        self,
+        result: QueryResultData,
+        *,
+        descriptor: StoredQueryResult,
+        context: QueryResultContext,
+    ) -> StoredQueryResult: ...
+
+    async def get(
+        self,
+        result_id: str,
+        *,
+        context: QueryResultContext,
+    ) -> LoadedQueryResult: ...
+
+
+def new_query_result_id() -> str:
+    return f"qr_{secrets.token_hex(16)}"
+
+
+def valid_query_result_id(value: str) -> bool:
+    return _RESULT_ID_RE.fullmatch(value) is not None
+
+
+def valid_query_result_file(value: str) -> bool:
+    return (
+        _RESULT_FILE_RE.fullmatch(value) is not None
+        and Path(value).name == value
+        and value not in {".", ".."}
+    )
+
+
+def logical_result_file(tool_call_id: str | None, result_id: str) -> str:
+    if tool_call_id and re.fullmatch(r"[A-Za-z0-9._-]{1,180}", tool_call_id):
+        return f"result_{tool_call_id}.json"
+    return f"result_{result_id}.json"
+
+
+def query_result_columns(rows: list[object]) -> tuple[str, ...]:
+    columns: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        keys = row.keys() if isinstance(row, Mapping) else ("value",)
+        for key in keys:
+            name = str(key)
+            if name not in seen:
+                seen.add(name)
+                columns.append(name)
+    return tuple(columns)
+
+
+def descriptor_for_data(
+    data: bytes,
+    *,
+    result_id: str,
+    file: str,
+    row_count: int,
+    columns: tuple[str, ...],
+    database_name: str | None = None,
+    created_at: float | None = None,
+    media_type: str = QUERY_RESULT_MEDIA_TYPE,
+) -> StoredQueryResult:
+    return StoredQueryResult(
+        id=result_id,
+        file=file,
+        media_type=media_type,
+        size=len(data),
+        sha256=hashlib.sha256(data).hexdigest(),
+        row_count=row_count,
+        columns=columns,
+        database_name=database_name,
+        created_at=created_at,
+    )
+
+
+def _validated_authoritative_descriptor(
+    result: QueryResultData, descriptor: StoredQueryResult
+) -> StoredQueryResult:
+    if StoredQueryResult.from_dict(descriptor.to_dict()) is None:
+        raise QueryResultUnavailable()
+    if not valid_query_result_id(descriptor.id):
+        raise QueryResultUnavailable()
+    if not valid_query_result_file(descriptor.file):
+        raise QueryResultUnavailable()
+    if result.media_type != QUERY_RESULT_MEDIA_TYPE:
+        raise QueryResultUnavailable()
+    if len(result.data) > MAX_CANONICAL_QUERY_RESULT_BYTES:
+        raise QueryResultUnavailable("Query result exceeds the storage size limit.")
+    return replace(
+        descriptor,
+        media_type=result.media_type,
+        size=len(result.data),
+        sha256=hashlib.sha256(result.data).hexdigest(),
+        created_at=(
+            descriptor.created_at if descriptor.created_at is not None else time.time()
+        ),
+    )
+
+
+def validate_loaded_query_result(
+    loaded: LoadedQueryResult,
+    *,
+    expected: StoredQueryResult | None = None,
+) -> LoadedQueryResult:
+    descriptor = loaded.descriptor
+    if StoredQueryResult.from_dict(descriptor.to_dict()) is None:
+        raise QueryResultUnavailable()
+    if len(loaded.data) != descriptor.size:
+        raise QueryResultUnavailable()
+    if hashlib.sha256(loaded.data).hexdigest() != descriptor.sha256:
+        raise QueryResultUnavailable()
+    if expected is not None and (
+        descriptor.id != expected.id
+        or descriptor.file != expected.file
+        or descriptor.media_type != expected.media_type
+        or descriptor.size != expected.size
+        or descriptor.sha256 != expected.sha256
+    ):
+        raise QueryResultUnavailable()
+    return loaded
+
+
+class InMemoryQueryResultStore:
+    """Session-local immutable query result storage."""
+
+    def __init__(self) -> None:
+        self._results: dict[str, LoadedQueryResult] = {}
+        self._lock = asyncio.Lock()
+
+    async def put(
+        self,
+        result: QueryResultData,
+        *,
+        descriptor: StoredQueryResult,
+        context: QueryResultContext,
+    ) -> StoredQueryResult:
+        del context
+        authoritative = _validated_authoritative_descriptor(result, descriptor)
+        async with self._lock:
+            if authoritative.id in self._results:
+                raise QueryResultUnavailable()
+            self._results[authoritative.id] = LoadedQueryResult(
+                authoritative, bytes(result.data)
+            )
+        return authoritative
+
+    async def get(
+        self,
+        result_id: str,
+        *,
+        context: QueryResultContext,
+    ) -> LoadedQueryResult:
+        del context
+        if not valid_query_result_id(result_id):
+            raise QueryResultUnavailable()
+        async with self._lock:
+            loaded = self._results.get(result_id)
+        if loaded is None:
+            raise QueryResultUnavailable()
+        return validate_loaded_query_result(
+            LoadedQueryResult(loaded.descriptor, bytes(loaded.data))
+        )
+
+
+class FilesystemQueryResultStore:
+    """Crash-aware immutable filesystem storage used by the SQLsaber CLI."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root).expanduser().absolute()
+
+    def _entry_path(self, result_id: str) -> Path:
+        if not valid_query_result_id(result_id):
+            raise QueryResultUnavailable()
+        return self.root / result_id[3:5] / result_id
+
+    async def put(
+        self,
+        result: QueryResultData,
+        *,
+        descriptor: StoredQueryResult,
+        context: QueryResultContext,
+    ) -> StoredQueryResult:
+        authoritative = _validated_authoritative_descriptor(result, descriptor)
+        try:
+            return await asyncio.to_thread(
+                self._put_sync, result.data, authoritative, context
+            )
+        except asyncio.CancelledError:
+            raise
+        except QueryResultUnavailable:
+            raise
+        except Exception as exc:
+            raise QueryResultUnavailable() from exc
+
+    def _put_sync(
+        self,
+        data: bytes,
+        descriptor: StoredQueryResult,
+        context: QueryResultContext,
+    ) -> StoredQueryResult:
+        self._ensure_root()
+        shard = self.root / descriptor.id[3:5]
+        self._ensure_directory(shard)
+        final = shard / descriptor.id
+        if final.exists() or final.is_symlink():
+            raise QueryResultUnavailable()
+        temporary = shard / f".tmp-{descriptor.id}-{secrets.token_hex(8)}"
+        try:
+            temporary.mkdir(mode=0o700)
+            result_path = temporary / "result.json"
+            manifest_path = temporary / "manifest.json"
+            self._write_durable(result_path, data)
+            manifest = {
+                "schema_version": QUERY_RESULT_SCHEMA_VERSION,
+                "descriptor": descriptor.to_dict(),
+                "context": {
+                    key: value
+                    for key, value in {
+                        "run_id": context.run_id,
+                        "conversation_id": context.conversation_id,
+                        "tool_call_id": context.tool_call_id,
+                    }.items()
+                    if value is not None
+                },
+            }
+            self._write_durable(
+                manifest_path,
+                json_dumps(manifest, ensure_ascii=False, sort_keys=True).encode(
+                    "utf-8"
+                ),
+            )
+            self._fsync_directory(temporary)
+            os.rename(temporary, final)
+            self._fsync_directory(shard)
+        except BaseException:
+            shutil.rmtree(temporary, ignore_errors=True)
+            raise
+        return descriptor
+
+    async def get(
+        self,
+        result_id: str,
+        *,
+        context: QueryResultContext,
+    ) -> LoadedQueryResult:
+        del context
+        try:
+            return await asyncio.to_thread(self._get_sync, result_id)
+        except QueryResultUnavailable:
+            raise
+        except Exception as exc:
+            raise QueryResultUnavailable() from exc
+
+    def _get_sync(self, result_id: str) -> LoadedQueryResult:
+        self._validate_root()
+        entry = self._entry_path(result_id)
+        self._require_directory(entry.parent)
+        self._require_directory(entry)
+        manifest_path = entry / "manifest.json"
+        result_path = entry / "result.json"
+        try:
+            names = {child.name for child in entry.iterdir()}
+        except OSError as exc:
+            raise QueryResultUnavailable() from exc
+        if names != {"manifest.json", "result.json"}:
+            raise QueryResultUnavailable()
+        try:
+            manifest = json.loads(self._read_regular_file(manifest_path))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise QueryResultUnavailable() from exc
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("schema_version") != QUERY_RESULT_SCHEMA_VERSION
+        ):
+            raise QueryResultUnavailable()
+        descriptor = StoredQueryResult.from_dict(manifest.get("descriptor"))
+        if descriptor is None or descriptor.id != result_id:
+            raise QueryResultUnavailable()
+        try:
+            data = self._read_regular_file(result_path)
+        except OSError as exc:
+            raise QueryResultUnavailable() from exc
+        return validate_loaded_query_result(LoadedQueryResult(descriptor, data))
+
+    async def iter_descriptors(self) -> list[StoredQueryResult]:
+        try:
+            return await asyncio.to_thread(self._iter_descriptors_sync)
+        except Exception as exc:
+            raise QueryResultUnavailable() from exc
+
+    def _iter_descriptors_sync(self) -> list[StoredQueryResult]:
+        if not self.root.exists():
+            return []
+        self._validate_root()
+        descriptors: list[StoredQueryResult] = []
+        for shard in self.root.iterdir():
+            if shard.name.startswith("."):
+                continue
+            try:
+                self._require_directory(shard)
+            except QueryResultUnavailable:
+                continue
+            for entry in shard.iterdir():
+                if entry.name.startswith((".tmp-", ".tombstone-")):
+                    continue
+                if not valid_query_result_id(entry.name):
+                    continue
+                try:
+                    descriptors.append(self._get_sync(entry.name).descriptor)
+                except QueryResultUnavailable:
+                    continue
+        return descriptors
+
+    async def delete(self, result_id: str) -> None:
+        try:
+            await asyncio.to_thread(self._delete_sync, result_id)
+        except FileNotFoundError:
+            return
+        except QueryResultUnavailable:
+            raise
+        except Exception as exc:
+            raise QueryResultUnavailable() from exc
+
+    async def cleanup_stale_workdirs(self, *, older_than: float) -> None:
+        try:
+            await asyncio.to_thread(self._cleanup_stale_workdirs_sync, older_than)
+        except Exception as exc:
+            raise QueryResultUnavailable() from exc
+
+    def _cleanup_stale_workdirs_sync(self, older_than: float) -> None:
+        if not self.root.exists():
+            return
+        self._validate_root()
+        for shard in self.root.iterdir():
+            try:
+                self._require_directory(shard)
+            except QueryResultUnavailable:
+                continue
+            for entry in shard.iterdir():
+                if not entry.name.startswith((".tmp-", ".tombstone-")):
+                    continue
+                try:
+                    info = entry.lstat()
+                except OSError:
+                    continue
+                if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                    continue
+                if info.st_mtime < older_than:
+                    shutil.rmtree(entry, ignore_errors=True)
+
+    def _delete_sync(self, result_id: str) -> None:
+        self._validate_root()
+        entry = self._entry_path(result_id)
+        self._require_directory(entry.parent)
+        if not entry.exists():
+            return
+        self._require_directory(entry)
+        tombstone = entry.parent / f".tombstone-{result_id}-{secrets.token_hex(8)}"
+        os.rename(entry, tombstone)
+        self._fsync_directory(entry.parent)
+        shutil.rmtree(tombstone, ignore_errors=True)
+
+    def _ensure_root(self) -> None:
+        self._reject_symlink_components(self.root)
+        self.root.mkdir(parents=True, mode=0o700, exist_ok=True)
+        self._require_directory(self.root)
+        try:
+            self.root.chmod(0o700)
+        except OSError:
+            pass
+
+    def _validate_root(self) -> None:
+        self._reject_symlink_components(self.root)
+        self._require_directory(self.root)
+
+    @staticmethod
+    def _reject_symlink_components(path: Path) -> None:
+        components = [path, *path.parents]
+        for component in reversed(components):
+            try:
+                mode = component.lstat().st_mode
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise QueryResultUnavailable() from exc
+            if stat.S_ISLNK(mode):
+                raise QueryResultUnavailable()
+
+    @staticmethod
+    def _ensure_directory(path: Path) -> None:
+        if path.is_symlink():
+            raise QueryResultUnavailable()
+        path.mkdir(mode=0o700, exist_ok=True)
+        FilesystemQueryResultStore._require_directory(path)
+        try:
+            path.chmod(0o700)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _require_directory(path: Path) -> None:
+        try:
+            mode = path.lstat().st_mode
+        except OSError as exc:
+            raise QueryResultUnavailable() from exc
+        if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+            raise QueryResultUnavailable()
+
+    @staticmethod
+    def _read_regular_file(path: Path) -> bytes:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise QueryResultUnavailable()
+            with os.fdopen(fd, "rb", closefd=False) as stream:
+                return stream.read()
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _write_durable(path: Path, data: bytes) -> None:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "wb", closefd=False) as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        if not hasattr(os, "O_DIRECTORY"):
+            return
+        try:
+            fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        except OSError:
+            return
+        try:
+            os.fsync(fd)
+        except OSError:
+            pass
+        finally:
+            os.close(fd)
+
+
+def _projection_json(value: Mapping[str, Any]) -> bytes:
+    return json_dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def build_model_projection(
+    canonical_payload: Mapping[str, Any],
+    descriptor: StoredQueryResult,
+    *,
+    max_bytes: int = MAX_MODEL_QUERY_RESULT_BYTES,
+) -> dict[str, Any]:
+    """Build a stable, valid JSON projection within a hard UTF-8 byte budget."""
+
+    if max_bytes < 256:
+        raise ValueError("max_bytes must be at least 256")
+    rows_value = canonical_payload.get("results")
+    rows = rows_value if isinstance(rows_value, list) else []
+    base: dict[str, Any] = {
+        "success": True,
+        "result_id": descriptor.id,
+        "file": descriptor.file,
+        "returned_rows": descriptor.row_count,
+        "columns": list(descriptor.columns),
+    }
+    if canonical_payload.get("auto_limit_applied") is True:
+        base["auto_limit_applied"] = True
+
+    complete = {**base, "results": rows, "results_truncated": False}
+    if len(_projection_json(complete)) <= max_bytes:
+        return complete
+
+    warning = (
+        "Preview only; omitted rows must not be used for whole-dataset statistics. "
+        "Use the result handle with an analysis tool."
+    )
+    projected = {
+        **base,
+        "preview_rows": [],
+        "results_truncated": True,
+        "warning": warning,
+    }
+    if len(_projection_json(projected)) > max_bytes:
+        projected["columns"] = []
+        projected["columns_truncated"] = True
+    if len(_projection_json(projected)) > max_bytes:
+        projected.pop("warning", None)
+        projected["warning"] = (
+            "Preview omitted; use the result handle for complete data."
+        )
+    if len(_projection_json(projected)) > max_bytes:
+        minimal: dict[str, Any] = {
+            "success": True,
+            "result_id": descriptor.id,
+            "file": descriptor.file,
+            "returned_rows": descriptor.row_count,
+            "columns": [],
+            "columns_truncated": True,
+            "preview_rows": [],
+            "results_truncated": True,
+        }
+        if len(_projection_json(minimal)) > max_bytes:
+            raise ValueError("max_bytes is too small for a query result descriptor")
+        projected = minimal
+
+    preview: list[Any] = []
+    for row in rows:
+        candidate = {**projected, "preview_rows": [*preview, row]}
+        if len(_projection_json(candidate)) > max_bytes:
+            break
+        preview.append(row)
+    projected["preview_rows"] = preview
+    if not preview and rows:
+        projected["preview_row_omitted"] = True
+        if len(_projection_json(projected)) > max_bytes:
+            projected.pop("preview_row_omitted")
+    if len(_projection_json(projected)) > max_bytes:  # defensive hard bound
+        raise ValueError("Unable to build a bounded query result projection")
+    return projected

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -17,6 +17,7 @@ from sqlsaber.database.registry import DatabaseRegistry
 from sqlsaber.database.resolver import resolve_databases
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.options import SQLSaberOptions
+from sqlsaber.query_results import InMemoryQueryResultStore
 from sqlsaber.threads.metadata import (
     encode_thread_extra_metadata,
     encode_thread_resume_disabled_metadata,
@@ -59,6 +60,11 @@ class SQLSaberSession:
         self.settings = options.settings or Config.default()
         self.knowledge_manager = options.knowledge_manager or KnowledgeManager()
         self.thread_manager = options.thread_manager
+        self.query_result_store = (
+            options.query_result_store
+            if options.query_result_store is not None
+            else InMemoryQueryResultStore()
+        )
         self._owns_knowledge_manager = options.knowledge_manager is None
 
         resolved_thinking_level: ThinkingLevel | None = None
@@ -88,6 +94,7 @@ class SQLSaberSession:
             extra_capabilities=options.extra_capabilities,
             artifact_publisher=options.artifact_publisher,
             artifact_failure_mode=options.artifact_failure_mode,
+            query_result_store=self.query_result_store,
         )
 
     async def query(
@@ -146,6 +153,18 @@ class SQLSaberSession:
                     model_name=resolved_model_name,
                     extra_metadata=extra_metadata,
                 )
+                # CLI filesystem maintenance is best-effort and daily rate-limited.
+                from sqlsaber.query_results import FilesystemQueryResultStore
+
+                if isinstance(self.query_result_store, FilesystemQueryResultStore):
+                    from sqlsaber.cli.query_result_gc import (
+                        collect_cli_query_results,
+                    )
+
+                    await collect_cli_query_results(
+                        self.thread_manager.storage,
+                        self.query_result_store,
+                    )
             except Exception as exc:
                 logger.warning("sdk.thread.save_failed", error=str(exc))
 

--- a/src/sqlsaber/threads/storage.py
+++ b/src/sqlsaber/threads/storage.py
@@ -244,6 +244,30 @@ class ThreadStorage:
             )
             return []
 
+    async def get_all_thread_messages_strict(self) -> list[list[ModelMessage]]:
+        """Parse every retained snapshot from one read transaction or raise.
+
+        This is intentionally not best-effort: query-result garbage collection must
+        abort rather than treating an unreadable snapshot as an empty thread.
+        """
+        await self._init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN")
+            try:
+                async with db.execute(
+                    "SELECT messages_json FROM threads ORDER BY id"
+                ) as cur:
+                    rows = await cur.fetchall()
+                snapshots = [
+                    ModelMessagesTypeAdapter.validate_json(bytes(row[0]))
+                    for row in rows
+                ]
+            except BaseException:
+                await db.rollback()
+                raise
+            await db.commit()
+        return snapshots
+
     async def list_threads(
         self, *, database_name: str | None = None, limit: int = 50
     ) -> list[Thread]:

--- a/src/sqlsaber/tools/sql_tools.py
+++ b/src/sqlsaber/tools/sql_tools.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from html import escape
 from typing import Any, cast
 
-from pydantic_ai import RunContext
+from pydantic_ai import RunContext, ToolReturn
 from rich.console import Console
 from rich.syntax import Syntax
 from rich.table import Table
@@ -17,6 +17,17 @@ from sqlsaber.theme.manager import get_theme_manager
 from sqlsaber.database import BaseDatabaseConnection
 from sqlsaber.database.registry import DatabaseRegistry, UnknownDatabaseError
 from sqlsaber.database.schema import SchemaManager
+from sqlsaber.query_results import (
+    MAX_CANONICAL_QUERY_RESULT_BYTES,
+    QueryResultContext,
+    QueryResultData,
+    QueryResultStore,
+    build_model_projection,
+    descriptor_for_data,
+    logical_result_file,
+    new_query_result_id,
+    query_result_columns,
+)
 from sqlsaber.utils.json_utils import json_dumps
 from sqlsaber.utils.text_input import sanitize_terminal_text
 
@@ -40,6 +51,7 @@ class _ResolvedTarget:
     connection: BaseDatabaseConnection
     schema_manager: SchemaManager
     dialect: str
+    database_name: str | None = None
 
 
 class ToolDatabaseError(Exception):
@@ -106,6 +118,7 @@ class SQLTool(Tool):
                 connection=entry.connection,
                 schema_manager=entry.schema_manager,
                 dialect=entry.dialect,
+                database_name=entry.name,
             )
 
         if not self.db:
@@ -116,6 +129,7 @@ class SQLTool(Tool):
             connection=self.db,
             schema_manager=schema_manager,
             dialect=self.db.sqlglot_dialect,
+            database_name=self.db.display_name,
         )
 
 
@@ -483,6 +497,16 @@ class IntrospectSchemaTool(SQLTool):
 class ExecuteSQLTool(SQLTool):
     """Tool for executing SQL queries."""
 
+    def __init__(
+        self,
+        db_connection: BaseDatabaseConnection | None = None,
+        schema_manager: SchemaManager | None = None,
+        *,
+        query_result_store: QueryResultStore | None = None,
+    ) -> None:
+        super().__init__(db_connection, schema_manager)
+        self.query_result_store = query_result_store
+
     display_spec = ToolDisplaySpec(
         metadata=DisplayMetadata(display_name="Execute SQL"),
     )
@@ -714,7 +738,7 @@ class ExecuteSQLTool(SQLTool):
 
     async def execute(
         self, ctx: RunContext, query: str, db_name: str | None = None
-    ) -> str:
+    ) -> str | ToolReturn:
         """
         Execute a SQL query against the database.
 
@@ -743,9 +767,13 @@ class ExecuteSQLTool(SQLTool):
                 return json_dumps({"error": validation_result.reason})
 
             # Add LIMIT if not present and it's a SELECT query
-            if validation_result.is_select and max_rows:
-                if not validation_result.has_limit:
-                    query = add_limit(query, dialect, max_rows)
+            auto_limit_applied = bool(
+                validation_result.is_select
+                and max_rows
+                and not validation_result.has_limit
+            )
+            if auto_limit_applied:
+                query = add_limit(query, dialect, max_rows)
 
             query_type = validation_result.query_type or "other"
 
@@ -759,10 +787,18 @@ class ExecuteSQLTool(SQLTool):
                 read_only=not self.allow_dangerous,
             )
 
-            # Format response based on query type
+            # Format response based on query type. Directly constructed legacy
+            # ExecuteSQLTool instances retain their old string return; managed and
+            # standalone SqlTools always inject a canonical result store.
             tool_call_id = ctx.tool_call_id
-            if query_type == "select":
-                row_count = len(results)
+            if query_type in {"dml", "ddl"}:
+                payload: dict[str, Any] = {"success": True}
+                if tool_call_id:
+                    payload["file"] = f"result_{tool_call_id}.json"
+                return json_dumps(payload)
+
+            row_count = len(results)
+            if self.query_result_store is None:
                 payload: dict[str, Any] = {
                     "success": True,
                     "row_count": row_count,
@@ -770,20 +806,79 @@ class ExecuteSQLTool(SQLTool):
                 }
                 if tool_call_id:
                     payload["file"] = f"result_{tool_call_id}.json"
+                if auto_limit_applied:
+                    payload["auto_limit_applied"] = True
                 return json_dumps(payload)
-            if query_type in {"dml", "ddl"}:
-                payload: dict[str, Any] = {"success": True}
-                if tool_call_id:
-                    payload["file"] = f"result_{tool_call_id}.json"
-                return json_dumps(payload)
-            payload: dict[str, Any] = {
+
+            result_id = new_query_result_id()
+            file = logical_result_file(tool_call_id, result_id)
+            canonical_payload: dict[str, Any] = {
                 "success": True,
-                "row_count": len(results),
+                "row_count": row_count,
                 "results": results,
+                "file": file,
             }
-            if tool_call_id:
-                payload["file"] = f"result_{tool_call_id}.json"
-            return json_dumps(payload)
+            if auto_limit_applied:
+                canonical_payload["auto_limit_applied"] = True
+            try:
+                canonical_data = json_dumps(
+                    canonical_payload, ensure_ascii=False
+                ).encode("utf-8")
+            except (TypeError, ValueError):
+                return json_dumps(
+                    {
+                        "error": (
+                            "Query completed but its result could not be serialized "
+                            "for retention."
+                        )
+                    }
+                )
+            if len(canonical_data) > MAX_CANONICAL_QUERY_RESULT_BYTES:
+                return json_dumps(
+                    {
+                        "error": (
+                            "Query completed but its result exceeds the retention "
+                            "size limit."
+                        )
+                    }
+                )
+            descriptor = descriptor_for_data(
+                canonical_data,
+                result_id=result_id,
+                file=file,
+                row_count=row_count,
+                columns=query_result_columns(cast(list[object], results)),
+                database_name=target.database_name,
+            )
+            try:
+                descriptor = await self.query_result_store.put(
+                    QueryResultData(canonical_data),
+                    descriptor=descriptor,
+                    context=QueryResultContext(
+                        run_id=getattr(ctx, "run_id", None),
+                        conversation_id=getattr(ctx, "conversation_id", None),
+                        tool_call_id=tool_call_id,
+                        metadata=getattr(ctx, "metadata", None) or {},
+                    ),
+                )
+                projection = build_model_projection(canonical_payload, descriptor)
+            except Exception:
+                return json_dumps(
+                    {
+                        "error": (
+                            "Query completed but its complete result could not be "
+                            "retained."
+                        )
+                    }
+                )
+            return ToolReturn(
+                return_value=json_dumps(
+                    projection,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ),
+                metadata={"query_result": descriptor.to_dict()},
+            )
 
         except Exception as e:
             error_msg = str(e)

--- a/tests/test_query_results.py
+++ b/tests/test_query_results.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+from pydantic_ai import ToolReturn
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+)
+
+from sqlsaber.cli.query_result_gc import collect_cli_query_results
+
+from sqlsaber.query_result_resolution import (
+    find_query_result_reference,
+    query_result_references_from_messages,
+    resolve_query_result,
+)
+from sqlsaber.query_results import (
+    MAX_MODEL_QUERY_RESULT_BYTES,
+    FilesystemQueryResultStore,
+    InMemoryQueryResultStore,
+    QueryResultContext,
+    QueryResultData,
+    QueryResultUnavailable,
+    build_model_projection,
+    descriptor_for_data,
+    new_query_result_id,
+)
+from sqlsaber.threads.storage import ThreadStorage
+from sqlsaber.tools.sql_tools import ExecuteSQLTool
+
+
+def _descriptor(data: bytes, *, file: str = "result_call.json"):
+    return descriptor_for_data(
+        data,
+        result_id=new_query_result_id(),
+        file=file,
+        row_count=1,
+        columns=("value",),
+        database_name="test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_in_memory_and_filesystem_stores_round_trip_exact_bytes(tmp_path) -> None:
+    data = b'{"success":true,"row_count":1,"results":[{"value":1}],"file":"result_call.json"}'
+    context = QueryResultContext(conversation_id="conversation-1")
+
+    memory = InMemoryQueryResultStore()
+    descriptor = await memory.put(
+        QueryResultData(data), descriptor=_descriptor(data), context=context
+    )
+    assert (await memory.get(descriptor.id, context=context)).data == data
+
+    first = FilesystemQueryResultStore(tmp_path / "results")
+    filesystem_descriptor = await first.put(
+        QueryResultData(data), descriptor=_descriptor(data), context=context
+    )
+    second = FilesystemQueryResultStore(tmp_path / "results")
+    loaded = await second.get(filesystem_descriptor.id, context=context)
+    assert loaded.data == data
+    assert loaded.descriptor == filesystem_descriptor
+
+
+@pytest.mark.asyncio
+async def test_filesystem_store_detects_corruption(tmp_path) -> None:
+    data = b'{"success":true,"results":[{"value":1}]}'
+    store = FilesystemQueryResultStore(tmp_path / "results")
+    descriptor = await store.put(
+        QueryResultData(data),
+        descriptor=_descriptor(data),
+        context=QueryResultContext(),
+    )
+    result_path = store.root / descriptor.id[3:5] / descriptor.id / "result.json"
+    result_path.write_bytes(b"corrupt")
+
+    with pytest.raises(QueryResultUnavailable):
+        await store.get(descriptor.id, context=QueryResultContext())
+
+
+def test_large_projection_is_deterministic_valid_and_bounded() -> None:
+    rows = [{"value": "x" * 500, "position": index} for index in range(1000)]
+    payload = {
+        "success": True,
+        "row_count": len(rows),
+        "results": rows,
+        "file": "result_call.json",
+        "auto_limit_applied": True,
+    }
+    canonical = json.dumps(payload).encode()
+    descriptor = descriptor_for_data(
+        canonical,
+        result_id="qr_0123456789abcdef0123456789abcdef",
+        file="result_call.json",
+        row_count=len(rows),
+        columns=("value", "position"),
+    )
+
+    first = build_model_projection(payload, descriptor)
+    second = build_model_projection(payload, descriptor)
+    encoded = json.dumps(first, ensure_ascii=False, separators=(",", ":")).encode()
+
+    assert first == second
+    assert len(encoded) <= MAX_MODEL_QUERY_RESULT_BYTES
+    assert first["results_truncated"] is True
+    assert first["auto_limit_applied"] is True
+    assert len(first["preview_rows"]) < len(rows)
+
+
+@pytest.mark.asyncio
+async def test_message_resolution_uses_descriptor_and_validates_store() -> None:
+    payload = {
+        "success": True,
+        "row_count": 1,
+        "results": [{"value": 1}],
+        "file": "result_call.json",
+    }
+    data = json.dumps(payload).encode()
+    store = InMemoryQueryResultStore()
+    descriptor = await store.put(
+        QueryResultData(data),
+        descriptor=_descriptor(data),
+        context=QueryResultContext(),
+    )
+    messages = [
+        ModelResponse(
+            parts=[ToolCallPart("execute_sql", {"query": "select 1"}, "call")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    "execute_sql",
+                    '{"success":true,"preview_rows":[]}',
+                    "call",
+                    metadata={"query_result": descriptor.to_dict()},
+                )
+            ]
+        ),
+    ]
+
+    references = query_result_references_from_messages(messages)
+    assert len(references) == 1
+    assert references[0].query == "select 1"
+    reference = find_query_result_reference(messages, "result_call.json")
+    assert reference is not None
+    resolved = await resolve_query_result(
+        reference, store=store, context=QueryResultContext()
+    )
+    assert resolved.data == data
+    assert resolved.source == "store"
+
+
+@pytest.mark.asyncio
+async def test_cli_gc_preserves_live_result_and_sweeps_old_orphan(tmp_path) -> None:
+    now = 2_000_000.0
+    store = FilesystemQueryResultStore(tmp_path / "results")
+    data = b'{"success":true,"row_count":1,"results":[{"value":1}],"file":"result_call.json"}'
+    live_draft = descriptor_for_data(
+        data,
+        result_id=new_query_result_id(),
+        file="result_call.json",
+        row_count=1,
+        columns=("value",),
+        created_at=now - 200_000,
+    )
+    orphan_draft = descriptor_for_data(
+        data,
+        result_id=new_query_result_id(),
+        file="result_orphan.json",
+        row_count=1,
+        columns=("value",),
+        created_at=now - 200_000,
+    )
+    live = await store.put(
+        QueryResultData(data), descriptor=live_draft, context=QueryResultContext()
+    )
+    orphan = await store.put(
+        QueryResultData(data), descriptor=orphan_draft, context=QueryResultContext()
+    )
+    messages = [
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    "execute_sql",
+                    '{"success":true,"preview_rows":[]}',
+                    "call",
+                    metadata={"query_result": live.to_dict()},
+                )
+            ]
+        )
+    ]
+    threads = ThreadStorage()
+    threads.db_path = tmp_path / "threads.db"
+    await threads.save_snapshot(
+        messages_json=ModelMessagesTypeAdapter.dump_json(messages),
+        database_name="test",
+    )
+
+    result = await collect_cli_query_results(
+        threads, store, force=True, grace_seconds=86_400, now=now
+    )
+
+    assert result.complete is True
+    assert result.deleted == 1
+    assert (await store.get(live.id, context=QueryResultContext())).data == data
+    with pytest.raises(QueryResultUnavailable):
+        await store.get(orphan.id, context=QueryResultContext())
+
+
+class _Database:
+    display_name = "test"
+    sqlglot_dialect = "sqlite"
+
+    async def execute_query(self, *args, **kwargs):
+        del args, kwargs
+        return [{"value": index} for index in range(1000)]
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_stores_complete_rows_but_returns_bounded_projection() -> (
+    None
+):
+    store = InMemoryQueryResultStore()
+    tool = ExecuteSQLTool(query_result_store=store)
+    tool.db = _Database()  # type: ignore[assignment]
+    tool.schema_manager = SimpleNamespace()  # type: ignore[assignment]
+    ctx = SimpleNamespace(
+        tool_call_id="call",
+        run_id="run",
+        conversation_id="conversation",
+        metadata={"tenant_id": "acme"},
+    )
+
+    returned = await tool.execute(ctx, "select value from numbers")  # type: ignore[arg-type]
+
+    assert isinstance(returned, ToolReturn)
+    projection = json.loads(returned.return_value)
+    assert len(returned.return_value.encode()) <= MAX_MODEL_QUERY_RESULT_BYTES
+    assert projection["results_truncated"] is True
+    descriptor = returned.metadata["query_result"]
+    loaded = await store.get(descriptor["id"], context=QueryResultContext())
+    assert len(loaded.rows()) == 1000
+    assert loaded.descriptor.sha256 == hashlib.sha256(loaded.data).hexdigest()


### PR DESCRIPTION
## Summary

- persist every successful row-returning SQL query as immutable canonical bytes while keeping model history bounded to a deterministic 12 KiB projection
- add in-memory and crash-aware filesystem stores, shared validated result resolution, SDK retrieval APIs, CLI hydration, retention/GC, and legacy history compaction
- migrate notebook, sandbox, and visualization plugins to consume complete stored results rather than model-facing tool content
- document storage ownership, web authorization, streaming descriptors, thread retention, and plugin integration

## Validation

- `uv run pytest -q` — 1131 passed, 3 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx ty check src/`
- targeted plugin type checks
- `uv run pytest tests/test_release_configuration.py -q`
- `uv run saber --help` — ~0.31s

## Release configuration

No release-please configuration or manifest changes are required. All four modified packages are already configured, manifest versions match their current `pyproject.toml` versions, and the release configuration test passes. Release Please will perform version updates in its generated release PRs.
