### PR TITLE
feat(notebook): add Microsandbox execution backend

### DIFF
--- a/plugins/notebook/CHANGELOG.md
+++ b/plugins/notebook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- add an opt-in local Microsandbox microVM execution backend while retaining Docker as the default
+
 ## [0.2.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-notebook-v0.1.0...sqlsaber-notebook-v0.2.0) (2026-07-22)
 
 

--- a/plugins/notebook/README.md
+++ b/plugins/notebook/README.md
@@ -6,6 +6,7 @@ Implemented components:
 
 - provider-neutral notebook execution contract,
 - hardened local Docker execution (default),
+- explicit local microVM execution through the optional `microsandbox` extra,
 - explicit remote Modal Sandbox execution through the optional `modal` extra,
 - fresh-kernel transactional notebook sessions,
 - bounded notebook/image rendering and history collapse,
@@ -37,12 +38,32 @@ uv tool install --with sqlsaber-notebook sqlsaber
 saber
 ```
 
-Docker is the default local backend. Select Modal explicitly because query results
-will be uploaded to a third party:
+Docker is the default local backend. Microsandbox is an opt-in local backend that
+runs notebook code in a hardware-isolated Linux microVM without host bind mounts:
+
+```bash
+uv tool install --with 'sqlsaber-notebook[microsandbox]' sqlsaber
+SQLSABER_NOTEBOOK_BACKEND=microsandbox saber
+```
+
+Microsandbox 0.6 is beta. It supports Apple Silicon macOS, Linux x86_64/ARM64 with
+usable KVM, and preview Windows x86_64/ARM64 hosts with Windows Hypervisor Platform.
+Intel macOS is not supported. Its OCI cache under `~/.microsandbox` is separate from
+Docker, so the first image preparation can be large and slow. For private or
+overridden registry images, authenticate them with Microsandbox's registry login
+support or set `SQLSABER_NOTEBOOK_IMAGE` to an immutable digest in an accessible
+registry.
+Guest networking is disabled, the restricted security profile is requested, and
+notebook processes receive a process-level PID rlimit. Microsandbox runs locally;
+query results are not uploaded to a third-party sandbox service.
+
+Select Modal explicitly because query results will be uploaded to a third party:
 
 ```bash
 SQLSABER_NOTEBOOK_BACKEND=modal saber
 ```
+
+Backends never fall back automatically after selection or failure.
 
 Configure a dedicated analyst model with:
 
@@ -106,6 +127,10 @@ Run live backend integration tests explicitly:
 ```bash
 SQLSABER_RUN_DOCKER_INTEGRATION=1 \
   uv run pytest plugins/notebook/tests/test_notebook_docker_integration.py -q
+
+SQLSABER_RUN_MICROSANDBOX_INTEGRATION=1 \
+  uv run --project plugins/notebook pytest \
+  plugins/notebook/tests/test_notebook_microsandbox_integration.py -q
 
 SQLSABER_RUN_MODAL_INTEGRATION=1 \
   uv run pytest plugins/notebook/tests/test_notebook_modal_integration.py -q

--- a/plugins/notebook/pyproject.toml
+++ b/plugins/notebook/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+microsandbox = ["microsandbox>=0.6.6,<0.7"]
 modal = ["modal>=1.4,<2"]
 
 [tool.uv.sources]
@@ -33,5 +34,6 @@ packages = ["src/sqlsaber_notebook"]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.0.0",
+    "microsandbox>=0.6.6,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
     "modal>=1.4,<2",
 ]

--- a/plugins/notebook/src/sqlsaber_notebook/cli.py
+++ b/plugins/notebook/src/sqlsaber_notebook/cli.py
@@ -74,7 +74,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--backend",
-        choices=("docker", "modal"),
+        choices=("docker", "microsandbox", "modal"),
         default=os.getenv("SQLSABER_NOTEBOOK_BACKEND", "docker"),
     )
     parser.add_argument("--output", type=Path, default=Path("analysis.ipynb"))

--- a/plugins/notebook/src/sqlsaber_notebook/execution/__init__.py
+++ b/plugins/notebook/src/sqlsaber_notebook/execution/__init__.py
@@ -22,8 +22,8 @@ from .docker import DockerNotebookBackend
 
 DEFAULT_NOTEBOOK_BACKEND = "docker"
 DEFAULT_NOTEBOOK_IMAGE = (
-    "jupyter/scipy-notebook@sha256:"
-    "fca4bcc9cbd49d9a15e0e4df6c666adf17776c950da9fa94a4f0a045d5c4ad33"
+    "quay.io/jupyter/scipy-notebook@sha256:"
+    "e6e8baae46b5e62bbc26910169082639a6fd96f90e9f6fc52e0c0389df92d35c"
 )
 
 
@@ -34,12 +34,17 @@ def resolve_notebook_backend(name: str | None = None) -> NotebookBackend:
     normalized = selected.strip().lower()
     if normalized == "docker":
         return DockerNotebookBackend()
+    if normalized == "microsandbox":
+        from .microsandbox import MicrosandboxNotebookBackend
+
+        return MicrosandboxNotebookBackend()
     if normalized == "modal":
         from .modal import ModalNotebookBackend
 
         return ModalNotebookBackend()
     raise NotebookBackendUnavailable(
-        f"Unknown notebook backend {selected!r}; expected 'docker' or 'modal'",
+        f"Unknown notebook backend {selected!r}; expected 'docker', "
+        "'microsandbox', or 'modal'",
         backend=normalized or "unknown",
         phase="configuration",
     )

--- a/plugins/notebook/src/sqlsaber_notebook/execution/microsandbox.py
+++ b/plugins/notebook/src/sqlsaber_notebook/execution/microsandbox.py
@@ -1,0 +1,994 @@
+"""Local microVM notebook execution through the optional Microsandbox SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import json
+import math
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from ._files import build_artifact_inventory, validate_notebook_bytes
+from .base import (
+    ArtifactInfo,
+    ExecutionLimits,
+    NotebookBackend,
+    NotebookBackendUnavailable,
+    NotebookEnvironment,
+    NotebookExecutionError,
+    NotebookExecutionResult,
+    NotebookExecutionTimeout,
+    NotebookImageError,
+    NotebookInfrastructureError,
+    NotebookInput,
+    NotebookLimitExceeded,
+    bound_log,
+    validate_artifact_path,
+    validate_inputs,
+)
+
+_REMOTE_ROOT = "/work"
+_INPUTS_PATH = f"{_REMOTE_ROOT}/inputs"
+_RUN_PATH = f"{_REMOTE_ROOT}/run"
+_CONTROL_PATH = f"{_REMOTE_ROOT}/control"
+_NOTEBOOK_PATH = f"{_RUN_PATH}/notebook.ipynb"
+_INVENTORY_PATH = f"{_CONTROL_PATH}/inventory.json"
+_RUN_USER = "1000"
+_RUN_OWNER = "1000:100"
+_PYTHON = "/opt/conda/bin/python"
+_PLATFORM_MAX_DURATION_SECONDS = 24 * 60 * 60
+_INVENTORY_MAX_BYTES = 128 * 1024
+_STREAM_CHUNK_BYTES = 1024 * 1024
+
+_PREFLIGHT_SCRIPT = r"""
+import os
+import pathlib
+import sys
+
+input_path = pathlib.Path(sys.argv[1])
+run_path = pathlib.Path(sys.argv[2])
+if os.getuid() != 1000:
+    raise SystemExit("notebook process did not run as uid 1000")
+input_path.read_bytes()
+probe = run_path / "preflight-write"
+probe.write_bytes(b"ok")
+probe.unlink()
+failed = []
+for operation in (
+    lambda: input_path.write_bytes(b"changed"),
+    lambda: input_path.chmod(0o600),
+    lambda: input_path.rename(run_path / "moved-input"),
+    lambda: input_path.unlink(),
+    lambda: (input_path.parent / "replacement").write_bytes(b"replacement"),
+):
+    try:
+        operation()
+    except OSError:
+        continue
+    failed.append("mutation unexpectedly succeeded")
+if failed:
+    raise SystemExit(failed[0])
+""".strip()
+
+_STOP_USER_PROCESSES_SCRIPT = r"""
+import os
+import signal
+import time
+
+for _ in range(3):
+    found = False
+    for entry in os.scandir("/proc"):
+        if not entry.name.isdigit():
+            continue
+        try:
+            if os.stat(entry.path).st_uid == 1000:
+                os.kill(int(entry.name), signal.SIGKILL)
+                found = True
+        except (FileNotFoundError, ProcessLookupError, PermissionError):
+            pass
+    if not found:
+        break
+    time.sleep(0.05)
+""".strip()
+
+_INVENTORY_SCRIPT = r"""
+import json
+import os
+import stat
+import sys
+
+root = sys.argv[1]
+output = sys.argv[2]
+max_entries = int(sys.argv[3]) + 1
+max_file = int(sys.argv[4])
+max_total = int(sys.argv[5])
+max_notebook = int(sys.argv[6])
+max_directories = 256
+max_depth = 32
+max_path = 1024
+entries = {}
+total = 0
+directories = 0
+try:
+    for current, dirs, files in os.walk(root, followlinks=False):
+        relative_dir = os.path.relpath(current, root)
+        depth = 0 if relative_dir == "." else len(relative_dir.split(os.sep))
+        if depth > max_depth:
+            raise ValueError("generated directory tree is too deep")
+        directories += len(dirs)
+        if directories > max_directories:
+            raise ValueError("too many generated directories")
+        for name in dirs:
+            path = os.path.join(current, name)
+            if os.path.islink(path):
+                raise ValueError(f"symlinked directory: {name}")
+        for name in files:
+            path = os.path.join(current, name)
+            info = os.lstat(path)
+            if not stat.S_ISREG(info.st_mode):
+                raise ValueError(f"non-regular file: {name}")
+            relative = os.path.relpath(path, root).replace(os.sep, "/")
+            if len(relative) > max_path:
+                raise ValueError("generated path is too long")
+            entries[relative] = info.st_size
+            total += info.st_size
+            if len(entries) > max_entries:
+                raise ValueError("too many generated files")
+            if info.st_size > max(max_file, max_notebook):
+                raise ValueError(f"generated file too large: {relative}")
+            if total > max_total + max_notebook:
+                raise ValueError("generated files are too large")
+    encoded = json.dumps({"files": entries}, separators=(",", ":")).encode()
+    if len(encoded) > 131072:
+        raise ValueError("artifact inventory is too large")
+    with open(output, "wb") as stream:
+        stream.write(encoded)
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    raise SystemExit(2)
+""".strip()
+
+
+class MicrosandboxNotebookBackend(NotebookBackend):
+    """Open explicitly selected notebook environments in local microVMs."""
+
+    name = "microsandbox"
+
+    def available(self) -> bool:
+        return importlib.util.find_spec("microsandbox") is not None
+
+    async def open(
+        self,
+        inputs: Sequence[NotebookInput],
+        *,
+        image: str,
+        limits: ExecutionLimits,
+    ) -> MicrosandboxNotebookEnvironment:
+        validated = validate_inputs(inputs, limits, backend=self.name)
+        cpu_count = _microsandbox_cpus(limits.cpu_cores)
+        sdk = _load_microsandbox()
+        name = f"sqlsaber-notebook-{uuid.uuid4().hex}"
+        sandbox: Any | None = None
+        try:
+            async with asyncio.timeout(limits.image_prepare_seconds):
+                sandbox = await sdk.Sandbox.create(
+                    name,
+                    image=image,
+                    cpus=cpu_count,
+                    memory=limits.memory_mb,
+                    network=sdk.Network.none(),
+                    security="restricted",
+                    ephemeral=True,
+                    max_duration=float(_PLATFORM_MAX_DURATION_SECONDS),
+                )
+        except TimeoutError as exc:
+            await _best_effort_cleanup(sdk, name, sandbox)
+            raise NotebookExecutionTimeout(
+                "Microsandbox image preparation timed out after "
+                f"{limits.image_prepare_seconds} seconds",
+                backend=self.name,
+                phase="image-prepare",
+            ) from exc
+        except asyncio.CancelledError:
+            await _best_effort_cleanup(sdk, name, sandbox)
+            raise
+        except Exception as exc:
+            await _best_effort_cleanup(sdk, name, sandbox)
+            if _is_sdk_exception(
+                exc, sdk, "ImageNotFoundError", "ImagePullFailedError"
+            ) or _looks_like_image_error(exc):
+                raise NotebookImageError(
+                    f"Could not prepare Microsandbox notebook image {image!r}",
+                    backend=self.name,
+                    phase="image-prepare",
+                    diagnostics=bound_log(str(exc), limits.max_log_chars),
+                ) from exc
+            raise NotebookBackendUnavailable(
+                "Microsandbox could not start; verify this host supports Apple "
+                "Virtualization, KVM, or Windows Hypervisor Platform",
+                backend=self.name,
+                phase="environment-open",
+                diagnostics=bound_log(str(exc), limits.max_log_chars),
+            ) from exc
+
+        environment = MicrosandboxNotebookEnvironment(
+            sdk=sdk,
+            sandbox=sandbox,
+            name=name,
+            limits=limits,
+        )
+        try:
+            async with asyncio.timeout(limits.open_seconds):
+                await environment.stage(validated)
+        except TimeoutError as exc:
+            await _close_preserving_primary(environment)
+            raise NotebookExecutionTimeout(
+                "Microsandbox input staging timed out after "
+                f"{limits.open_seconds} seconds",
+                backend=self.name,
+                phase="input-upload",
+            ) from exc
+        except BaseException:
+            await _close_preserving_primary(environment)
+            raise
+        return environment
+
+
+class MicrosandboxNotebookEnvironment(NotebookEnvironment):
+    """A private Microsandbox VM reused for fresh-kernel notebook runs."""
+
+    def __init__(
+        self,
+        *,
+        sdk: Any,
+        sandbox: Any,
+        name: str,
+        limits: ExecutionLimits,
+    ) -> None:
+        self.sdk = sdk
+        self.sandbox = sandbox
+        self.name = name
+        self.limits = limits
+        self.inputs_path = _INPUTS_PATH
+        self.run_path = _RUN_PATH
+        self._inventory: tuple[ArtifactInfo, ...] = ()
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._cleanup_task: asyncio.Task[None] | None = None
+
+    async def stage(self, inputs: Sequence[NotebookInput]) -> None:
+        try:
+            result = await self._exec(
+                "input-upload",
+                "mkdir",
+                ["-p", _INPUTS_PATH, _RUN_PATH, _CONTROL_PATH],
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not create Microsandbox notebook directories",
+                phase="input-upload",
+            )
+            sentinel = f"{_INPUTS_PATH}/.sqlsaber-preflight"
+            await self._write_file(sentinel, b"immutable", phase="input-upload")
+            for item in inputs:
+                await self._write_file(
+                    f"{_INPUTS_PATH}/{item.name}",
+                    item.data,
+                    phase="input-upload",
+                )
+
+            result = await self._exec(
+                "input-upload",
+                "chown",
+                ["-R", "root:root", _INPUTS_PATH],
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not protect Microsandbox notebook input ownership",
+                phase="input-upload",
+            )
+            result = await self._exec(
+                "input-upload",
+                "chmod",
+                ["-R", "a-w", _INPUTS_PATH],
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not make Microsandbox notebook inputs read-only",
+                phase="input-upload",
+            )
+            result = await self._exec(
+                "input-upload",
+                "chown",
+                ["-R", _RUN_OWNER, _RUN_PATH],
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not prepare the Microsandbox run directory",
+                phase="input-upload",
+            )
+            await self._preflight_runtime(sentinel)
+            result = await self._exec(
+                "input-upload",
+                "rm",
+                ["-f", sentinel],
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not remove the Microsandbox input preflight sentinel",
+                phase="input-upload",
+            )
+        except NotebookExecutionError:
+            raise
+        except Exception as exc:
+            raise NotebookInfrastructureError(
+                "Could not stage Microsandbox notebook inputs",
+                backend="microsandbox",
+                phase="input-upload",
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    async def execute(
+        self,
+        notebook: bytes,
+        *,
+        cell_timeout: int | None,
+        command_timeout: int | None,
+    ) -> NotebookExecutionResult:
+        async with self._lock:
+            self._ensure_open()
+            validate_notebook_bytes(
+                notebook,
+                self.limits,
+                backend="microsandbox",
+                phase="notebook-upload",
+            )
+            self._inventory = ()
+            try:
+                await self._reset_run(notebook)
+                timeout = _bounded_timeout(command_timeout, self.limits.command_seconds)
+                returncode, stdout_bytes, stderr_bytes = await self._stream_exec(
+                    "jupyter",
+                    [
+                        "nbconvert",
+                        "--to",
+                        "notebook",
+                        "--execute",
+                        "--inplace",
+                        "--allow-errors",
+                        "--ExecutePreprocessor.timeout="
+                        f"{_bounded_timeout(cell_timeout, self.limits.cell_seconds) or -1}",
+                        "notebook.ipynb",
+                    ],
+                    timeout=timeout,
+                    cwd=_RUN_PATH,
+                    user=_RUN_USER,
+                    rlimits=[self.sdk.Rlimit.nproc(self.limits.pids)],
+                )
+                stdout = bound_log(stdout_bytes, self.limits.max_log_chars)
+                stderr = bound_log(stderr_bytes, self.limits.max_log_chars)
+                if returncode != 0:
+                    raise NotebookInfrastructureError(
+                        "Microsandbox notebook execution failed",
+                        backend="microsandbox",
+                        phase="notebook-execution",
+                        diagnostics=stderr or stdout,
+                    )
+                await self._stop_run_processes()
+                await self._freeze_run()
+                sizes = await self._inventory_sizes()
+                notebook_size = sizes.pop("notebook.ipynb", None)
+                if notebook_size is None:
+                    raise NotebookInfrastructureError(
+                        "Microsandbox execution did not return a notebook",
+                        backend="microsandbox",
+                        phase="notebook-download",
+                    )
+                if notebook_size > self.limits.max_notebook_bytes:
+                    raise NotebookLimitExceeded(
+                        f"Notebook exceeds {self.limits.max_notebook_bytes} bytes",
+                        backend="microsandbox",
+                        phase="notebook-download",
+                    )
+                executed = await self._read_file(
+                    _NOTEBOOK_PATH,
+                    expected_size=notebook_size,
+                    byte_limit=self.limits.max_notebook_bytes,
+                    phase="notebook-download",
+                )
+                validate_notebook_bytes(
+                    executed,
+                    self.limits,
+                    backend="microsandbox",
+                    phase="notebook-download",
+                )
+                inventory = build_artifact_inventory(
+                    sizes,
+                    self.limits,
+                    backend="microsandbox",
+                )
+                self._inventory = inventory
+                return NotebookExecutionResult(
+                    notebook=executed,
+                    artifacts=inventory,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            except NotebookExecutionTimeout:
+                await self._terminate_after_interruption()
+                raise
+            except asyncio.CancelledError:
+                await self._terminate_after_interruption()
+                raise
+            except NotebookExecutionError:
+                raise
+            except Exception as exc:
+                if _is_sdk_exception(exc, self.sdk, "ExecTimeoutError"):
+                    await self._terminate_after_interruption()
+                    raise NotebookExecutionTimeout(
+                        "Microsandbox notebook execution timed out",
+                        backend="microsandbox",
+                        phase="notebook-execution",
+                    ) from exc
+                raise NotebookInfrastructureError(
+                    "Could not transfer Microsandbox notebook results",
+                    backend="microsandbox",
+                    phase="notebook-download",
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+
+    async def read_artifact(self, artifact: ArtifactInfo) -> bytes:
+        async with self._lock:
+            self._ensure_open()
+            if artifact not in self._inventory:
+                raise NotebookInfrastructureError(
+                    f"Unknown artifact: {artifact.path}",
+                    backend="microsandbox",
+                    phase="artifact-download",
+                )
+            relative = validate_artifact_path(artifact.path, backend="microsandbox")
+            path = f"{_RUN_PATH}/{relative.as_posix()}"
+            try:
+                metadata = await self._operation(
+                    self.sandbox.fs.stat(path),
+                    timeout=self.limits.open_seconds,
+                    phase="artifact-download",
+                )
+                if metadata.kind != "file" or metadata.size != artifact.size:
+                    raise ValueError("artifact changed after inventory")
+                return await self._read_file(
+                    path,
+                    expected_size=artifact.size,
+                    byte_limit=self.limits.max_artifact_bytes,
+                    phase="artifact-download",
+                )
+            except NotebookExecutionTimeout:
+                await self._terminate_after_interruption()
+                raise
+            except NotebookExecutionError:
+                raise
+            except Exception as exc:
+                raise NotebookInfrastructureError(
+                    f"Could not read artifact: {artifact.path}",
+                    backend="microsandbox",
+                    phase="artifact-download",
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+
+    async def list_workspace(self) -> tuple[ArtifactInfo, ...]:
+        async with self._lock:
+            self._ensure_open()
+            return self._inventory
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._cleanup_task is None:
+                self._closed = True
+                self._inventory = ()
+                self._cleanup_task = asyncio.create_task(self._cleanup())
+            task = self._cleanup_task
+        await asyncio.shield(task)
+
+    async def _reset_run(self, notebook: bytes) -> None:
+        result = await self._exec(
+            "run-setup",
+            "rm",
+            ["-rf", _RUN_PATH],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not reset the Microsandbox run directory",
+            phase="run-setup",
+        )
+        result = await self._exec(
+            "run-setup",
+            "mkdir",
+            ["-p", _RUN_PATH],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not recreate the Microsandbox run directory",
+            phase="run-setup",
+        )
+        await self._write_file(_NOTEBOOK_PATH, notebook, phase="notebook-upload")
+        result = await self._exec(
+            "run-setup",
+            "chown",
+            ["-R", _RUN_OWNER, _RUN_PATH],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image cannot prepare an unprivileged run directory",
+            phase="run-setup",
+            image_error=True,
+        )
+
+    async def _stop_run_processes(self) -> None:
+        result = await self._exec(
+            "notebook-execution",
+            _PYTHON,
+            ["-c", _STOP_USER_PROCESSES_SCRIPT],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not stop background notebook processes",
+            phase="notebook-execution",
+        )
+
+    async def _freeze_run(self) -> None:
+        result = await self._exec(
+            "artifact-inventory",
+            "chown",
+            ["-R", "root:root", _RUN_PATH],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not freeze Microsandbox notebook results",
+            phase="artifact-inventory",
+        )
+        result = await self._exec(
+            "artifact-inventory",
+            "chmod",
+            ["-R", "a-w", _RUN_PATH],
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not freeze Microsandbox notebook results",
+            phase="artifact-inventory",
+        )
+
+    async def _preflight_runtime(self, sentinel: str) -> None:
+        result = await self._exec(
+            "image-preflight",
+            "jupyter",
+            ["nbconvert", "--version"],
+            timeout=self.limits.open_seconds,
+            user=_RUN_USER,
+        )
+        self._require_success(
+            result,
+            "Notebook image must provide UID 1000, jupyter, and nbconvert",
+            phase="image-preflight",
+            image_error=True,
+        )
+        result = await self._exec(
+            "image-preflight",
+            _PYTHON,
+            ["-c", _PREFLIGHT_SCRIPT, sentinel, _RUN_PATH],
+            timeout=self.limits.open_seconds,
+            user=_RUN_USER,
+        )
+        self._require_success(
+            result,
+            "Notebook image does not preserve immutable inputs for UID 1000",
+            phase="image-preflight",
+            image_error=True,
+        )
+
+    async def _inventory_sizes(self) -> dict[str, int]:
+        with contextlib.suppress(Exception):
+            await self._operation(
+                self.sandbox.fs.remove(_INVENTORY_PATH),
+                timeout=self.limits.open_seconds,
+                phase="artifact-inventory",
+            )
+        result = await self._exec(
+            "artifact-inventory",
+            _PYTHON,
+            [
+                "-c",
+                _INVENTORY_SCRIPT,
+                _RUN_PATH,
+                _INVENTORY_PATH,
+                str(self.limits.max_artifacts),
+                str(self.limits.max_artifact_bytes),
+                str(self.limits.max_total_artifact_bytes),
+                str(self.limits.max_notebook_bytes),
+            ],
+            timeout=self.limits.open_seconds,
+        )
+        if not result.success:
+            raise NotebookLimitExceeded(
+                "Microsandbox artifact inventory exceeded limits or contained unsafe files",
+                backend="microsandbox",
+                phase="artifact-inventory",
+                diagnostics=bound_log(
+                    result.stderr_bytes or result.stdout_bytes,
+                    self.limits.max_log_chars,
+                ),
+            )
+        metadata = await self._operation(
+            self.sandbox.fs.stat(_INVENTORY_PATH),
+            timeout=self.limits.open_seconds,
+            phase="artifact-inventory",
+        )
+        if metadata.kind != "file" or metadata.size > _INVENTORY_MAX_BYTES:
+            raise NotebookInfrastructureError(
+                "Microsandbox returned an invalid artifact inventory",
+                backend="microsandbox",
+                phase="artifact-inventory",
+            )
+        payload_bytes = await self._read_file(
+            _INVENTORY_PATH,
+            expected_size=metadata.size,
+            byte_limit=_INVENTORY_MAX_BYTES,
+            phase="artifact-inventory",
+        )
+        try:
+            payload = json.loads(payload_bytes)
+            files = payload["files"]
+            if not isinstance(files, dict):
+                raise TypeError("files must be an object")
+            parsed: dict[str, int] = {}
+            for path, size in files.items():
+                if not isinstance(path, str) or not isinstance(size, int):
+                    raise TypeError("inventory entries must be string/integer pairs")
+                parsed[path] = size
+            return parsed
+        except (KeyError, TypeError, json.JSONDecodeError) as exc:
+            raise NotebookInfrastructureError(
+                "Microsandbox returned an invalid artifact inventory",
+                backend="microsandbox",
+                phase="artifact-inventory",
+            ) from exc
+
+    async def _write_file(self, path: str, data: bytes, *, phase: str) -> None:
+        try:
+            async with asyncio.timeout(self.limits.open_seconds):
+                sink = await self.sandbox.fs.write_stream(path)
+                async with sink:
+                    for offset in range(0, len(data), _STREAM_CHUNK_BYTES):
+                        await sink.write(data[offset : offset + _STREAM_CHUNK_BYTES])
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Microsandbox {phase} timed out after "
+                f"{self.limits.open_seconds} seconds",
+                backend="microsandbox",
+                phase=phase,
+            ) from exc
+
+    async def _read_file(
+        self,
+        path: str,
+        *,
+        expected_size: int,
+        byte_limit: int,
+        phase: str,
+    ) -> bytes:
+        if expected_size < 0 or expected_size > byte_limit:
+            raise NotebookLimitExceeded(
+                f"Microsandbox file exceeds {byte_limit} bytes",
+                backend="microsandbox",
+                phase=phase,
+            )
+        stream = await self._operation(
+            self.sandbox.fs.read_stream(path),
+            timeout=self.limits.open_seconds,
+            phase=phase,
+        )
+        data = bytearray()
+        try:
+            async with asyncio.timeout(self.limits.open_seconds):
+                async for chunk in stream:
+                    data.extend(chunk)
+                    if len(data) > expected_size or len(data) > byte_limit:
+                        raise NotebookInfrastructureError(
+                            "Microsandbox file changed during download",
+                            backend="microsandbox",
+                            phase=phase,
+                        )
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Microsandbox {phase} timed out after "
+                f"{self.limits.open_seconds} seconds",
+                backend="microsandbox",
+                phase=phase,
+            ) from exc
+        if len(data) != expected_size:
+            raise NotebookInfrastructureError(
+                "Microsandbox file changed during download",
+                backend="microsandbox",
+                phase=phase,
+            )
+        return bytes(data)
+
+    async def _exec(
+        self,
+        phase: str,
+        command: str,
+        args: list[str],
+        *,
+        timeout: int | None,
+        user: str = "root",
+    ) -> Any:
+        try:
+            async with asyncio.timeout(timeout):
+                return await self.sandbox.exec(
+                    command,
+                    args,
+                    user=user,
+                    timeout=timeout,
+                )
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Microsandbox {phase} timed out after {timeout} seconds",
+                backend="microsandbox",
+                phase=phase,
+            ) from exc
+        except Exception as exc:
+            if _is_sdk_exception(exc, self.sdk, "ExecTimeoutError"):
+                raise NotebookExecutionTimeout(
+                    f"Microsandbox {phase} timed out after {timeout} seconds",
+                    backend="microsandbox",
+                    phase=phase,
+                ) from exc
+            raise
+
+    async def _stream_exec(
+        self,
+        command: str,
+        args: list[str],
+        *,
+        timeout: int | None,
+        cwd: str,
+        user: str,
+        rlimits: list[Any],
+    ) -> tuple[int, bytes, bytes]:
+        handle: Any | None = None
+        stdout = _BoundedBytes(self.limits.max_log_chars)
+        stderr = _BoundedBytes(self.limits.max_log_chars)
+        exit_code: int | None = None
+        try:
+            async with asyncio.timeout(timeout):
+                handle = await self.sandbox.exec_stream(
+                    command,
+                    args,
+                    cwd=cwd,
+                    user=user,
+                    env={"HOME": "/tmp"},
+                    timeout=timeout,
+                    rlimits=rlimits,
+                )
+                async for event in handle:
+                    if event.event_type == "stdout" and event.data:
+                        stdout.append(event.data)
+                    elif event.event_type in {"stderr", "failed"} and event.data:
+                        stderr.append(event.data)
+                    elif event.event_type == "exited":
+                        exit_code = event.code
+                if exit_code is None:
+                    exit_code, _ = await handle.wait()
+        except TimeoutError as exc:
+            await _kill_exec_handle(handle)
+            raise NotebookExecutionTimeout(
+                f"Microsandbox notebook execution timed out after {timeout} seconds",
+                backend="microsandbox",
+                phase="notebook-execution",
+            ) from exc
+        except asyncio.CancelledError:
+            await _kill_exec_handle(handle)
+            raise
+        except Exception as exc:
+            await _kill_exec_handle(handle)
+            if _is_sdk_exception(exc, self.sdk, "ExecTimeoutError"):
+                raise NotebookExecutionTimeout(
+                    f"Microsandbox notebook execution timed out after {timeout} seconds",
+                    backend="microsandbox",
+                    phase="notebook-execution",
+                ) from exc
+            raise
+        return exit_code or 0, stdout.value(), stderr.value()
+
+    async def _operation(self, operation: Any, *, timeout: int, phase: str) -> Any:
+        try:
+            async with asyncio.timeout(timeout):
+                return await operation
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Microsandbox {phase} timed out after {timeout} seconds",
+                backend="microsandbox",
+                phase=phase,
+            ) from exc
+
+    def _require_success(
+        self,
+        result: Any,
+        message: str,
+        *,
+        phase: str,
+        image_error: bool = False,
+    ) -> None:
+        if result.success:
+            return
+        error_type = NotebookImageError if image_error else NotebookInfrastructureError
+        raise error_type(
+            message,
+            backend="microsandbox",
+            phase=phase,
+            diagnostics=bound_log(
+                result.stderr_bytes or result.stdout_bytes,
+                self.limits.max_log_chars,
+            ),
+        )
+
+    async def _terminate_after_interruption(self) -> None:
+        self._closed = True
+        self._inventory = ()
+        if self._cleanup_task is None:
+            self._cleanup_task = asyncio.create_task(self._cleanup())
+        with contextlib.suppress(Exception):
+            await asyncio.shield(self._cleanup_task)
+
+    async def _cleanup(self) -> None:
+        try:
+            await _cleanup_named_sandbox(self.sdk, self.name, self.sandbox)
+        except Exception as exc:
+            raise NotebookInfrastructureError(
+                "Could not remove the Microsandbox notebook environment",
+                backend="microsandbox",
+                phase="cleanup",
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise NotebookInfrastructureError(
+                "Notebook environment is closed",
+                backend="microsandbox",
+                phase="lifecycle",
+            )
+
+
+class _BoundedBytes:
+    def __init__(self, log_chars: int) -> None:
+        self._limit = max(log_chars * 4, 32_000)
+        self._head_limit = self._limit // 2
+        self._tail_limit = self._limit - self._head_limit
+        self._head = bytearray()
+        self._tail = bytearray()
+
+    def append(self, chunk: bytes) -> None:
+        if len(self._head) < self._head_limit:
+            consumed = min(self._head_limit - len(self._head), len(chunk))
+            self._head.extend(chunk[:consumed])
+            chunk = chunk[consumed:]
+        if chunk:
+            self._tail.extend(chunk)
+            if len(self._tail) > self._tail_limit:
+                del self._tail[: -self._tail_limit]
+
+    def value(self) -> bytes:
+        return bytes(self._head + self._tail)
+
+
+def _microsandbox_cpus(value: float) -> int:
+    if not math.isfinite(value):
+        raise NotebookLimitExceeded(
+            "Microsandbox CPU limit must be finite",
+            backend="microsandbox",
+            phase="configuration",
+        )
+    result = math.floor(value)
+    if result < 1:
+        raise NotebookLimitExceeded(
+            "Microsandbox requires at least one whole CPU",
+            backend="microsandbox",
+            phase="configuration",
+        )
+    return result
+
+
+def _bounded_timeout(
+    requested: int | None,
+    configured: int | None,
+) -> int | None:
+    if requested is None:
+        return configured
+    if configured is None:
+        return requested
+    return min(requested, configured)
+
+
+async def _kill_exec_handle(handle: Any | None) -> None:
+    if handle is None:
+        return
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(handle.kill(), timeout=5)
+
+
+async def _cleanup_named_sandbox(sdk: Any, name: str, sandbox: Any | None) -> None:
+    if sandbox is not None:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(sandbox.kill(timeout=10.0), timeout=15)
+
+    try:
+        handle = await asyncio.wait_for(sdk.Sandbox.get(name), timeout=10)
+    except Exception as exc:
+        if _is_sdk_exception(exc, sdk, "SandboxNotFoundError"):
+            return
+        raise
+
+    if str(handle.status).lower() in {"running", "draining", "paused"}:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(handle.kill(timeout=10.0), timeout=15)
+        handle = await asyncio.wait_for(handle.refresh(), timeout=10)
+    await asyncio.wait_for(handle.remove(), timeout=10)
+    try:
+        await asyncio.wait_for(sdk.Sandbox.get(name), timeout=10)
+    except Exception as exc:
+        if _is_sdk_exception(exc, sdk, "SandboxNotFoundError"):
+            return
+        raise
+    raise RuntimeError(f"Microsandbox sandbox {name!r} still exists after removal")
+
+
+async def _best_effort_cleanup(sdk: Any, name: str, sandbox: Any | None) -> None:
+    task = asyncio.create_task(_cleanup_named_sandbox(sdk, name, sandbox))
+    with contextlib.suppress(Exception):
+        await asyncio.shield(task)
+
+
+async def _close_preserving_primary(
+    environment: MicrosandboxNotebookEnvironment,
+) -> None:
+    with contextlib.suppress(Exception):
+        await environment.close()
+
+
+def _looks_like_image_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "image error:" in message or "registry error:" in message
+
+
+def _is_sdk_exception(exc: Exception, sdk: Any, *names: str) -> bool:
+    types = tuple(
+        candidate
+        for name in names
+        if isinstance((candidate := getattr(sdk, name, None)), type)
+    )
+    return bool(types) and isinstance(exc, types)
+
+
+def _load_microsandbox() -> Any:
+    try:
+        return importlib.import_module("microsandbox")
+    except ImportError as exc:
+        raise NotebookBackendUnavailable(
+            "Microsandbox backend requires the `sqlsaber-notebook[microsandbox]` extra",
+            backend="microsandbox",
+            phase="availability",
+        ) from exc

--- a/plugins/notebook/tests/test_notebook_execution.py
+++ b/plugins/notebook/tests/test_notebook_execution.py
@@ -56,8 +56,11 @@ def test_backend_selection_is_explicit_without_fallback(
     assert resolve_notebook_backend().name == "modal"
     assert resolve_notebook_backend("docker").name == "docker"
 
+    assert resolve_notebook_backend("microsandbox").name == "microsandbox"
+
     with pytest.raises(
-        NotebookBackendUnavailable, match="expected 'docker' or 'modal'"
+        NotebookBackendUnavailable,
+        match="expected 'docker', 'microsandbox', or 'modal'",
     ):
         resolve_notebook_backend("daytona")
 

--- a/plugins/notebook/tests/test_notebook_microsandbox.py
+++ b/plugins/notebook/tests/test_notebook_microsandbox.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sqlsaber_notebook.execution import (
+    ExecutionLimits,
+    NotebookBackendUnavailable,
+    NotebookExecutionTimeout,
+    NotebookImageError,
+    NotebookInput,
+    NotebookLimitExceeded,
+)
+from sqlsaber_notebook.execution.base import NotebookInfrastructureError
+from sqlsaber_notebook.execution import microsandbox as microsandbox_backend
+
+
+class SandboxNotFoundError(Exception):
+    pass
+
+
+class ImagePullFailedError(Exception):
+    pass
+
+
+class ExecTimeoutError(Exception):
+    pass
+
+
+class IoError(Exception):
+    pass
+
+
+class FakeOutput:
+    def __init__(
+        self,
+        *,
+        success: bool = True,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+    ) -> None:
+        self.success = success
+        self.exit_code = 0 if success else 1
+        self.stdout_bytes = stdout
+        self.stderr_bytes = stderr
+        self.stdout_text = stdout.decode()
+        self.stderr_text = stderr.decode()
+
+
+class FakeEvent:
+    def __init__(
+        self, event_type: str, data: bytes | None = None, code: int | None = None
+    ) -> None:
+        self.event_type = event_type
+        self.data = data
+        self.code = code
+
+
+class FakeExecHandle:
+    def __init__(self, *, hang: bool = False, output_size: int = 0) -> None:
+        self.hang = hang
+        self.output_size = output_size
+        self.killed = False
+
+    async def __aiter__(self):
+        if self.hang:
+            await asyncio.sleep(60)
+        if self.output_size:
+            yield FakeEvent("stdout", b"x" * self.output_size)
+        yield FakeEvent("exited", code=0)
+
+    async def wait(self) -> tuple[int, bool]:
+        return 0, True
+
+    async def kill(self) -> None:
+        self.killed = True
+
+
+class FakeReadStream:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def __aiter__(self):
+        for offset in range(0, len(self.data), 7):
+            yield self.data[offset : offset + 7]
+
+
+class FakeWriteStream:
+    def __init__(self, filesystem: FakeFilesystem, path: str) -> None:
+        self.filesystem = filesystem
+        self.path = path
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data.extend(data)
+
+    async def __aenter__(self) -> FakeWriteStream:
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        self.filesystem.files[self.path] = bytes(self.data)
+        return False
+
+
+class FakeFilesystem:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    async def write_stream(self, path: str) -> FakeWriteStream:
+        return FakeWriteStream(self, path)
+
+    async def read_stream(self, path: str) -> FakeReadStream:
+        return FakeReadStream(self.files[path])
+
+    async def stat(self, path: str) -> Any:
+        data = self.files[path]
+        return SimpleNamespace(kind="file", size=len(data), mode=0o444)
+
+    async def remove(self, path: str) -> None:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        del self.files[path]
+
+
+class FakeHandle:
+    def __init__(self, api: FakeSandboxApi, sandbox: FakeSandbox) -> None:
+        self.api = api
+        self.sandbox = sandbox
+        self.status = sandbox.status
+
+    async def kill(self, timeout: float | None = None) -> None:
+        del timeout
+        self.sandbox.status = "stopped"
+        self.status = "stopped"
+
+    async def refresh(self) -> FakeHandle:
+        self.status = self.sandbox.status
+        return self
+
+    async def remove(self) -> None:
+        if self.sandbox.status == "running":
+            raise RuntimeError("still running")
+        self.api.removed = True
+
+
+class FakeSandbox:
+    def __init__(self, api: FakeSandboxApi) -> None:
+        self.api = api
+        self.fs = FakeFilesystem()
+        self.commands: list[tuple[str, tuple[str, ...], dict[str, Any]]] = []
+        self.status = "running"
+        self.raise_after_kill = False
+        self.hang = False
+        self.output_size = 0
+        self.last_exec_handle: FakeExecHandle | None = None
+        self.run_count = 0
+        self.artifact_path = "nested/result.txt"
+
+    async def exec(
+        self,
+        command: str,
+        args: list[str],
+        **kwargs: Any,
+    ) -> FakeOutput:
+        self.commands.append((command, tuple(args), kwargs))
+        if command == "rm" and microsandbox_backend._RUN_PATH in args:
+            prefix = f"{microsandbox_backend._RUN_PATH}/"
+            self.fs.files = {
+                path: data
+                for path, data in self.fs.files.items()
+                if not path.startswith(prefix)
+            }
+        elif command == "rm" and args[:1] == ["-f"]:
+            self.fs.files.pop(args[1], None)
+        if (
+            command == microsandbox_backend._PYTHON
+            and args[1] == microsandbox_backend._INVENTORY_SCRIPT
+        ):
+            inventory = {
+                "files": {
+                    "notebook.ipynb": len(
+                        self.fs.files[microsandbox_backend._NOTEBOOK_PATH]
+                    ),
+                    self.artifact_path: len(
+                        self.fs.files[
+                            f"{microsandbox_backend._RUN_PATH}/{self.artifact_path}"
+                        ]
+                    ),
+                }
+            }
+            self.fs.files[microsandbox_backend._INVENTORY_PATH] = json.dumps(
+                inventory
+            ).encode()
+        return FakeOutput(stdout=b"ok\n")
+
+    async def exec_stream(
+        self,
+        command: str,
+        args: list[str],
+        **kwargs: Any,
+    ) -> FakeExecHandle:
+        self.commands.append((command, tuple(args), kwargs))
+        self.run_count += 1
+        self.artifact_path = (
+            "nested/result.txt"
+            if self.run_count == 1
+            else f"nested/result-{self.run_count}.txt"
+        )
+        self.fs.files[f"{microsandbox_backend._RUN_PATH}/{self.artifact_path}"] = (
+            b"result"
+        )
+        self.last_exec_handle = FakeExecHandle(
+            hang=self.hang, output_size=self.output_size
+        )
+        return self.last_exec_handle
+
+    async def kill(self, timeout: float | None = None) -> None:
+        del timeout
+        self.status = "stopped"
+        if self.raise_after_kill:
+            raise IoError("No child processes")
+
+
+class FakeSandboxApi:
+    def __init__(self) -> None:
+        self.created: FakeSandbox | None = None
+        self.create_name = ""
+        self.create_kwargs: dict[str, Any] = {}
+        self.removed = False
+
+    async def create(self, name: str, **kwargs: Any) -> FakeSandbox:
+        self.create_name = name
+        self.create_kwargs = kwargs
+        self.created = FakeSandbox(self)
+        return self.created
+
+    async def get(self, name: str) -> FakeHandle:
+        assert name == self.create_name
+        if self.created is None or self.removed:
+            raise SandboxNotFoundError(name)
+        return FakeHandle(self, self.created)
+
+
+class FakeNetwork:
+    @staticmethod
+    def none() -> str:
+        return "network-none"
+
+
+class FakeRlimit:
+    @staticmethod
+    def nproc(limit: int) -> tuple[str, int]:
+        return "nproc", limit
+
+
+def fake_sdk() -> Any:
+    sandbox_api = FakeSandboxApi()
+    return SimpleNamespace(
+        Sandbox=sandbox_api,
+        Network=FakeNetwork,
+        Rlimit=FakeRlimit,
+        SandboxNotFoundError=SandboxNotFoundError,
+        ImagePullFailedError=ImagePullFailedError,
+        ExecTimeoutError=ExecTimeoutError,
+        IoError=IoError,
+    )
+
+
+def notebook_bytes() -> bytes:
+    return json.dumps(
+        {
+            "cells": [],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    ).encode()
+
+
+async def open_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    limits: ExecutionLimits | None = None,
+):
+    sdk = fake_sdk()
+    monkeypatch.setattr(microsandbox_backend, "_load_microsandbox", lambda: sdk)
+    environment = await microsandbox_backend.MicrosandboxNotebookBackend().open(
+        [NotebookInput("data.json", b"{}")],
+        image="registry/image@sha256:digest",
+        limits=limits or ExecutionLimits(),
+    )
+    return sdk, environment
+
+
+def test_missing_sdk_reports_optional_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing(name: str) -> Any:
+        assert name == "microsandbox"
+        raise ImportError(name)
+
+    monkeypatch.setattr(microsandbox_backend.importlib, "import_module", missing)
+    with pytest.raises(NotebookBackendUnavailable, match="microsandbox.*extra"):
+        microsandbox_backend._load_microsandbox()
+
+
+async def test_registry_failure_is_normalized_as_image_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk = fake_sdk()
+
+    async def fail_create(name: str, **kwargs: Any) -> FakeSandbox:
+        del name, kwargs
+        raise RuntimeError("image error: registry error: Not authorized")
+
+    sdk.Sandbox.create = fail_create
+    monkeypatch.setattr(microsandbox_backend, "_load_microsandbox", lambda: sdk)
+    with pytest.raises(NotebookImageError, match="Could not prepare") as raised:
+        await microsandbox_backend.MicrosandboxNotebookBackend().open(
+            [], image="private/image", limits=ExecutionLimits()
+        )
+    assert raised.value.phase == "image-prepare"
+
+
+async def test_open_uses_restricted_networkless_microvm_and_immutable_staging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    sandbox = sdk.Sandbox.created
+    assert sandbox is not None
+    assert sdk.Sandbox.create_name.startswith("sqlsaber-notebook-")
+    assert sdk.Sandbox.create_kwargs == {
+        "image": "registry/image@sha256:digest",
+        "cpus": 4,
+        "memory": 8192,
+        "network": "network-none",
+        "security": "restricted",
+        "ephemeral": True,
+        "max_duration": 86_400.0,
+    }
+    assert sandbox.fs.files[f"{microsandbox_backend._INPUTS_PATH}/data.json"] == b"{}"
+    assert any(
+        command == "chmod" and "a-w" in args for command, args, _ in sandbox.commands
+    )
+    assert any(
+        command == "jupyter"
+        and args == ("nbconvert", "--version")
+        and kwargs["user"] == "1000"
+        for command, args, kwargs in sandbox.commands
+    )
+    await environment.close()
+    await environment.close()
+    assert sdk.Sandbox.removed is True
+
+
+async def test_execute_streams_as_uid_1000_with_pid_limit_and_lazy_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    result = await environment.execute(
+        notebook_bytes(), cell_timeout=30, command_timeout=60
+    )
+    assert [artifact.path for artifact in result.artifacts] == ["nested/result.txt"]
+    assert await environment.read_artifact(result.artifacts[0]) == b"result"
+
+    stream_commands = [
+        item
+        for item in environment.sandbox.commands
+        if item[0] == "jupyter" and "--execute" in item[1]
+    ]
+    assert len(stream_commands) == 1
+    _, args, kwargs = stream_commands[0]
+    assert "--ExecutePreprocessor.timeout=30" in args
+    assert kwargs["cwd"] == microsandbox_backend._RUN_PATH
+    assert kwargs["user"] == "1000"
+    assert kwargs["rlimits"] == [("nproc", 256)]
+    await environment.close()
+
+
+async def test_execution_timeout_kills_process_and_removes_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    environment.sandbox.hang = True
+    with pytest.raises(NotebookExecutionTimeout, match="timed out"):
+        await environment.execute(
+            notebook_bytes(),
+            cell_timeout=1,
+            command_timeout=0.01,  # type: ignore[arg-type]
+        )
+    assert environment.sandbox.last_exec_handle is not None
+    assert environment.sandbox.last_exec_handle.killed is True
+    assert sdk.Sandbox.removed is True
+    with pytest.raises(NotebookInfrastructureError, match="closed"):
+        await environment.list_workspace()
+
+
+async def test_execution_cancellation_kills_process_and_removes_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    environment.sandbox.hang = True
+    task = asyncio.create_task(
+        environment.execute(notebook_bytes(), cell_timeout=1, command_timeout=None)
+    )
+    while environment.sandbox.last_exec_handle is None:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert environment.sandbox.last_exec_handle.killed is True
+    assert sdk.Sandbox.removed is True
+
+
+async def test_streamed_execution_logs_are_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    environment.sandbox.output_size = 1_000_000
+    result = await environment.execute(
+        notebook_bytes(), cell_timeout=1, command_timeout=2
+    )
+    assert len(result.stdout) <= environment.limits.max_log_chars
+    assert "backend log truncated" in result.stdout
+    await environment.close()
+
+
+async def test_cleanup_verifies_state_when_kill_raises_no_child_processes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    environment.sandbox.raise_after_kill = True
+    await environment.close()
+    assert sdk.Sandbox.removed is True
+
+
+async def test_stale_artifact_is_rejected_after_next_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    first = await environment.execute(
+        notebook_bytes(), cell_timeout=1, command_timeout=2
+    )
+    await environment.execute(notebook_bytes(), cell_timeout=1, command_timeout=2)
+    with pytest.raises(NotebookInfrastructureError, match="Unknown artifact"):
+        await environment.read_artifact(first.artifacts[0])
+    await environment.close()
+
+
+@pytest.mark.parametrize(("value", "expected"), [(4.0, 4), (2.9, 2), (1.0, 1)])
+def test_cpu_mapping_is_conservative(value: float, expected: int) -> None:
+    assert microsandbox_backend._microsandbox_cpus(value) == expected
+
+
+@pytest.mark.parametrize("value", [0.9, 0.0, float("inf"), float("nan")])
+def test_cpu_mapping_rejects_unsupported_values(value: float) -> None:
+    with pytest.raises(NotebookLimitExceeded):
+        microsandbox_backend._microsandbox_cpus(value)

--- a/plugins/notebook/tests/test_notebook_microsandbox_integration.py
+++ b/plugins/notebook/tests/test_notebook_microsandbox_integration.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+import pytest
+
+from sqlsaber_notebook.execution import (
+    DEFAULT_NOTEBOOK_IMAGE,
+    ExecutionLimits,
+    NotebookInput,
+    NotebookLimitExceeded,
+)
+from sqlsaber_notebook.execution.microsandbox import (
+    MicrosandboxNotebookBackend,
+    _load_microsandbox,
+)
+
+from _notebooks import assert_contract_result, contract_notebook
+
+
+def _single_cell_notebook(source: str) -> bytes:
+    notebook: dict[str, Any] = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "id": "cell-1",
+                "metadata": {},
+                "outputs": [],
+                "source": source.splitlines(keepends=True),
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3 (ipykernel)",
+                "language": "python",
+                "name": "python3",
+            }
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    return json.dumps(notebook).encode()
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.getenv("SQLSABER_RUN_MICROSANDBOX_INTEGRATION") != "1",
+        reason="set SQLSABER_RUN_MICROSANDBOX_INTEGRATION=1 for local microVM tests",
+    ),
+]
+
+
+async def test_live_microsandbox_notebook_contract_and_removal() -> None:
+    backend = MicrosandboxNotebookBackend()
+    image = os.getenv("SQLSABER_MICROSANDBOX_INTEGRATION_IMAGE", DEFAULT_NOTEBOOK_IMAGE)
+    environment = await backend.open(
+        [NotebookInput("data.json", b'{"values":[1,2,3]}')],
+        image=image,
+        limits=ExecutionLimits(),
+    )
+    name = environment.name
+    try:
+        first = await environment.execute(
+            contract_notebook(),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        second = await environment.execute(
+            contract_notebook(),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        assert_contract_result(first.notebook, expected_uid=1000)
+        assert_contract_result(second.notebook, expected_uid=1000)
+        assert [item.path for item in second.artifacts] == [
+            "nested/summary.txt",
+            "plot.png",
+        ]
+        summary = next(
+            item for item in second.artifacts if item.path.endswith("summary.txt")
+        )
+        plot = next(item for item in second.artifacts if item.path == "plot.png")
+        assert await environment.read_artifact(summary) == b"sum=6 counter=1"
+        assert (await environment.read_artifact(plot)).startswith(b"\x89PNG\r\n\x1a\n")
+
+        background = await environment.execute(
+            _single_cell_notebook(
+                """import subprocess
+import sys
+import time
+from pathlib import Path
+Path('background.txt').write_bytes(b'start')
+subprocess.Popen([
+    sys.executable,
+    '-c',
+    \"import time; p='background.txt'; \"
+    \"[(open(p, 'ab').write(b'x'), time.sleep(.02)) for _ in iter(int, 1)]\",
+])
+time.sleep(.1)
+"""
+            ),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        background_artifact = next(
+            item for item in background.artifacts if item.path == "background.txt"
+        )
+        await asyncio.sleep(0.2)
+        background_bytes = await environment.read_artifact(background_artifact)
+        assert background_bytes.startswith(b"start")
+        assert len(background_bytes) == background_artifact.size
+
+        with pytest.raises(NotebookLimitExceeded, match="unsafe files"):
+            await environment.execute(
+                _single_cell_notebook(
+                    """from pathlib import Path
+Path('target.txt').write_text('target')
+Path('unsafe-link').symlink_to('target.txt')
+"""
+                ),
+                cell_timeout=120,
+                command_timeout=600,
+            )
+    finally:
+        await environment.close()
+        await environment.close()
+
+    sdk = _load_microsandbox()
+    with pytest.raises(sdk.SandboxNotFoundError):
+        await sdk.Sandbox.get(name)

--- a/plugins/notebook/uv.lock
+++ b/plugins/notebook/uv.lock
@@ -1505,6 +1505,18 @@ wheels = [
 ]
 
 [[package]]
+name = "microsandbox"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/65/2ae39dc0696be4c62294a9f75e994ab6e4607cbe17616e8e8a886e5f6e69/microsandbox-0.6.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:af13ac4dce2d6e65a5d133a82ded83b8d3d87a12f7509fd4463b6dd066b740a3", size = 33980256, upload-time = "2026-07-07T19:50:31.088Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7a/16f408a001ff95413ba24e6e8d97c0fc3612889b148ecda6fad288c667ed/microsandbox-0.6.6-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3fea362038b1b5e089784bcfb15a31cc16fc1fb65ccc75b14ed41bc47c03d10c", size = 35768649, upload-time = "2026-07-07T19:50:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fb/53b10d0009c1fc0ec9ec2e6bf105da82be0e63bb9c67559c918ff8b05d54/microsandbox-0.6.6-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6d9e1fd907f63076c1dd98320047c8e174a9b582708b58790cf8b2873d95a6e6", size = 32550428, upload-time = "2026-07-07T19:50:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5f/122938a028194bf83dfa315f58935743af51175609d4e80822da868997d3/microsandbox-0.6.6-cp310-abi3-win_amd64.whl", hash = "sha256:8d1a1792b2bc9621e50f5e63bd736767c6ddd42de167ab6cd98dce6d9f6ab7d8", size = 30137912, upload-time = "2026-07-07T19:50:45.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/08/b9e1324f46d2b2c90388d977fef91179f6a432b808ff90d29338474b07bf/microsandbox-0.6.6-cp310-abi3-win_arm64.whl", hash = "sha256:f38aa447b70ed19d3570e27a58a40f9037bc1e6891747b485359dc9f4e536d12", size = 33742966, upload-time = "2026-07-07T19:50:50.523Z" },
+]
+
+[[package]]
 name = "mistralai"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2940,12 +2952,16 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+microsandbox = [
+    { name = "microsandbox" },
+]
 modal = [
     { name = "modal" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
     { name = "modal" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2953,15 +2969,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "microsandbox", marker = "extra == 'microsandbox'", specifier = ">=0.6.6,<0.7" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4,<2" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "pillow", specifier = ">=11,<13" },
     { name = "sqlsaber", editable = "../../" },
 ]
-provides-extras = ["modal"]
+provides-extras = ["microsandbox", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "modal", specifier = ">=1.4,<2" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
     "sqlsaber-notebook[modal]",
+    "microsandbox>=0.6.6,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
     "sqlsaber-sandbox",
     "sqlsaber-viz",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1680,6 +1680,18 @@ wheels = [
 ]
 
 [[package]]
+name = "microsandbox"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/65/2ae39dc0696be4c62294a9f75e994ab6e4607cbe17616e8e8a886e5f6e69/microsandbox-0.6.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:af13ac4dce2d6e65a5d133a82ded83b8d3d87a12f7509fd4463b6dd066b740a3", size = 33980256, upload-time = "2026-07-07T19:50:31.088Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7a/16f408a001ff95413ba24e6e8d97c0fc3612889b148ecda6fad288c667ed/microsandbox-0.6.6-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3fea362038b1b5e089784bcfb15a31cc16fc1fb65ccc75b14ed41bc47c03d10c", size = 35768649, upload-time = "2026-07-07T19:50:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fb/53b10d0009c1fc0ec9ec2e6bf105da82be0e63bb9c67559c918ff8b05d54/microsandbox-0.6.6-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6d9e1fd907f63076c1dd98320047c8e174a9b582708b58790cf8b2873d95a6e6", size = 32550428, upload-time = "2026-07-07T19:50:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5f/122938a028194bf83dfa315f58935743af51175609d4e80822da868997d3/microsandbox-0.6.6-cp310-abi3-win_amd64.whl", hash = "sha256:8d1a1792b2bc9621e50f5e63bd736767c6ddd42de167ab6cd98dce6d9f6ab7d8", size = 30137912, upload-time = "2026-07-07T19:50:45.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/08/b9e1324f46d2b2c90388d977fef91179f6a432b808ff90d29338474b07bf/microsandbox-0.6.6-cp310-abi3-win_arm64.whl", hash = "sha256:f38aa447b70ed19d3570e27a58a40f9037bc1e6891747b485359dc9f4e536d12", size = 33742966, upload-time = "2026-07-07T19:50:50.523Z" },
+]
+
+[[package]]
 name = "mistralai"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3144,6 +3156,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -3175,6 +3188,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
@@ -3200,15 +3214,17 @@ modal = [
 
 [package.metadata]
 requires-dist = [
+    { name = "microsandbox", marker = "extra == 'microsandbox'", specifier = ">=0.6.6,<0.7" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4,<2" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "pillow", specifier = ">=11,<13" },
     { name = "sqlsaber", editable = "." },
 ]
-provides-extras = ["modal"]
+provides-extras = ["microsandbox", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "modal", specifier = ">=1.4,<2" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

- add an opt-in Microsandbox microVM backend for notebook execution while keeping Docker as the default
- enforce network isolation, immutable inputs, bounded streaming, fresh kernels, artifact validation, and defensive cleanup
- pin the shared notebook image to a Quay multi-architecture digest that works with Docker and Microsandbox
- add mocked and opt-in live integration coverage, dependency metadata, and user documentation

## Validation

- `uv run pytest -q` — 1150 passed, 4 skipped
- `uv run ruff check .`
- `uvx ty check src/ plugins/notebook/src/`
- `SQLSABER_RUN_MICROSANDBOX_INTEGRATION=1 uv run --project plugins/notebook pytest plugins/notebook/tests/test_notebook_microsandbox_integration.py -q`
- `SQLSABER_RUN_DOCKER_INTEGRATION=1 uv run pytest plugins/notebook/tests/test_notebook_docker_integration.py -q`
- warm `uv run saber --help` startup approximately 0.21s
