### PR TITLE
feat: render analyses with native TUI

### DIFF
--- a/plugins/notebook/src/sqlsaber_notebook/capability.py
+++ b/plugins/notebook/src/sqlsaber_notebook/capability.py
@@ -39,7 +39,7 @@ from sqlsaber.query_results import (
     QueryResultStore,
     QueryResultUnavailable,
 )
-from sqlsaber.tools.base import Tool
+from sqlsaber.tools.base import Tool, ToolResultTUI
 from sqlsaber.utils.json_utils import json_dumps
 
 from ._shared import (
@@ -186,6 +186,49 @@ class AnalyzeDataTool(Tool):
             console.print(f"[muted bold]Analyzing data:[/muted bold] {goal.strip()}")
         else:
             console.print("[muted bold]Analyzing data in notebook[/muted bold]")
+        return True
+
+    def render_executing_tui(self, tui: ToolResultTUI, args: dict) -> bool:
+        """Render the notebook request in a theme-matched panel."""
+        panel = tui.append_panel()
+        goal = args.get("goal")
+        if isinstance(goal, str) and goal.strip():
+            request = limit_output(goal.strip(), 4_000)
+            panel.append_markdown(f"**Analyzing data**\n\n{request}")
+        else:
+            panel.append_markdown("**Analyzing data in notebook**")
+        return True
+
+    def render_result_tui(
+        self,
+        tui: ToolResultTUI,
+        result: object,
+        *,
+        tool_call_id: str | None = None,
+        metadata: object = None,
+    ) -> bool:
+        """Render the notebook with native saber-tui Markdown and Image components."""
+        del metadata
+        display = self._display_results.pop(tool_call_id or "", None)
+        if display is None:
+            return False
+
+        panel = tui.append_panel()
+        notebook = display.markdown.strip() or "*No notebook cells were executed.*"
+        panel.append_markdown(f"## Analysis notebook\n\n{notebook}")
+        for index, image in enumerate(display.images, start=1):
+            panel.append_markdown(f"**Plot {index}**")
+            panel.append_image(
+                image,
+                "image/png",
+                filename=f"plot_{index}.png",
+                max_width_cells=_MAX_PLOT_COLUMNS,
+                max_height_cells=_MAX_PLOT_ROWS,
+            )
+
+        answer = limit_output(str(result)).strip()
+        if answer:
+            panel.append_markdown(f"## Analysis result\n\n{answer}")
         return True
 
     def render_result_event(

--- a/plugins/notebook/tests/test_notebook_capability.py
+++ b/plugins/notebook/tests/test_notebook_capability.py
@@ -90,6 +90,44 @@ def _png_bytes() -> bytes:
     return buffer.getvalue()
 
 
+class _RecordingTUI:
+    def __init__(self) -> None:
+        self.markdown: list[str] = []
+        self.images: list[tuple[bytes, str, dict[str, object]]] = []
+        self.panels = 0
+
+    def append_panel(self) -> _RecordingTUI:
+        self.panels += 1
+        return self
+
+    def append_markdown(self, text: str = "", *, muted: bool = False) -> object:
+        del muted
+        self.markdown.append(text)
+        return object()
+
+    def append_image(
+        self,
+        data: bytes,
+        mime_type: str,
+        *,
+        filename: str | None = None,
+        max_width_cells: int = 60,
+        max_height_cells: int | None = None,
+    ) -> object:
+        self.images.append(
+            (
+                data,
+                mime_type,
+                {
+                    "filename": filename,
+                    "max_width_cells": max_width_cells,
+                    "max_height_cells": max_height_cells,
+                },
+            )
+        )
+        return object()
+
+
 @pytest.mark.asyncio
 async def test_workspace_selects_newest_successful_selects_and_pairs_sql() -> None:
     messages = [
@@ -252,14 +290,53 @@ async def test_analyze_tool_renders_notebook_and_child_answer(
     assert captured["collect_files"] is False
     assert captured["parent_usage"] is not None
 
+    request_tui = _RecordingTUI()
+    assert tool.render_executing_tui(request_tui, {"goal": "Calculate the total"})
+    assert request_tui.panels == 1
+    assert request_tui.markdown == ["**Analyzing data**\n\nCalculate the total"]
+
+    tui = _RecordingTUI()
+    assert tool.render_result_tui(
+        tui,
+        returned.return_value,
+        tool_call_id="analysis-call",
+        metadata=returned.metadata,
+    )
+    assert tui.panels == 1
+    assert "Analysis notebook" in tui.markdown[0]
+    assert "print('evidence')" in tui.markdown[0]
+    assert tui.markdown[1] == "**Plot 1**"
+    assert tui.images == [
+        (
+            _png_bytes(),
+            "image/png",
+            {
+                "filename": "plot_1.png",
+                "max_width_cells": 80,
+                "max_height_cells": 24,
+            },
+        )
+    ]
+    assert "Analysis result" in tui.markdown[-1]
+    assert "The calculated answer is 10" in tui.markdown[-1]
+    assert not tool.render_result_tui(
+        tui,
+        returned.return_value,
+        tool_call_id="analysis-call",
+    )
+
+    rich_returned = await tool.execute(
+        _ctx(messages, tool_call_id="rich-analysis-call"), "Calculate the total"
+    )
+    assert isinstance(rich_returned, ToolReturn)
     console = Console(
         record=True, force_terminal=True, color_system="truecolor", width=60
     )
     assert tool.render_result_event(
         console,
-        returned.return_value,
-        tool_call_id="analysis-call",
-        metadata=returned.metadata,
+        rich_returned.return_value,
+        tool_call_id="rich-analysis-call",
+        metadata=rich_returned.metadata,
     )
     rendered = console.export_text()
     assert "Analysis notebook" in rendered
@@ -270,8 +347,8 @@ async def test_analyze_tool_renders_notebook_and_child_answer(
     assert "The calculated answer is 10" in rendered
     assert not tool.render_result_event(
         console,
-        returned.return_value,
-        tool_call_id="analysis-call",
+        rich_returned.return_value,
+        tool_call_id="rich-analysis-call",
     )
 
 

--- a/plugins/notebook/uv.lock
+++ b/plugins/notebook/uv.lock
@@ -2775,16 +2775,16 @@ wheels = [
 
 [[package]]
 name = "saber-tui"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mistune" },
     { name = "regex" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/f3/62a88e1815cd9a917c689160b6e12596bb76cc173bf68785d0f0a74ceb06/saber_tui-0.5.0.tar.gz", hash = "sha256:721fc6fde7067b32affaa019ecf5be9a4f28f5a2289837b2c767dea06bda25cb", size = 155608, upload-time = "2026-07-13T21:49:27.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/51/6757f60b7350accad4f07118e1d2285c4d3598995cd6c3085b999d8c1d77/saber_tui-0.6.0.tar.gz", hash = "sha256:f6694087b00508c36cc031a78289a1c696605a79c28331577c3b739ebd241aa5", size = 163824, upload-time = "2026-07-21T23:32:26.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0a/459dc360c6191f4cc1a1210b994380db52c97be3bd0e3be7b8d74ad8db5a/saber_tui-0.5.0-py3-none-any.whl", hash = "sha256:22a17e3f2fb2802f8da7911acd2f77fd4702969b1fb7d56b7c80681e393a92f5", size = 65247, upload-time = "2026-07-13T21:49:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/df/923445a3c2f15c79f35854ab2ebe007371cdd5d152569267d80ce43578cd/saber_tui-0.6.0-py3-none-any.whl", hash = "sha256:fa81993c88e09cde17647bc9057e39b90a53a9eee94f53a01b01a2a62ecb3a5f", size = 71045, upload-time = "2026-07-21T23:32:25.709Z" },
 ]
 
 [[package]]
@@ -2913,7 +2913,7 @@ requires-dist = [
     { name = "pydantic-ai", extras = ["cohere", "groq", "huggingface", "mistral"], specifier = ">=2.9,<3" },
     { name = "questionary", specifier = ">=2.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "saber-tui", specifier = ">=0.4.0" },
+    { name = "saber-tui", specifier = ">=0.6.0" },
     { name = "sqlglot", extras = ["rs"], specifier = ">=27.20.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tabulate", specifier = ">=0.9.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "sqlglot[rs]>=27.20.0",
     "structlog>=25.4.0",
     "tabulate>=0.9.0",
-    "saber-tui>=0.5.0",
+    "saber-tui>=0.6.0",
     "genai-prices>=0.0.57",
 ]
 

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import platform
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
@@ -24,10 +25,14 @@ from saber_tui import (
     matches_key,
 )
 from saber_tui.components import (
+    Box,
     CancellableLoader,
     DefaultTextStyle,
     Editor,
     EditorTheme,
+    Image,
+    ImageOptions,
+    ImageTheme,
     Markdown,
     MarkdownTheme,
     SettingItem,
@@ -56,9 +61,26 @@ def _fg(r: int, g: int, b: int) -> Callable[[str], str]:
     return lambda text: f"{code}{text}\x1b[39m"
 
 
+_SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+
+
 def _bg(r: int, g: int, b: int) -> Callable[[str], str]:
     code = f"\x1b[48;2;{r};{g};{b}m"
-    return lambda text: f"{code}{text}\x1b[49m"
+
+    def apply(text: str) -> str:
+        # Syntax highlighters may emit a full SGR reset (for example ``39;00``),
+        # which also clears an enclosing panel background. Restore it after any
+        # full/background reset so highlighted code stays visually continuous.
+        def restore(match: re.Match[str]) -> str:
+            parameters = match.group(1).split(";")
+            clears_background = not match.group(1) or any(
+                parameter in {"0", "00", "49"} for parameter in parameters
+            )
+            return match.group(0) + code if clears_background else match.group(0)
+
+        return f"{code}{_SGR_RE.sub(restore, text)}\x1b[49m"
+
+    return apply
 
 
 def _bold(text: str) -> str:
@@ -170,6 +192,21 @@ def _theme_user_bg() -> Callable[[str], str]:
     return _bg(*_blend(background, accent, 0.16))
 
 
+def _theme_tool_bg() -> Callable[[str], str]:
+    """Derive a subtle tool panel background from the selected theme."""
+    tm = get_theme_manager()
+    try:
+        style = get_style_by_name(tm.pygments_style_name)
+    except ClassNotFound:
+        return _bg(*USER_BG_FALLBACK)
+
+    background = _hex_to_rgb(getattr(style, "background_color", None))
+    if background is None:
+        background = USER_BG_FALLBACK
+    accent = _theme_fg_rgb("panel.border.assistant", SUCCESS_FALLBACK)
+    return _bg(*_blend(background, accent, 0.10))
+
+
 @dataclass(frozen=True)
 class _TUITheme:
     user_fg: Callable[[str], str]
@@ -179,6 +216,7 @@ class _TUITheme:
     spinner_fg: Callable[[str], str]
     status_fg: Callable[[str], str]
     user_bg: Callable[[str], str]
+    tool_bg: Callable[[str], str]
     markdown: MarkdownTheme
 
 
@@ -207,6 +245,7 @@ def _build_tui_theme() -> _TUITheme:
         spinner_fg=_theme_fg("spinner", WARNING_FALLBACK),
         status_fg=_theme_fg("status", WARNING_FALLBACK),
         user_bg=_theme_user_bg(),
+        tool_bg=_theme_tool_bg(),
         markdown=MarkdownTheme(
             heading=primary,
             link=info,
@@ -501,6 +540,44 @@ class ChatConsole(Console):
         self._app.append_rich(lambda console: console.print_json(*args, **kwargs))
 
 
+class _PanelTUIView:
+    """Tool renderer surface backed by one themed saber-tui box."""
+
+    def __init__(self, app: ChatApp, box: Box) -> None:
+        self.app = app
+        self.box = box
+
+    def append_markdown(self, text: str = "", *, muted: bool = False) -> Markdown:
+        component = self.app._create_markdown(text, muted=muted)
+        self._append(component)
+        return component
+
+    def append_image(
+        self,
+        data: bytes,
+        mime_type: str,
+        *,
+        filename: str | None = None,
+        max_width_cells: int = 60,
+        max_height_cells: int | None = None,
+    ) -> Image:
+        component = self.app._create_image(
+            data,
+            mime_type,
+            filename=filename,
+            max_width_cells=max_width_cells,
+            max_height_cells=max_height_cells,
+        )
+        self._append(component)
+        return component
+
+    def _append(self, component) -> None:
+        if self.box.children:
+            self.box.add_child(_AnsiBlock(""))
+        self.box.add_child(component)
+        self.app.tui.request_render()
+
+
 class ChatApp:
     """Small persistent chat shell built on saber-tui."""
 
@@ -577,6 +654,33 @@ class ChatApp:
         self._append_component(component)
         return component
 
+    def append_panel(self) -> _PanelTUIView:
+        """Append a theme-derived background panel for a tool interaction."""
+        box = Box(padding_x=2, padding_y=1, bg_fn=self.theme.tool_bg)
+        panel = _PanelTUIView(self, box)
+        self._append_component(box)
+        return panel
+
+    def append_image(
+        self,
+        data: bytes,
+        mime_type: str,
+        *,
+        filename: str | None = None,
+        max_width_cells: int = 60,
+        max_height_cells: int | None = None,
+    ) -> Image:
+        """Append a terminal-native image with saber-tui's text fallback."""
+        component = self._create_image(
+            data,
+            mime_type,
+            filename=filename,
+            max_width_cells=max_width_cells,
+            max_height_cells=max_height_cells,
+        )
+        self._append_component(component)
+        return component
+
     def insert_markdown_before(
         self, before: Markdown, text: str = "", *, muted: bool = False
     ) -> Markdown:
@@ -612,6 +716,27 @@ class ChatApp:
             text,
             theme=self.theme.markdown,
             default_text_style=default_style,
+        )
+
+    def _create_image(
+        self,
+        data: bytes,
+        mime_type: str,
+        *,
+        filename: str | None,
+        max_width_cells: int,
+        max_height_cells: int | None,
+    ) -> Image:
+        return Image(
+            self.tui,
+            data,
+            mime_type,
+            theme=ImageTheme(fallback_color=self.theme.muted_fg),
+            options=ImageOptions(
+                filename=filename,
+                max_width_cells=max_width_cells,
+                max_height_cells=max_height_cells,
+            ),
         )
 
     def freeze_markdown(self, component: Markdown) -> Markdown:

--- a/src/sqlsaber/cli/tui_streaming.py
+++ b/src/sqlsaber/cli/tui_streaming.py
@@ -226,14 +226,17 @@ class TUIStreamingQueryHandler:
                 self._clear_tool_call_state(index)
             return
 
-        self._append_display(
-            lambda display: display.show_tool_executing(event.part.tool_name, args)
-        )
+        if not self._append_tui_tool_executing(event.part.tool_name, args):
+            self._append_display(
+                lambda display: display.show_tool_executing(event.part.tool_name, args)
+            )
         if index is not None:
             self._discard_sql_stream(index)
             self._clear_tool_call_state(index)
         if event.part.tool_name == "viz":
             self.app.set_loading("Generating visualization...")
+        elif event.part.tool_name == "analyze_data":
+            self.app.set_loading("Analyzing data...")
 
     async def _on_tool_result(
         self, event: FunctionToolResultEvent, ctx: RunContext | None
@@ -282,12 +285,21 @@ class TUIStreamingQueryHandler:
                 self.app.append_markdown(markdown)
                 self.app.set_loading("Crunching data...")
                 return
+        metadata = getattr(event.part, "metadata", None)
+        if self._append_tui_tool_result(
+            tool_name,
+            content,
+            tool_call_id=event.part.tool_call_id,
+            metadata=metadata,
+        ):
+            self.app.set_loading("Crunching data...")
+            return
         self._append_display(
             lambda display: display.show_tool_result(
                 tool_name,
                 content,
                 tool_call_id=event.part.tool_call_id,
-                metadata=getattr(event.part, "metadata", None),
+                metadata=metadata,
             )
         )
         self.app.set_loading("Crunching data...")
@@ -465,6 +477,35 @@ class TUIStreamingQueryHandler:
     def _maybe_start_sql_generation_status(self, tool_name: str) -> None:
         if tool_name == "execute_sql":
             self.app.set_loading("Generating SQL...")
+
+    def _append_tui_tool_executing(self, tool_name: str, args: dict[str, Any]) -> bool:
+        registry = self._resolve_display_registry() or {}
+        tool = registry.get(tool_name)
+        if tool is None:
+            return False
+        return tool.render_executing_tui(self.app, args)
+
+    def _append_tui_tool_result(
+        self,
+        tool_name: str,
+        result: object,
+        *,
+        tool_call_id: str | None,
+        metadata: object,
+    ) -> bool:
+        registry = self._resolve_display_registry() or {}
+        tool = registry.get(tool_name)
+        if tool is None:
+            return False
+        set_replay_messages = getattr(tool, "set_replay_messages", None)
+        if self._replay_messages is not None and callable(set_replay_messages):
+            set_replay_messages(self._replay_messages)
+        return tool.render_result_tui(
+            self.app,
+            result,
+            tool_call_id=tool_call_id,
+            metadata=metadata,
+        )
 
     def _resolve_display_registry(self) -> Mapping[str, Tool] | None:
         if self._display_registry_provider is not None:

--- a/src/sqlsaber/tools/base.py
+++ b/src/sqlsaber/tools/base.py
@@ -1,11 +1,33 @@
 """Base class for SQLSaber tools."""
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Protocol
 
 from rich.console import Console
 
 from sqlsaber.tools.display import ToolDisplaySpec
+
+
+class ToolResultPanel(Protocol):
+    """Native components that can be composed inside a themed tool panel."""
+
+    def append_markdown(self, text: str = "", *, muted: bool = False) -> object: ...
+
+    def append_image(
+        self,
+        data: bytes,
+        mime_type: str,
+        *,
+        filename: str | None = None,
+        max_width_cells: int = 60,
+        max_height_cells: int | None = None,
+    ) -> object: ...
+
+
+class ToolResultTUI(ToolResultPanel, Protocol):
+    """Native TUI surface available to tool renderers."""
+
+    def append_panel(self) -> ToolResultPanel: ...
 
 
 class Tool(ABC):
@@ -42,6 +64,11 @@ class Tool(ABC):
         """Optionally render execution details. Return True if handled."""
         return False
 
+    def render_executing_tui(self, tui: ToolResultTUI, args: dict) -> bool:
+        """Optionally append native saber-tui components for tool execution."""
+        del tui, args
+        return False
+
     def render_result(self, console: Console, result: object) -> bool:
         """Optionally render tool results. Return True if handled."""
         return False
@@ -57,6 +84,18 @@ class Tool(ABC):
         """Render a live/replayed result with framework event context."""
         del tool_call_id, metadata
         return self.render_result(console, result)
+
+    def render_result_tui(
+        self,
+        tui: ToolResultTUI,
+        result: object,
+        *,
+        tool_call_id: str | None = None,
+        metadata: object = None,
+    ) -> bool:
+        """Optionally append native saber-tui components for a live result."""
+        del tui, result, tool_call_id, metadata
+        return False
 
     def render_result_html(self, result: object) -> str | None:
         """Optionally render tool results as HTML."""

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from collections.abc import Callable
-from io import StringIO
+from io import BytesIO, StringIO
 from types import SimpleNamespace
 
 import pytest
@@ -23,7 +23,9 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.usage import RequestUsage, RunUsage
 from rich.table import Table
-from saber_tui import PosixProcessTerminal, WindowsProcessTerminal
+from saber_tui import PosixProcessTerminal, TerminalCapabilities, WindowsProcessTerminal
+from saber_tui.components import Box
+from saber_tui.components import Image as TUIImage
 from saber_tui.components import Markdown
 from saber_tui.stdin_buffer import StdinBuffer
 from saber_tui.utils import strip_ansi, visible_width
@@ -659,6 +661,50 @@ def test_chat_app_uses_native_saber_tui_markdown() -> None:
     assert "streamed markdown" in "\n".join(app.render_plain_viewport())
 
 
+def test_chat_app_appends_theme_matched_tool_panel() -> None:
+    app = build_chat_app(
+        terminal=FakeTerminal(columns=80, rows=12), on_submit=lambda text: None
+    )
+
+    panel = app.append_panel()
+    panel.append_markdown("**Analyzing data**\n\nFind the strongest peaks")
+    panel.append_markdown("```python\nimport json\nprint(json.dumps({}))\n```")
+
+    component = app.chat_container.children[-1]
+    assert isinstance(component, Box)
+    rendered = component.render(80)
+    assert any("Analyzing data" in strip_ansi(line) for line in rendered)
+    assert all("\x1b[48;2;" in line for line in rendered)
+    assert all(visible_width(line) == 80 for line in rendered)
+    assert any("\x1b[39;00m\x1b[48;2;" in line for line in rendered)
+
+
+def test_chat_app_appends_native_terminal_image() -> None:
+    from PIL import Image as PillowImage
+
+    png = BytesIO()
+    PillowImage.new("RGB", (8, 4), "red").save(png, format="PNG")
+
+    app = build_chat_app(
+        terminal=FakeTerminal(columns=80, rows=12), on_submit=lambda text: None
+    )
+    app.tui.capabilities = TerminalCapabilities("kitty")
+    component = app.append_image(
+        png.getvalue(),
+        "image/png",
+        filename="plot_1.png",
+        max_width_cells=40,
+        max_height_cells=10,
+    )
+
+    assert isinstance(component, TUIImage)
+    assert component.options.filename == "plot_1.png"
+    assert component.options.max_width_cells == 40
+    assert component.options.max_height_cells == 10
+    assert component in app.chat_container.children
+    assert component.render(80)[0].startswith("\x1b_G")
+
+
 def test_ansi_block_wraps_once_per_width(monkeypatch) -> None:
     calls = 0
     original_wrap = tui_chat.wrap_text_with_ansi
@@ -1209,6 +1255,64 @@ async def test_successful_run_preserves_reconciled_sql_after_state_cleanup() -> 
     assert handler._tool_call_ids == {}
     assert handler._sql_stream_components == {}
     assert handler._sql_stream_queries == {}
+
+
+@pytest.mark.asyncio
+async def test_streaming_handler_prefers_native_tool_result_tui() -> None:
+    class NativeRenderer:
+        def render_executing_tui(self, tui, args: dict) -> bool:
+            tui.append_markdown(f"native request: {args['goal']}")
+            return True
+
+        def render_result_tui(
+            self,
+            tui,
+            result: object,
+            *,
+            tool_call_id: str | None = None,
+            metadata: object = None,
+        ) -> bool:
+            tui.append_markdown(f"native {result} ({tool_call_id}, {metadata})")
+            return True
+
+    app = build_chat_app(
+        terminal=FakeTerminal(columns=80, rows=20), on_submit=lambda text: None
+    )
+    handler = TUIStreamingQueryHandler(
+        app,
+        create_console(file=StringIO(), width=80, legacy_windows=False),
+        display_registry={"analyze_data": NativeRenderer()},
+    )
+
+    await handler.on_event(
+        FunctionToolCallEvent(
+            ToolCallPart(
+                "analyze_data",
+                {"goal": "Find peaks"},
+                tool_call_id="native-call",
+            )
+        )
+    )
+    assert app.status.text == "Analyzing data..."
+
+    await handler.on_event(
+        FunctionToolResultEvent(
+            ToolReturnPart(
+                "analyze_data",
+                "result",
+                tool_call_id="native-call",
+                metadata={"source": "test"},
+            )
+        )
+    )
+
+    components = [
+        child for child in app.chat_container.children if isinstance(child, Markdown)
+    ]
+    assert [component.text for component in components] == [
+        "native request: Find peaks",
+        "native result (native-call, {'source': 'test'})",
+    ]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3022,16 +3022,16 @@ wheels = [
 
 [[package]]
 name = "saber-tui"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mistune" },
     { name = "regex" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/f3/62a88e1815cd9a917c689160b6e12596bb76cc173bf68785d0f0a74ceb06/saber_tui-0.5.0.tar.gz", hash = "sha256:721fc6fde7067b32affaa019ecf5be9a4f28f5a2289837b2c767dea06bda25cb", size = 155608, upload-time = "2026-07-13T21:49:27.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/51/6757f60b7350accad4f07118e1d2285c4d3598995cd6c3085b999d8c1d77/saber_tui-0.6.0.tar.gz", hash = "sha256:f6694087b00508c36cc031a78289a1c696605a79c28331577c3b739ebd241aa5", size = 163824, upload-time = "2026-07-21T23:32:26.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0a/459dc360c6191f4cc1a1210b994380db52c97be3bd0e3be7b8d74ad8db5a/saber_tui-0.5.0-py3-none-any.whl", hash = "sha256:22a17e3f2fb2802f8da7911acd2f77fd4702969b1fb7d56b7c80681e393a92f5", size = 65247, upload-time = "2026-07-13T21:49:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/df/923445a3c2f15c79f35854ab2ebe007371cdd5d152569267d80ce43578cd/saber_tui-0.6.0-py3-none-any.whl", hash = "sha256:fa81993c88e09cde17647bc9057e39b90a53a9eee94f53a01b01a2a62ecb3a5f", size = 71045, upload-time = "2026-07-21T23:32:25.709Z" },
 ]
 
 [[package]]
@@ -3167,7 +3167,7 @@ requires-dist = [
     { name = "pydantic-ai", extras = ["cohere", "groq", "huggingface", "mistral"], specifier = ">=2.9,<3" },
     { name = "questionary", specifier = ">=2.1.0" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "saber-tui", specifier = ">=0.5.0" },
+    { name = "saber-tui", specifier = ">=0.6.0" },
     { name = "sqlglot", extras = ["rs"], specifier = ">=27.20.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tabulate", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Summary
- upgrade saber-tui to v0.6.0 and add native tool execution/result rendering hooks
- render notebook requests, cells, outputs, analysis, and plots with native saber-tui components
- add theme-derived analysis panels and preserve their background through syntax-highlighting resets
- show `Analyzing data...` while the notebook subagent is running
- retain Rich rendering as a fallback for non-TUI contexts

## Testing
- `uv run ruff check .`
- `uvx ty check src/`
- `uv run pytest -q` (1134 passed, 3 skipped)
