### PR TITLE
feat: add Daytona notebook execution backend

### DIFF
--- a/plugins/notebook/CHANGELOG.md
+++ b/plugins/notebook/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - add an opt-in local Microsandbox microVM execution backend while retaining Docker as the default
+- add an opt-in Daytona notebook backend pinned to the deployed legacy SDK contract
 
 ## [0.2.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-notebook-v0.1.0...sqlsaber-notebook-v0.2.0) (2026-07-22)
 

--- a/plugins/notebook/README.md
+++ b/plugins/notebook/README.md
@@ -8,6 +8,7 @@ Implemented components:
 - hardened local Docker execution (default),
 - explicit local microVM execution through the optional `microsandbox` extra,
 - explicit remote Modal Sandbox execution through the optional `modal` extra,
+- explicit remote Daytona execution through the pinned `daytona` extra,
 - fresh-kernel transactional notebook sessions,
 - bounded notebook/image rendering and history collapse,
 - `list_workspace` and `edit_cell` analyst tools,
@@ -63,6 +64,37 @@ Select Modal explicitly because query results will be uploaded to a third party:
 SQLSABER_NOTEBOOK_BACKEND=modal saber
 ```
 
+Daytona is also an explicit remote backend. The deployed legacy control plane requires
+exactly `daytona==0.143.0`, which is installed by the extra:
+
+```bash
+uv tool install --with 'sqlsaber-notebook[daytona]' sqlsaber
+export DAYTONA_API_KEY=...
+export DAYTONA_API_URL=https://your-daytona.example/api
+SQLSABER_NOTEBOOK_BACKEND=daytona saber
+```
+
+SQL query results and selected local files are uploaded to the configured Daytona
+service. SQLsaber derives a minimal `USER root` control image from the exact configured
+`SQLSABER_NOTEBOOK_IMAGE` parent, protects inputs as root, and executes notebooks as
+`jovyan`. The sandbox requests blocked outbound networking and ephemeral deletion.
+Daytona 0.143.0 has no hard age-based TTL: its 24-hour setting is inactivity-based.
+Deployments requiring a strict maximum resource age must run a label-based reaper for
+sandboxes labeled `application=sqlsaber,purpose=notebook`.
+
+Backend isolation differs by provider:
+
+| Backend | Location | Guest network | CPU/memory units | PID limit | Abandonment cleanup |
+| --- | --- | --- | --- | --- | --- |
+| Docker | Local | Docker `none` | Fractional CPU / MiB | Enforced | Per-run container removal |
+| Microsandbox | Local microVM | Disabled | Whole CPU / MiB | Process rlimit | 24-hour max duration |
+| Modal | Remote | Blocked | Fractional CPU / MiB | Not exposed | 24-hour platform lifetime |
+| Daytona | Remote | Provider block requested | Whole CPU / GiB | Not exposed | Ephemeral 24-hour inactivity stop; no hard TTL |
+
+Daytona image derivation can make the first cold start slower. Network denial, root
+input ownership, and deletion are verified by credentialed tests, but do not assume
+PID-limit or complete isolation parity across providers.
+
 Backends never fall back automatically after selection or failure.
 
 Configure a dedicated analyst model with:
@@ -105,12 +137,17 @@ uv run sqlsaber-notebook \
   "Compare revenue by region and explain material anomalies" data.csv
 ```
 
-Modal is never selected as an automatic fallback. Select it explicitly because local
-files will be uploaded to Modal:
+Remote backends are never selected as automatic fallbacks. Select one explicitly
+because local files will be uploaded to that provider:
 
 ```bash
 modal setup
 SQLSABER_NOTEBOOK_BACKEND=modal uv run sqlsaber-notebook \
+  --model anthropic:claude-sonnet-4-6 \
+  "Analyze this dataset" data.csv
+
+DAYTONA_API_KEY=... DAYTONA_API_URL=https://your-daytona.example/api \
+  SQLSABER_NOTEBOOK_BACKEND=daytona uv run sqlsaber-notebook \
   --model anthropic:claude-sonnet-4-6 \
   "Analyze this dataset" data.csv
 ```
@@ -134,4 +171,7 @@ SQLSABER_RUN_MICROSANDBOX_INTEGRATION=1 \
 
 SQLSABER_RUN_MODAL_INTEGRATION=1 \
   uv run pytest plugins/notebook/tests/test_notebook_modal_integration.py -q
+
+SQLSABER_RUN_DAYTONA_INTEGRATION=1 \
+  uv run pytest plugins/notebook/tests/test_notebook_daytona_integration.py -q
 ```

--- a/plugins/notebook/pyproject.toml
+++ b/plugins/notebook/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+daytona = ["daytona==0.143.0"]
 microsandbox = ["microsandbox>=0.6.6,<0.7"]
 modal = ["modal>=1.4,<2"]
 
@@ -32,6 +33,7 @@ packages = ["src/sqlsaber_notebook"]
 
 [dependency-groups]
 dev = [
+    "daytona==0.143.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.0.0",
     "microsandbox>=0.6.6,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",

--- a/plugins/notebook/src/sqlsaber_notebook/capability.py
+++ b/plugins/notebook/src/sqlsaber_notebook/capability.py
@@ -61,8 +61,6 @@ from .result import AnalysisResult, ManifestEntry, Workspace
 
 _RESULT_FILE_PATTERN = re.compile(r"^result_[A-Za-z0-9._-]+\.json$")
 _MAX_DISPLAY_RESULTS = 2
-_MAX_PLOT_COLUMNS = 80
-_MAX_PLOT_ROWS = 24
 
 
 @dataclass(frozen=True, slots=True)
@@ -222,8 +220,7 @@ class AnalyzeDataTool(Tool):
                 image,
                 "image/png",
                 filename=f"plot_{index}.png",
-                max_width_cells=_MAX_PLOT_COLUMNS,
-                max_height_cells=_MAX_PLOT_ROWS,
+                max_width_cells=None,
             )
 
         answer = limit_output(str(result)).strip()
@@ -514,10 +511,8 @@ def _render_plot(console: Console, image_data: bytes, *, index: int) -> None:
         console.print(f"[Plot {index} omitted: invalid PNG]")
         return
 
-    max_columns = max(1, min(_MAX_PLOT_COLUMNS, console.width - 4))
-    width = min(max_columns, image.width)
+    width = min(max(1, console.width - 4), image.width)
     pixel_height = max(2, round(image.height * width / max(1, image.width)))
-    pixel_height = min(pixel_height, _MAX_PLOT_ROWS * 2)
     if pixel_height % 2:
         pixel_height += 1
     image.thumbnail((width, pixel_height), Image.Resampling.LANCZOS)

--- a/plugins/notebook/src/sqlsaber_notebook/cli.py
+++ b/plugins/notebook/src/sqlsaber_notebook/cli.py
@@ -74,7 +74,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--backend",
-        choices=("docker", "microsandbox", "modal"),
+        choices=("docker", "microsandbox", "modal", "daytona"),
         default=os.getenv("SQLSABER_NOTEBOOK_BACKEND", "docker"),
     )
     parser.add_argument("--output", type=Path, default=Path("analysis.ipynb"))

--- a/plugins/notebook/src/sqlsaber_notebook/execution/__init__.py
+++ b/plugins/notebook/src/sqlsaber_notebook/execution/__init__.py
@@ -42,9 +42,13 @@ def resolve_notebook_backend(name: str | None = None) -> NotebookBackend:
         from .modal import ModalNotebookBackend
 
         return ModalNotebookBackend()
+    if normalized == "daytona":
+        from .daytona import DaytonaNotebookBackend
+
+        return DaytonaNotebookBackend()
     raise NotebookBackendUnavailable(
         f"Unknown notebook backend {selected!r}; expected 'docker', "
-        "'microsandbox', or 'modal'",
+        "'microsandbox', 'modal', or 'daytona'",
         backend=normalized or "unknown",
         phase="configuration",
     )

--- a/plugins/notebook/src/sqlsaber_notebook/execution/daytona.py
+++ b/plugins/notebook/src/sqlsaber_notebook/execution/daytona.py
@@ -1,0 +1,1354 @@
+"""Remote Daytona implementation of notebook execution for legacy SDK 0.143.0."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import importlib
+import importlib.util
+import json
+import math
+import os
+import shlex
+import stat
+import tempfile
+import time
+import uuid
+from collections.abc import Awaitable, Sequence
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from ._files import build_artifact_inventory, validate_notebook_bytes
+from .base import (
+    ArtifactInfo,
+    ExecutionLimits,
+    NotebookBackend,
+    NotebookBackendUnavailable,
+    NotebookEnvironment,
+    NotebookExecutionError,
+    NotebookExecutionResult,
+    NotebookExecutionTimeout,
+    NotebookImageError,
+    NotebookInfrastructureError,
+    NotebookInput,
+    NotebookLimitExceeded,
+    bound_log,
+    validate_artifact_path,
+    validate_inputs,
+)
+
+_SDK_VERSION = "0.143.0"
+_RUN_USER = "jovyan"
+_RUN_GROUP = "users"
+_RUNUSER = "/usr/sbin/runuser"
+_PYTHON = "/opt/conda/bin/python"
+_AUTO_STOP_MINUTES = 24 * 60
+_DELETE_TIMEOUT_SECONDS = 60
+_INVENTORY_MAX_BYTES = 128 * 1024
+_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+
+_ROOT_PREFLIGHT_SCRIPT = r"""
+import os
+import pathlib
+import pwd
+import shutil
+import sys
+
+run = pathlib.Path(sys.argv[1])
+if os.geteuid() != 0:
+    raise SystemExit("Daytona control process is not root")
+if pwd.getpwnam("jovyan").pw_name != "jovyan":
+    raise SystemExit("jovyan user is missing")
+for path in ("/usr/sbin/runuser", "/opt/conda/bin/python"):
+    if not pathlib.Path(path).is_file():
+        raise SystemExit(f"required executable is missing: {path}")
+if shutil.which("jupyter") is None:
+    raise SystemExit("jupyter is missing")
+probe = run / ".root-write-probe"
+probe.write_bytes(b"ok")
+probe.unlink()
+""".strip()
+
+_USER_PREFLIGHT_SCRIPT = r"""
+import os
+import pathlib
+import pwd
+import sys
+
+source = pathlib.Path(sys.argv[1])
+run = pathlib.Path(sys.argv[2])
+if pwd.getpwuid(os.geteuid()).pw_name != "jovyan":
+    raise SystemExit("notebook process is not jovyan")
+source.read_bytes()
+probe = run / ".jovyan-write-probe"
+probe.write_bytes(b"ok")
+probe.unlink()
+operations = (
+    lambda: source.write_bytes(b"changed"),
+    lambda: source.chmod(0o600),
+    lambda: source.rename(run / "moved-input"),
+    lambda: source.unlink(),
+    lambda: (source.parent / "replacement").write_bytes(b"replacement"),
+)
+for operation in operations:
+    try:
+        operation()
+    except OSError:
+        continue
+    raise SystemExit("protected notebook input was mutable")
+""".strip()
+
+_STOP_USER_PROCESSES_SCRIPT = r"""
+import os
+import pwd
+import signal
+import time
+
+uid = pwd.getpwnam("jovyan").pw_uid
+for _ in range(4):
+    found = False
+    for entry in os.scandir("/proc"):
+        if not entry.name.isdigit():
+            continue
+        try:
+            if os.stat(entry.path).st_uid == uid:
+                os.kill(int(entry.name), signal.SIGKILL)
+                found = True
+        except (FileNotFoundError, ProcessLookupError, PermissionError):
+            pass
+    if not found:
+        break
+    time.sleep(0.05)
+""".strip()
+
+_INVENTORY_SCRIPT = r"""
+import json
+import os
+import stat
+import sys
+
+root = sys.argv[1]
+output = sys.argv[2]
+max_artifacts = int(sys.argv[3])
+max_file = int(sys.argv[4])
+max_total = int(sys.argv[5])
+max_notebook = int(sys.argv[6])
+max_directories = 256
+max_depth = 32
+max_path = 1024
+entries = {}
+artifact_total = 0
+directories = 0
+try:
+    for current, dirs, files in os.walk(root, followlinks=False):
+        dirs.sort()
+        files.sort()
+        relative_dir = os.path.relpath(current, root)
+        depth = 0 if relative_dir == "." else len(relative_dir.split(os.sep))
+        if depth > max_depth:
+            raise ValueError("generated directory tree is too deep")
+        directories += len(dirs)
+        if directories > max_directories:
+            raise ValueError("too many generated directories")
+        for name in dirs:
+            path = os.path.join(current, name)
+            if os.path.islink(path):
+                raise ValueError("symlinked generated directory")
+        for name in files:
+            path = os.path.join(current, name)
+            info = os.lstat(path)
+            if not stat.S_ISREG(info.st_mode):
+                raise ValueError("non-regular generated file")
+            relative = os.path.relpath(path, root).replace(os.sep, "/")
+            if len(relative) > max_path:
+                raise ValueError("generated path is too long")
+            if relative in entries:
+                raise ValueError("duplicate generated path")
+            if relative == "notebook.ipynb":
+                if info.st_size > max_notebook:
+                    raise ValueError("executed notebook is too large")
+            else:
+                if info.st_size > max_file:
+                    raise ValueError("generated artifact is too large")
+                artifact_total += info.st_size
+                if artifact_total > max_total:
+                    raise ValueError("generated artifacts are too large")
+                if len(entries) >= max_artifacts + ("notebook.ipynb" in entries):
+                    raise ValueError("too many generated artifacts")
+            entries[relative] = {
+                "size": info.st_size,
+                "device": info.st_dev,
+                "inode": info.st_ino,
+            }
+    if "notebook.ipynb" not in entries:
+        raise ValueError("executed notebook is missing")
+    encoded = json.dumps({"files": entries}, separators=(",", ":")).encode()
+    if len(encoded) > 131072:
+        raise ValueError("artifact inventory is too large")
+    with open(output, "wb") as stream:
+        stream.write(encoded)
+except Exception as exc:
+    print(str(exc)[:1024], file=sys.stderr)
+    raise SystemExit(2)
+""".strip()
+
+_METADATA_SCRIPT = r"""
+import json
+import os
+import stat
+import sys
+
+info = os.lstat(sys.argv[1])
+print(json.dumps({
+    "regular": stat.S_ISREG(info.st_mode),
+    "size": info.st_size,
+    "device": info.st_dev,
+    "inode": info.st_ino,
+}, separators=(",", ":")))
+""".strip()
+
+_LOG_READER_SCRIPT = r"""
+import base64
+import json
+import pathlib
+import sys
+
+limit = int(sys.argv[3])
+def read_bounded(path):
+    stream = pathlib.Path(path)
+    try:
+        size = stream.stat().st_size
+        with stream.open("rb") as handle:
+            if size <= limit:
+                return handle.read(limit + 1)
+            head = limit // 2
+            value = handle.read(head)
+            handle.seek(max(0, size - (limit - head)))
+            return value + handle.read(limit - head)
+    except FileNotFoundError:
+        return b""
+print(json.dumps({
+    "stdout": base64.b64encode(read_bounded(sys.argv[1])).decode(),
+    "stderr": base64.b64encode(read_bounded(sys.argv[2])).decode(),
+}, separators=(",", ":")))
+""".strip()
+
+_LOG_WRAPPER = 'stdout=$1; stderr=$2; shift 2; "$@" >"$stdout" 2>"$stderr"'
+
+Identity = tuple[int, int, int]
+
+
+class DaytonaNotebookBackend(NotebookBackend):
+    """Open explicitly selected notebook environments in Daytona."""
+
+    name = "daytona"
+
+    def available(self) -> bool:
+        return importlib.util.find_spec("daytona") is not None
+
+    async def open(
+        self,
+        inputs: Sequence[NotebookInput],
+        *,
+        image: str,
+        limits: ExecutionLimits,
+    ) -> DaytonaNotebookEnvironment:
+        validated = validate_inputs(inputs, limits, backend=self.name)
+        cpu = _daytona_cpu(limits.cpu_cores)
+        memory = _daytona_memory_gib(limits.memory_mb)
+        sdk = _load_daytona()
+        name = f"sqlsaber-notebook-{uuid.uuid4().hex}"
+        client: Any | None = None
+        sandbox: Any | None = None
+        try:
+            client = sdk.AsyncDaytona()
+            runtime_image = sdk.Image.base(image).dockerfile_commands(
+                ["USER root", "WORKDIR /home/jovyan"]
+            )
+            params = sdk.CreateSandboxFromImageParams(
+                image=runtime_image,
+                language="python",
+                os_user="root",
+                name=name,
+                labels={"application": "sqlsaber", "purpose": "notebook"},
+                resources=sdk.Resources(cpu=cpu, memory=memory),
+                network_block_all=True,
+                ephemeral=True,
+                auto_stop_interval=_AUTO_STOP_MINUTES,
+            )
+            async with asyncio.timeout(limits.image_prepare_seconds):
+                sandbox = await client.create(
+                    params,
+                    timeout=limits.image_prepare_seconds,
+                )
+            async with asyncio.timeout(limits.open_seconds):
+                work_dir = await sandbox.get_work_dir()
+            remote_root = f"{work_dir.rstrip('/')}/sqlsaber-notebook-{uuid.uuid4().hex}"
+            environment = DaytonaNotebookEnvironment(
+                sdk=sdk,
+                client=client,
+                sandbox=sandbox,
+                sandbox_name=name,
+                limits=limits,
+                remote_root=remote_root,
+            )
+            async with asyncio.timeout(limits.open_seconds):
+                await environment.stage(validated)
+            return environment
+        except asyncio.CancelledError:
+            await _best_effort_cleanup(sdk, client, sandbox, name)
+            raise
+        except TimeoutError as exc:
+            await _best_effort_cleanup(sdk, client, sandbox, name)
+            phase = "image-prepare" if sandbox is None else "input-upload"
+            seconds = (
+                limits.image_prepare_seconds if sandbox is None else limits.open_seconds
+            )
+            raise NotebookExecutionTimeout(
+                f"Daytona {phase} timed out after {seconds} seconds",
+                backend=self.name,
+                phase=phase,
+            ) from exc
+        except NotebookExecutionError:
+            await _best_effort_cleanup(sdk, client, sandbox, name)
+            raise
+        except Exception as exc:
+            await _best_effort_cleanup(sdk, client, sandbox, name)
+            if _is_sdk_exception(exc, sdk, "DaytonaTimeoutError"):
+                raise NotebookExecutionTimeout(
+                    "Daytona image preparation timed out",
+                    backend=self.name,
+                    phase="image-prepare",
+                    diagnostics=bound_log(str(exc), limits.max_log_chars),
+                ) from exc
+            if sandbox is None and _looks_like_image_error(exc):
+                raise NotebookImageError(
+                    f"Could not prepare Daytona notebook image {image!r}",
+                    backend=self.name,
+                    phase="image-prepare",
+                    diagnostics=bound_log(str(exc), limits.max_log_chars),
+                ) from exc
+            if sandbox is None:
+                raise NotebookBackendUnavailable(
+                    "Daytona could not create a sandbox; verify DAYTONA_API_KEY, "
+                    "DAYTONA_API_URL, account limits, and service availability",
+                    backend=self.name,
+                    phase="environment-open",
+                    diagnostics=bound_log(str(exc), limits.max_log_chars),
+                ) from exc
+            raise NotebookInfrastructureError(
+                "Could not initialize the Daytona notebook environment",
+                backend=self.name,
+                phase="input-upload",
+                diagnostics=bound_log(str(exc), limits.max_log_chars),
+            ) from exc
+
+
+class DaytonaNotebookEnvironment(NotebookEnvironment):
+    """A private Daytona sandbox reused for fresh-kernel notebook runs."""
+
+    def __init__(
+        self,
+        *,
+        sdk: Any,
+        client: Any,
+        sandbox: Any,
+        sandbox_name: str,
+        limits: ExecutionLimits,
+        remote_root: str,
+    ) -> None:
+        self.sdk = sdk
+        self.client = client
+        self.sandbox = sandbox
+        self.sandbox_name = sandbox_name
+        self.limits = limits
+        self.remote_root = remote_root
+        self.inputs_path = f"{remote_root}/inputs"
+        self.run_path = f"{remote_root}/run"
+        self.control_path = f"{remote_root}/control"
+        self.notebook_path = f"{self.run_path}/notebook.ipynb"
+        self.inventory_path = f"{self.control_path}/inventory.json"
+        self.stdout_path = f"{self.control_path}/stdout.log"
+        self.stderr_path = f"{self.control_path}/stderr.log"
+        self._inventory: tuple[ArtifactInfo, ...] = ()
+        self._identities: dict[str, Identity] = {}
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._cleanup_task: asyncio.Task[None] | None = None
+
+    async def stage(self, inputs: Sequence[NotebookInput]) -> None:
+        sentinel = f"{self.inputs_path}/.sqlsaber-preflight"
+        try:
+            result = await self._exec(
+                "input-upload",
+                "mkdir",
+                "-p",
+                self.inputs_path,
+                self.run_path,
+                self.control_path,
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not create Daytona notebook directories",
+                phase="input-upload",
+            )
+            await self._upload_file(sentinel, b"immutable", phase="input-upload")
+            for item in inputs:
+                await self._upload_file(
+                    f"{self.inputs_path}/{item.name}",
+                    item.data,
+                    phase="input-upload",
+                )
+            result = await self._exec(
+                "input-upload",
+                "chown",
+                "-R",
+                "root:root",
+                self.inputs_path,
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not protect Daytona notebook input ownership",
+                phase="input-upload",
+            )
+            result = await self._exec(
+                "input-upload",
+                "chmod",
+                "-R",
+                "a-w",
+                self.inputs_path,
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not make Daytona notebook inputs read-only",
+                phase="input-upload",
+            )
+            await self._preflight_runtime(sentinel)
+            result = await self._exec(
+                "input-upload",
+                "rm",
+                "-f",
+                sentinel,
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Could not remove the Daytona input preflight sentinel",
+                phase="input-upload",
+            )
+        except NotebookExecutionError:
+            raise
+        except Exception as exc:
+            raise NotebookInfrastructureError(
+                "Could not stage Daytona notebook inputs",
+                backend="daytona",
+                phase="input-upload",
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    async def execute(
+        self,
+        notebook: bytes,
+        *,
+        cell_timeout: int | None,
+        command_timeout: int | None,
+    ) -> NotebookExecutionResult:
+        async with self._lock:
+            self._ensure_open()
+            validate_notebook_bytes(
+                notebook,
+                self.limits,
+                backend="daytona",
+                phase="notebook-upload",
+            )
+            self._inventory = ()
+            self._identities = {}
+            notebook_command_started = False
+            run_secured = False
+            try:
+                await self._reset_run(notebook)
+                effective_cell_timeout = _bounded_timeout(
+                    cell_timeout, self.limits.cell_seconds
+                )
+                effective_command_timeout = _bounded_timeout(
+                    command_timeout, self.limits.command_seconds
+                )
+                notebook_command_started = True
+                response = await self._exec(
+                    "notebook-execution",
+                    "/bin/sh",
+                    "-c",
+                    _LOG_WRAPPER,
+                    "sqlsaber-nbconvert",
+                    self.stdout_path,
+                    self.stderr_path,
+                    _RUNUSER,
+                    "-u",
+                    _RUN_USER,
+                    "--",
+                    "jupyter",
+                    "nbconvert",
+                    "--to",
+                    "notebook",
+                    "--execute",
+                    "--inplace",
+                    "--allow-errors",
+                    f"--ExecutePreprocessor.timeout={effective_cell_timeout or -1}",
+                    "notebook.ipynb",
+                    timeout=effective_command_timeout,
+                    workdir=self.run_path,
+                )
+                stdout, stderr = await self._read_remote_logs()
+                await self._stop_run_processes()
+                await self._freeze_run()
+                run_secured = True
+                if response[0] != 0:
+                    raise NotebookInfrastructureError(
+                        "Daytona notebook execution failed",
+                        backend="daytona",
+                        phase="notebook-execution",
+                        diagnostics=stderr or stdout,
+                    )
+                sizes, identities = await self._inventory_sizes()
+                notebook_size = sizes.pop("notebook.ipynb", None)
+                if notebook_size is None:
+                    raise NotebookInfrastructureError(
+                        "Daytona execution did not return a notebook",
+                        backend="daytona",
+                        phase="notebook-download",
+                    )
+                if notebook_size > self.limits.max_notebook_bytes:
+                    raise NotebookLimitExceeded(
+                        f"Notebook exceeds {self.limits.max_notebook_bytes} bytes",
+                        backend="daytona",
+                        phase="notebook-download",
+                    )
+                executed = await self._download_frozen_file(
+                    self.notebook_path,
+                    expected_size=notebook_size,
+                    expected_identity=identities["notebook.ipynb"],
+                    byte_limit=self.limits.max_notebook_bytes,
+                    phase="notebook-download",
+                )
+                validate_notebook_bytes(
+                    executed,
+                    self.limits,
+                    backend="daytona",
+                    phase="notebook-download",
+                )
+                inventory = build_artifact_inventory(
+                    sizes,
+                    self.limits,
+                    backend="daytona",
+                )
+                self._identities = {
+                    path: identity
+                    for path, identity in identities.items()
+                    if path != "notebook.ipynb"
+                }
+                self._inventory = inventory
+                return NotebookExecutionResult(
+                    notebook=executed,
+                    artifacts=inventory,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            except NotebookExecutionTimeout:
+                await self._terminate_after_interruption()
+                raise
+            except asyncio.CancelledError:
+                await self._terminate_after_interruption()
+                raise
+            except NotebookExecutionError:
+                if notebook_command_started and not run_secured:
+                    await self._terminate_after_interruption()
+                raise
+            except Exception as exc:
+                if notebook_command_started and not run_secured:
+                    await self._terminate_after_interruption()
+                raise NotebookInfrastructureError(
+                    "Could not transfer Daytona notebook results",
+                    backend="daytona",
+                    phase="notebook-download",
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+
+    async def read_artifact(self, artifact: ArtifactInfo) -> bytes:
+        async with self._lock:
+            self._ensure_open()
+            if artifact not in self._inventory:
+                raise NotebookInfrastructureError(
+                    f"Unknown artifact: {artifact.path}",
+                    backend="daytona",
+                    phase="artifact-download",
+                )
+            relative = validate_artifact_path(artifact.path, backend="daytona")
+            identity = self._identities.get(artifact.path)
+            if identity is None:
+                raise NotebookInfrastructureError(
+                    f"Artifact identity is unavailable: {artifact.path}",
+                    backend="daytona",
+                    phase="artifact-download",
+                )
+            try:
+                return await self._download_frozen_file(
+                    f"{self.run_path}/{relative.as_posix()}",
+                    expected_size=artifact.size,
+                    expected_identity=identity,
+                    byte_limit=self.limits.max_artifact_bytes,
+                    phase="artifact-download",
+                )
+            except NotebookExecutionTimeout:
+                await self._terminate_after_interruption()
+                raise
+            except NotebookExecutionError:
+                raise
+            except Exception as exc:
+                raise NotebookInfrastructureError(
+                    f"Could not read artifact: {artifact.path}",
+                    backend="daytona",
+                    phase="artifact-download",
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+
+    async def list_workspace(self) -> tuple[ArtifactInfo, ...]:
+        async with self._lock:
+            self._ensure_open()
+            return self._inventory
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._cleanup_task is None:
+                self._closed = True
+                self._inventory = ()
+                self._identities = {}
+                self._cleanup_task = asyncio.create_task(self._cleanup())
+            task = self._cleanup_task
+        await asyncio.shield(task)
+
+    async def _reset_run(self, notebook: bytes) -> None:
+        result = await self._exec(
+            "run-setup",
+            "rm",
+            "-rf",
+            "--",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not reset the Daytona run directory",
+            phase="run-setup",
+        )
+        result = await self._exec(
+            "run-setup",
+            "mkdir",
+            "-p",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not recreate the Daytona run directory",
+            phase="run-setup",
+        )
+        result = await self._exec(
+            "run-setup",
+            "rm",
+            "-f",
+            self.stdout_path,
+            self.stderr_path,
+            self.inventory_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not reset Daytona control files",
+            phase="run-setup",
+        )
+        await self._upload_file(
+            self.notebook_path,
+            notebook,
+            phase="notebook-upload",
+        )
+        result = await self._exec(
+            "run-setup",
+            "chown",
+            "-R",
+            f"{_RUN_USER}:{_RUN_GROUP}",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image cannot prepare an unprivileged Daytona run directory",
+            phase="run-setup",
+            image_error=True,
+        )
+
+    async def _preflight_runtime(self, sentinel: str) -> None:
+        result = await self._exec(
+            "image-preflight",
+            _PYTHON,
+            "-c",
+            _ROOT_PREFLIGHT_SCRIPT,
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image must provide a root Daytona control identity",
+            phase="image-preflight",
+            image_error=True,
+        )
+        result = await self._exec(
+            "image-preflight",
+            _RUNUSER,
+            "-u",
+            _RUN_USER,
+            "--",
+            "jupyter",
+            "nbconvert",
+            "--version",
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image must provide jovyan, runuser, jupyter, and nbconvert",
+            phase="image-preflight",
+            image_error=True,
+        )
+        result = await self._exec(
+            "image-preflight",
+            "chown",
+            "-R",
+            f"{_RUN_USER}:{_RUN_GROUP}",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image cannot prepare a jovyan-owned run directory",
+            phase="image-preflight",
+            image_error=True,
+        )
+        result = await self._exec(
+            "image-preflight",
+            _RUNUSER,
+            "-u",
+            _RUN_USER,
+            "--",
+            _PYTHON,
+            "-c",
+            _USER_PREFLIGHT_SCRIPT,
+            sentinel,
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Notebook image does not preserve immutable Daytona inputs for jovyan",
+            phase="image-preflight",
+            image_error=True,
+        )
+
+    async def _stop_run_processes(self) -> None:
+        result = await self._exec(
+            "notebook-execution",
+            _PYTHON,
+            "-c",
+            _STOP_USER_PROCESSES_SCRIPT,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not stop background Daytona notebook processes",
+            phase="notebook-execution",
+        )
+
+    async def _freeze_run(self) -> None:
+        result = await self._exec(
+            "artifact-inventory",
+            "chown",
+            "-R",
+            "root:root",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not freeze Daytona notebook results",
+            phase="artifact-inventory",
+        )
+        result = await self._exec(
+            "artifact-inventory",
+            "chmod",
+            "-R",
+            "a-w",
+            self.run_path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not freeze Daytona notebook results",
+            phase="artifact-inventory",
+        )
+
+    async def _inventory_sizes(self) -> tuple[dict[str, int], dict[str, Identity]]:
+        result = await self._exec(
+            "artifact-inventory",
+            _PYTHON,
+            "-c",
+            _INVENTORY_SCRIPT,
+            self.run_path,
+            self.inventory_path,
+            str(self.limits.max_artifacts),
+            str(self.limits.max_artifact_bytes),
+            str(self.limits.max_total_artifact_bytes),
+            str(self.limits.max_notebook_bytes),
+            timeout=self.limits.open_seconds,
+        )
+        if result[0] != 0:
+            raise NotebookLimitExceeded(
+                "Daytona artifact inventory exceeded limits or contained unsafe files",
+                backend="daytona",
+                phase="artifact-inventory",
+                diagnostics=result[1],
+            )
+        control_identity = await self._remote_identity(
+            self.inventory_path,
+            phase="artifact-inventory",
+        )
+        if control_identity[2] > _INVENTORY_MAX_BYTES:
+            raise NotebookInfrastructureError(
+                "Daytona returned an oversized artifact inventory",
+                backend="daytona",
+                phase="artifact-inventory",
+            )
+        payload_bytes = await self._download_frozen_file(
+            self.inventory_path,
+            expected_size=control_identity[2],
+            expected_identity=control_identity,
+            byte_limit=_INVENTORY_MAX_BYTES,
+            phase="artifact-inventory",
+        )
+        try:
+            payload = json.loads(payload_bytes)
+            files = payload["files"]
+            if not isinstance(files, dict):
+                raise TypeError("files must be an object")
+            sizes: dict[str, int] = {}
+            identities: dict[str, Identity] = {}
+            for path, metadata in files.items():
+                if not isinstance(path, str) or not isinstance(metadata, dict):
+                    raise TypeError("invalid inventory entry")
+                size = metadata["size"]
+                device = metadata["device"]
+                inode = metadata["inode"]
+                if not all(isinstance(value, int) for value in (size, device, inode)):
+                    raise TypeError("invalid inventory identity")
+                if size < 0 or device < 0 or inode < 0:
+                    raise ValueError("negative inventory identity")
+                sizes[path] = size
+                identities[path] = (device, inode, size)
+            return sizes, identities
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise NotebookInfrastructureError(
+                "Daytona returned an invalid artifact inventory",
+                backend="daytona",
+                phase="artifact-inventory",
+            ) from exc
+
+    async def _read_remote_logs(self) -> tuple[str, str]:
+        byte_limit = max(self.limits.max_log_chars * 4, 32_000)
+        result = await self._exec(
+            "notebook-execution",
+            _PYTHON,
+            "-c",
+            _LOG_READER_SCRIPT,
+            self.stdout_path,
+            self.stderr_path,
+            str(byte_limit),
+            timeout=self.limits.open_seconds,
+            result_limit=byte_limit * 3,
+        )
+        self._require_success(
+            result,
+            "Could not read bounded Daytona notebook logs",
+            phase="notebook-execution",
+        )
+        try:
+            payload = json.loads(result[1])
+            stdout = base64.b64decode(payload["stdout"], validate=True)
+            stderr = base64.b64decode(payload["stderr"], validate=True)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise NotebookInfrastructureError(
+                "Daytona returned invalid bounded notebook logs",
+                backend="daytona",
+                phase="notebook-execution",
+            ) from exc
+        return (
+            bound_log(stdout, self.limits.max_log_chars),
+            bound_log(stderr, self.limits.max_log_chars),
+        )
+
+    async def _upload_file(self, path: str, data: bytes, *, phase: str) -> None:
+        try:
+            await self._operation(
+                self.sandbox.fs.upload_file(
+                    data,
+                    path,
+                    timeout=self.limits.open_seconds,
+                ),
+                timeout=self.limits.open_seconds,
+                phase=phase,
+            )
+        except NotebookExecutionError:
+            raise
+        except Exception as exc:
+            raise NotebookInfrastructureError(
+                f"Could not upload Daytona file for {phase}",
+                backend="daytona",
+                phase=phase,
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    async def _download_frozen_file(
+        self,
+        remote_path: str,
+        *,
+        expected_size: int,
+        expected_identity: Identity,
+        byte_limit: int,
+        phase: str,
+    ) -> bytes:
+        if expected_size < 0 or expected_size > byte_limit:
+            raise NotebookLimitExceeded(
+                f"Daytona file exceeds {byte_limit} bytes",
+                backend="daytona",
+                phase=phase,
+            )
+        if await self._remote_identity(remote_path, phase=phase) != expected_identity:
+            raise NotebookInfrastructureError(
+                "Daytona file changed after inventory",
+                backend="daytona",
+                phase=phase,
+            )
+        file_descriptor, local_name = tempfile.mkstemp(prefix="sqlsaber-daytona-")
+        os.close(file_descriptor)
+        local_path = Path(local_name)
+        try:
+            await self._operation(
+                self.sandbox.fs.download_file(
+                    remote_path,
+                    local_name,
+                    self.limits.open_seconds,
+                ),
+                timeout=self.limits.open_seconds,
+                phase=phase,
+            )
+            metadata = await asyncio.to_thread(local_path.lstat)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_size != expected_size:
+                raise NotebookInfrastructureError(
+                    "Daytona file changed during download",
+                    backend="daytona",
+                    phase=phase,
+                )
+            data = await asyncio.to_thread(
+                _read_bounded_local_file,
+                local_path,
+                byte_limit,
+            )
+            if len(data) != expected_size:
+                raise NotebookInfrastructureError(
+                    "Daytona file changed during download",
+                    backend="daytona",
+                    phase=phase,
+                )
+            if (
+                await self._remote_identity(remote_path, phase=phase)
+                != expected_identity
+            ):
+                raise NotebookInfrastructureError(
+                    "Daytona file changed during download",
+                    backend="daytona",
+                    phase=phase,
+                )
+            return data
+        finally:
+            with contextlib.suppress(OSError):
+                local_path.unlink()
+
+    async def _remote_identity(self, path: str, *, phase: str) -> Identity:
+        result = await self._exec(
+            phase,
+            _PYTHON,
+            "-c",
+            _METADATA_SCRIPT,
+            path,
+            timeout=self.limits.open_seconds,
+        )
+        self._require_success(
+            result,
+            "Could not verify Daytona file metadata",
+            phase=phase,
+        )
+        try:
+            payload = json.loads(result[1])
+            if payload["regular"] is not True:
+                raise ValueError("file is not regular")
+            size = payload["size"]
+            device = payload["device"]
+            inode = payload["inode"]
+            if not all(isinstance(value, int) for value in (size, device, inode)):
+                raise TypeError("invalid metadata")
+            if size < 0 or device < 0 or inode < 0:
+                raise ValueError("negative metadata")
+            return device, inode, size
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise NotebookInfrastructureError(
+                "Daytona returned invalid file metadata",
+                backend="daytona",
+                phase=phase,
+                diagnostics=result[1],
+            ) from exc
+
+    async def _exec(
+        self,
+        phase: str,
+        *argv: str,
+        timeout: int | None,
+        workdir: str | None = None,
+        result_limit: int | None = None,
+    ) -> tuple[int, str]:
+        try:
+            async with asyncio.timeout(timeout):
+                response = await self.sandbox.process.exec(
+                    shlex.join(argv),
+                    cwd=workdir,
+                    timeout=timeout,
+                )
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Daytona {phase} timed out after {timeout} seconds",
+                backend="daytona",
+                phase=phase,
+            ) from exc
+        except Exception as exc:
+            if _is_sdk_exception(exc, self.sdk, "DaytonaTimeoutError"):
+                raise NotebookExecutionTimeout(
+                    f"Daytona {phase} timed out after {timeout} seconds",
+                    backend="daytona",
+                    phase=phase,
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+            raise NotebookInfrastructureError(
+                f"Daytona {phase} operation failed",
+                backend="daytona",
+                phase=phase,
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+        return response.exit_code, bound_log(
+            response.result,
+            result_limit or self.limits.max_log_chars,
+        )
+
+    async def _operation(
+        self,
+        operation: Awaitable[Any],
+        *,
+        timeout: int,
+        phase: str,
+    ) -> Any:
+        try:
+            async with asyncio.timeout(timeout):
+                return await operation
+        except TimeoutError as exc:
+            raise NotebookExecutionTimeout(
+                f"Daytona {phase} timed out after {timeout} seconds",
+                backend="daytona",
+                phase=phase,
+            ) from exc
+        except Exception as exc:
+            if _is_sdk_exception(exc, self.sdk, "DaytonaTimeoutError"):
+                raise NotebookExecutionTimeout(
+                    f"Daytona {phase} timed out after {timeout} seconds",
+                    backend="daytona",
+                    phase=phase,
+                    diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+                ) from exc
+            raise NotebookInfrastructureError(
+                f"Daytona {phase} operation failed",
+                backend="daytona",
+                phase=phase,
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    def _require_success(
+        self,
+        result: tuple[int, str],
+        message: str,
+        *,
+        phase: str,
+        image_error: bool = False,
+    ) -> None:
+        if result[0] == 0:
+            return
+        error_type = NotebookImageError if image_error else NotebookInfrastructureError
+        raise error_type(
+            message,
+            backend="daytona",
+            phase=phase,
+            diagnostics=result[1],
+        )
+
+    async def _terminate_after_interruption(self) -> None:
+        self._closed = True
+        self._inventory = ()
+        self._identities = {}
+        if self._cleanup_task is None:
+            self._cleanup_task = asyncio.create_task(self._cleanup())
+        with contextlib.suppress(Exception):
+            await asyncio.shield(self._cleanup_task)
+
+    async def _cleanup(self) -> None:
+        try:
+            await _delete_resources(
+                self.sdk,
+                self.client,
+                self.sandbox,
+                self.sandbox_name,
+            )
+        except Exception as exc:
+            raise NotebookInfrastructureError(
+                "Could not remove the Daytona notebook environment",
+                backend="daytona",
+                phase="cleanup",
+                diagnostics=bound_log(str(exc), self.limits.max_log_chars),
+            ) from exc
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise NotebookInfrastructureError(
+                "Notebook environment is closed",
+                backend="daytona",
+                phase="lifecycle",
+            )
+
+
+def _daytona_cpu(value: float) -> int:
+    if not math.isfinite(value):
+        raise NotebookLimitExceeded(
+            "Daytona CPU limit must be finite",
+            backend="daytona",
+            phase="configuration",
+        )
+    result = math.floor(value)
+    if result < 1:
+        raise NotebookLimitExceeded(
+            "Daytona requires at least one whole CPU",
+            backend="daytona",
+            phase="configuration",
+        )
+    return result
+
+
+def _daytona_memory_gib(value: int) -> int:
+    result = value // 1024
+    if result < 1:
+        raise NotebookLimitExceeded(
+            "Daytona requires at least one GiB of memory",
+            backend="daytona",
+            phase="configuration",
+        )
+    return result
+
+
+def _bounded_timeout(
+    requested: int | None,
+    configured: int | None,
+) -> int | None:
+    if requested is None:
+        return configured
+    if configured is None:
+        return requested
+    return min(requested, configured)
+
+
+def _read_bounded_local_file(path: Path, byte_limit: int) -> bytes:
+    with path.open("rb") as stream:
+        data = stream.read(byte_limit + 1)
+    if len(data) > byte_limit:
+        raise NotebookLimitExceeded(
+            f"Daytona download exceeds {byte_limit} bytes",
+            backend="daytona",
+            phase="file-download",
+        )
+    return data
+
+
+async def _delete_resources(
+    sdk: Any,
+    client: Any,
+    sandbox: Any,
+    sandbox_name: str,
+) -> None:
+    try:
+        async with asyncio.timeout(_DELETE_TIMEOUT_SECONDS + 5):
+            await sandbox.delete(timeout=_DELETE_TIMEOUT_SECONDS)
+        await _wait_until_deleted(
+            client,
+            sandbox_name,
+            sdk,
+            timeout=_DELETE_TIMEOUT_SECONDS,
+        )
+    finally:
+        await asyncio.wait_for(client.close(), timeout=10)
+
+
+async def _wait_until_deleted(
+    client: Any,
+    sandbox_name: str,
+    sdk: Any,
+    *,
+    timeout: float,
+    poll_interval: float = 0.25,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Daytona sandbox {sandbox_name!r} still exists after deletion"
+            )
+        try:
+            await asyncio.wait_for(
+                client.get(sandbox_name),
+                timeout=min(10, remaining),
+            )
+        except Exception as exc:
+            if _is_sdk_exception(exc, sdk, "DaytonaNotFoundError"):
+                return
+            raise
+        await asyncio.sleep(min(poll_interval, max(0, deadline - time.monotonic())))
+
+
+async def _best_effort_cleanup(
+    sdk: Any,
+    client: Any | None,
+    sandbox: Any | None,
+    sandbox_name: str,
+) -> None:
+    if client is None:
+        return
+
+    async def cleanup() -> None:
+        target = sandbox
+        if target is None:
+            try:
+                target = await _lookup_after_create_failure(
+                    client,
+                    sandbox_name,
+                    sdk,
+                )
+            except BaseException:
+                await asyncio.wait_for(client.close(), timeout=10)
+                raise
+        if target is None:
+            await asyncio.wait_for(client.close(), timeout=10)
+            return
+        await _delete_resources(sdk, client, target, sandbox_name)
+
+    task = asyncio.create_task(cleanup())
+    with contextlib.suppress(Exception):
+        await asyncio.shield(task)
+
+
+async def _lookup_after_create_failure(
+    client: Any,
+    sandbox_name: str,
+    sdk: Any,
+) -> Any | None:
+    for attempt in range(5):
+        try:
+            return await asyncio.wait_for(client.get(sandbox_name), timeout=2)
+        except Exception as exc:
+            if not _is_sdk_exception(exc, sdk, "DaytonaNotFoundError"):
+                raise
+        if attempt < 4:
+            await asyncio.sleep(0.25)
+    return None
+
+
+def _looks_like_image_error(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    message = str(exc).lower()
+    return status_code == 404 or any(
+        marker in message
+        for marker in (
+            "image not found",
+            "failed to pull",
+            "manifest unknown",
+            "registry error",
+            "snapshot creation failed",
+        )
+    )
+
+
+def _is_sdk_exception(exc: Exception, sdk: Any, *names: str) -> bool:
+    types = tuple(
+        candidate
+        for name in names
+        if isinstance((candidate := getattr(sdk, name, None)), type)
+    )
+    return bool(types) and isinstance(exc, types)
+
+
+def _load_daytona() -> Any:
+    try:
+        sdk = importlib.import_module("daytona")
+    except ImportError as exc:
+        raise NotebookBackendUnavailable(
+            "Daytona backend requires the `sqlsaber-notebook[daytona]` extra",
+            backend="daytona",
+            phase="availability",
+        ) from exc
+    try:
+        installed_version = version("daytona")
+    except PackageNotFoundError as exc:
+        raise NotebookBackendUnavailable(
+            "Could not determine the installed Daytona SDK version",
+            backend="daytona",
+            phase="availability",
+        ) from exc
+    if installed_version != _SDK_VERSION:
+        raise NotebookBackendUnavailable(
+            f"Daytona backend requires daytona=={_SDK_VERSION}; found "
+            f"{installed_version}",
+            backend="daytona",
+            phase="availability",
+        )
+    required = (
+        "AsyncDaytona",
+        "CreateSandboxFromImageParams",
+        "Image",
+        "Resources",
+        "DaytonaError",
+        "DaytonaNotFoundError",
+        "DaytonaRateLimitError",
+        "DaytonaTimeoutError",
+    )
+    missing = [name for name in required if not hasattr(sdk, name)]
+    if missing:
+        raise NotebookBackendUnavailable(
+            "Installed Daytona SDK 0.143.0 is incompatible; missing: "
+            + ", ".join(missing),
+            backend="daytona",
+            phase="availability",
+        )
+    return sdk

--- a/plugins/notebook/src/sqlsaber_notebook/execution/daytona.py
+++ b/plugins/notebook/src/sqlsaber_notebook/execution/daytona.py
@@ -48,15 +48,56 @@ _AUTO_STOP_MINUTES = 24 * 60
 _DELETE_TIMEOUT_SECONDS = 60
 _INVENTORY_MAX_BYTES = 128 * 1024
 _DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+_REMOTE_PARENT = "/tmp/sqlsaber-notebook"
+
+_SECURE_PARENT_SCRIPT = r"""
+import os
+import pathlib
+import stat
+import sys
+
+parent = pathlib.Path(sys.argv[1])
+
+def validate_directory(path, *, allow_sticky_writable):
+    info = os.lstat(path)
+    mode = stat.S_IMODE(info.st_mode)
+    if not stat.S_ISDIR(info.st_mode):
+        raise SystemExit(f"trusted ancestor is not a directory: {path}")
+    if info.st_uid != 0:
+        raise SystemExit(f"trusted ancestor is not root-owned: {path}")
+    if mode & 0o022 and not (allow_sticky_writable and mode & stat.S_ISVTX):
+        raise SystemExit(f"trusted ancestor is writable by non-root users: {path}")
+
+for ancestor in (*reversed(parent.parent.parents), parent.parent):
+    validate_directory(ancestor, allow_sticky_writable=True)
+try:
+    parent.mkdir(mode=0o711)
+except FileExistsError:
+    pass
+validate_directory(parent, allow_sticky_writable=False)
+""".strip()
 
 _ROOT_PREFLIGHT_SCRIPT = r"""
 import os
 import pathlib
 import pwd
 import shutil
+import stat
 import sys
 
 run = pathlib.Path(sys.argv[1])
+trusted_root = run.parent
+
+def validate_directory(path, *, allow_sticky_writable):
+    info = os.lstat(path)
+    mode = stat.S_IMODE(info.st_mode)
+    if not stat.S_ISDIR(info.st_mode):
+        raise SystemExit(f"trusted ancestor is not a directory: {path}")
+    if info.st_uid != 0:
+        raise SystemExit(f"trusted ancestor is not root-owned: {path}")
+    if mode & 0o022 and not (allow_sticky_writable and mode & stat.S_ISVTX):
+        raise SystemExit(f"trusted ancestor is writable by non-root users: {path}")
+
 if os.geteuid() != 0:
     raise SystemExit("Daytona control process is not root")
 if pwd.getpwnam("jovyan").pw_name != "jovyan":
@@ -66,6 +107,10 @@ for path in ("/usr/sbin/runuser", "/opt/conda/bin/python"):
         raise SystemExit(f"required executable is missing: {path}")
 if shutil.which("jupyter") is None:
     raise SystemExit("jupyter is missing")
+for ancestor in reversed(trusted_root.parent.parents):
+    validate_directory(ancestor, allow_sticky_writable=True)
+validate_directory(trusted_root.parent, allow_sticky_writable=False)
+validate_directory(trusted_root, allow_sticky_writable=False)
 probe = run / ".root-write-probe"
 probe.write_bytes(b"ok")
 probe.unlink()
@@ -79,6 +124,7 @@ import sys
 
 source = pathlib.Path(sys.argv[1])
 run = pathlib.Path(sys.argv[2])
+trusted_root = run.parent
 if pwd.getpwuid(os.geteuid()).pw_name != "jovyan":
     raise SystemExit("notebook process is not jovyan")
 source.read_bytes()
@@ -98,6 +144,19 @@ for operation in operations:
     except OSError:
         continue
     raise SystemExit("protected notebook input was mutable")
+for protected_directory in (trusted_root, trusted_root.parent):
+    target = protected_directory.with_name(f"{protected_directory.name}-moved")
+    try:
+        protected_directory.rename(target)
+    except OSError:
+        continue
+    raise SystemExit("trusted notebook control directory was renamable")
+try:
+    (trusted_root.parent / "replacement").mkdir()
+except OSError:
+    pass
+else:
+    raise SystemExit("trusted notebook parent was writable")
 """.strip()
 
 _STOP_USER_PROCESSES_SCRIPT = r"""
@@ -283,9 +342,7 @@ class DaytonaNotebookBackend(NotebookBackend):
                     params,
                     timeout=limits.image_prepare_seconds,
                 )
-            async with asyncio.timeout(limits.open_seconds):
-                work_dir = await sandbox.get_work_dir()
-            remote_root = f"{work_dir.rstrip('/')}/sqlsaber-notebook-{uuid.uuid4().hex}"
+            remote_root = f"{_REMOTE_PARENT}/{uuid.uuid4().hex}"
             environment = DaytonaNotebookEnvironment(
                 sdk=sdk,
                 client=client,
@@ -381,6 +438,20 @@ class DaytonaNotebookEnvironment(NotebookEnvironment):
     async def stage(self, inputs: Sequence[NotebookInput]) -> None:
         sentinel = f"{self.inputs_path}/.sqlsaber-preflight"
         try:
+            result = await self._exec(
+                "image-preflight",
+                _PYTHON,
+                "-c",
+                _SECURE_PARENT_SCRIPT,
+                _REMOTE_PARENT,
+                timeout=self.limits.open_seconds,
+            )
+            self._require_success(
+                result,
+                "Notebook image cannot provide a secure Daytona control parent",
+                phase="image-preflight",
+                image_error=True,
+            )
             result = await self._exec(
                 "input-upload",
                 "mkdir",
@@ -1199,8 +1270,13 @@ async def _delete_resources(
     sandbox_name: str,
 ) -> None:
     try:
-        async with asyncio.timeout(_DELETE_TIMEOUT_SECONDS + 5):
-            await sandbox.delete(timeout=_DELETE_TIMEOUT_SECONDS)
+        try:
+            async with asyncio.timeout(_DELETE_TIMEOUT_SECONDS + 5):
+                await sandbox.delete(timeout=_DELETE_TIMEOUT_SECONDS)
+        except Exception as exc:
+            if _is_sdk_exception(exc, sdk, "DaytonaNotFoundError"):
+                return
+            raise
         await _wait_until_deleted(
             client,
             sandbox_name,

--- a/plugins/notebook/tests/test_notebook_capability.py
+++ b/plugins/notebook/tests/test_notebook_capability.py
@@ -111,7 +111,7 @@ class _RecordingTUI:
         mime_type: str,
         *,
         filename: str | None = None,
-        max_width_cells: int = 60,
+        max_width_cells: int | None = 60,
         max_height_cells: int | None = None,
     ) -> object:
         self.images.append(
@@ -312,8 +312,8 @@ async def test_analyze_tool_renders_notebook_and_child_answer(
             "image/png",
             {
                 "filename": "plot_1.png",
-                "max_width_cells": 80,
-                "max_height_cells": 24,
+                "max_width_cells": None,
+                "max_height_cells": None,
             },
         )
     ]

--- a/plugins/notebook/tests/test_notebook_daytona.py
+++ b/plugins/notebook/tests/test_notebook_daytona.py
@@ -349,12 +349,13 @@ async def test_open_uses_root_wrapper_blocked_network_and_immutable_staging(
     assert params.resources.cpu == 4
     assert params.resources.memory == 8
     assert client.create_timeout == 600
-    assert environment.remote_root.startswith("/home/jovyan/sqlsaber-notebook-")
+    assert environment.remote_root.startswith("/tmp/sqlsaber-notebook/")
     assert (
         environment.sandbox.fs.files[f"{environment.inputs_path}/data file;$x.json"]
         == b"{}"
     )
     commands = [call[1] for call in environment.sandbox.process.calls]
+    assert any(daytona_backend._SECURE_PARENT_SCRIPT in command for command in commands)
     assert any(command[:3] == ("chown", "-R", "root:root") for command in commands)
     assert any(command[:3] == ("chmod", "-R", "a-w") for command in commands)
     assert any(
@@ -610,6 +611,26 @@ async def test_client_closes_when_sandbox_deletion_fails() -> None:
             sandbox,
             sandbox.name,
         )
+    assert client.closed is True
+
+
+async def test_already_deleted_sandbox_is_successful_cleanup() -> None:
+    sdk = fake_sdk()
+    client = FakeClient(sdk)
+    sandbox = FakeSandbox(client, "already-deleted")
+
+    async def already_deleted(timeout: float | None = None) -> None:
+        del timeout
+        raise DaytonaNotFoundError("already deleted")
+
+    sandbox.delete = already_deleted
+    await daytona_backend._delete_resources(
+        sdk,
+        client,
+        sandbox,
+        sandbox.name,
+    )
+    assert client.get_calls == 0
     assert client.closed is True
 
 

--- a/plugins/notebook/tests/test_notebook_daytona.py
+++ b/plugins/notebook/tests/test_notebook_daytona.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import shlex
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sqlsaber_notebook.execution import (
+    ExecutionLimits,
+    NotebookBackendUnavailable,
+    NotebookExecutionTimeout,
+    NotebookImageError,
+    NotebookInput,
+    NotebookLimitExceeded,
+)
+from sqlsaber_notebook.execution import daytona as daytona_backend
+from sqlsaber_notebook.execution.base import NotebookInfrastructureError
+
+
+class DaytonaError(Exception):
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class DaytonaNotFoundError(DaytonaError):
+    pass
+
+
+class DaytonaRateLimitError(DaytonaError):
+    pass
+
+
+class DaytonaTimeoutError(DaytonaError):
+    pass
+
+
+class FakeImage:
+    def __init__(self, parent: str) -> None:
+        self.parent = parent
+        self.commands: list[str] = []
+
+    def dockerfile_commands(self, commands: list[str]) -> FakeImage:
+        self.commands = list(commands)
+        return self
+
+
+class FakeImageFactory:
+    created: list[FakeImage] = []
+
+    @classmethod
+    def base(cls, parent: str) -> FakeImage:
+        image = FakeImage(parent)
+        cls.created.append(image)
+        return image
+
+
+class FakeResources:
+    def __init__(self, *, cpu: int, memory: int) -> None:
+        self.cpu = cpu
+        self.memory = memory
+
+
+class FakeCreateParams:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+class FakeFilesystem:
+    def __init__(self, sandbox: FakeSandbox) -> None:
+        self.sandbox = sandbox
+        self.files: dict[str, bytes] = {}
+        self.identities: dict[str, tuple[int, int, int]] = {}
+        self.next_inode = 100
+        self.download_paths: list[str] = []
+        self.short_download = False
+
+    def put(self, path: str, data: bytes) -> None:
+        self.files[path] = bytes(data)
+        prior = self.identities.get(path)
+        inode = prior[1] if prior else self.next_inode
+        if prior is None:
+            self.next_inode += 1
+        self.identities[path] = (1, inode, len(data))
+
+    async def upload_file(
+        self,
+        source: bytes,
+        destination: str,
+        timeout: int,
+    ) -> None:
+        assert timeout > 0
+        self.put(destination, source)
+
+    async def download_file(self, *args: str) -> None:
+        remote, local, _timeout = args
+        self.download_paths.append(local)
+        data = self.files[remote]
+        if self.short_download:
+            data = data[:-1]
+        Path(local).write_bytes(data)
+
+
+class FakeProcess:
+    def __init__(self, sandbox: FakeSandbox) -> None:
+        self.sandbox = sandbox
+        self.calls: list[tuple[str, tuple[str, ...], str | None, int | None]] = []
+        self.hang = False
+        self.fail_preflight = False
+        self.execution_count = 0
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> Any:
+        del env
+        argv = tuple(shlex.split(command))
+        self.calls.append((command, argv, cwd, timeout))
+        if self.hang and daytona_backend._LOG_WRAPPER in argv:
+            await asyncio.sleep(60)
+        if self.fail_preflight and daytona_backend._ROOT_PREFLIGHT_SCRIPT in argv:
+            return SimpleNamespace(exit_code=1, result="missing root")
+
+        files = self.sandbox.fs.files
+        if argv[:2] == ("rm", "-rf"):
+            prefix = f"{argv[-1].rstrip('/')}/"
+            for path in tuple(files):
+                if path == argv[-1] or path.startswith(prefix):
+                    files.pop(path, None)
+                    self.sandbox.fs.identities.pop(path, None)
+        elif argv[:2] == ("rm", "-f"):
+            for path in argv[2:]:
+                files.pop(path, None)
+                self.sandbox.fs.identities.pop(path, None)
+        elif daytona_backend._LOG_WRAPPER in argv:
+            self.execution_count += 1
+            wrapper_index = argv.index(daytona_backend._LOG_WRAPPER)
+            stdout_path = argv[wrapper_index + 2]
+            stderr_path = argv[wrapper_index + 3]
+            self.sandbox.fs.put(stdout_path, b"executed\n")
+            self.sandbox.fs.put(stderr_path, b"")
+            artifact = f"{cwd}/nested/result-{self.execution_count}.txt"
+            self.sandbox.fs.put(artifact, f"run-{self.execution_count}".encode())
+        elif daytona_backend._INVENTORY_SCRIPT in argv:
+            script_index = argv.index(daytona_backend._INVENTORY_SCRIPT)
+            run_path = argv[script_index + 1]
+            output_path = argv[script_index + 2]
+            prefix = f"{run_path}/"
+            entries: dict[str, dict[str, int]] = {}
+            for path, data in sorted(files.items()):
+                if path.startswith(prefix):
+                    relative = path[len(prefix) :]
+                    device, inode, size = self.sandbox.fs.identities[path]
+                    entries[relative] = {
+                        "size": size,
+                        "device": device,
+                        "inode": inode,
+                    }
+            self.sandbox.fs.put(
+                output_path,
+                json.dumps({"files": entries}, separators=(",", ":")).encode(),
+            )
+        elif daytona_backend._METADATA_SCRIPT in argv:
+            script_index = argv.index(daytona_backend._METADATA_SCRIPT)
+            path = argv[script_index + 1]
+            device, inode, size = self.sandbox.fs.identities[path]
+            return SimpleNamespace(
+                exit_code=0,
+                result=json.dumps(
+                    {
+                        "regular": True,
+                        "size": size,
+                        "device": device,
+                        "inode": inode,
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        elif daytona_backend._LOG_READER_SCRIPT in argv:
+            script_index = argv.index(daytona_backend._LOG_READER_SCRIPT)
+            stdout_path = argv[script_index + 1]
+            stderr_path = argv[script_index + 2]
+            return SimpleNamespace(
+                exit_code=0,
+                result=json.dumps(
+                    {
+                        "stdout": base64.b64encode(
+                            files.get(stdout_path, b"")
+                        ).decode(),
+                        "stderr": base64.b64encode(
+                            files.get(stderr_path, b"")
+                        ).decode(),
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        return SimpleNamespace(exit_code=0, result="ok")
+
+
+class FakeSandbox:
+    def __init__(self, client: FakeClient, name: str) -> None:
+        self.client = client
+        self.name = name
+        self.fs = FakeFilesystem(self)
+        self.process = FakeProcess(self)
+        self.delete_calls = 0
+
+    async def get_work_dir(self) -> str:
+        return "/home/jovyan"
+
+    async def delete(self, timeout: float | None = None) -> None:
+        assert timeout == 60
+        self.delete_calls += 1
+        self.client.deleted = True
+
+
+class FakeClient:
+    def __init__(self, sdk: Any) -> None:
+        self.sdk = sdk
+        self.create_params: FakeCreateParams | None = None
+        self.create_timeout: float | None = None
+        self.sandbox: FakeSandbox | None = None
+        self.deleted = False
+        self.closed = False
+        self.get_calls = 0
+        self.create_error: Exception | None = None
+        sdk.clients.append(self)
+
+    async def create(self, params: FakeCreateParams, *, timeout: float) -> FakeSandbox:
+        self.create_params = params
+        self.create_timeout = timeout
+        name = params.name
+        self.sandbox = FakeSandbox(self, name)
+        if self.sdk.create_error is not None:
+            raise self.sdk.create_error
+        return self.sandbox
+
+    async def get(self, name: str) -> FakeSandbox:
+        self.get_calls += 1
+        if self.sandbox is None or self.deleted:
+            raise DaytonaNotFoundError(name)
+        assert name == self.sandbox.name
+        return self.sandbox
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def fake_sdk() -> Any:
+    FakeImageFactory.created = []
+    sdk = SimpleNamespace(
+        clients=[],
+        create_error=None,
+        CreateSandboxFromImageParams=FakeCreateParams,
+        Image=FakeImageFactory,
+        Resources=FakeResources,
+        DaytonaError=DaytonaError,
+        DaytonaNotFoundError=DaytonaNotFoundError,
+        DaytonaRateLimitError=DaytonaRateLimitError,
+        DaytonaTimeoutError=DaytonaTimeoutError,
+    )
+    sdk.AsyncDaytona = lambda: FakeClient(sdk)
+    return sdk
+
+
+def notebook_bytes() -> bytes:
+    return json.dumps(
+        {
+            "cells": [],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    ).encode()
+
+
+async def open_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    limits: ExecutionLimits | None = None,
+):
+    sdk = fake_sdk()
+    monkeypatch.setattr(daytona_backend, "_load_daytona", lambda: sdk)
+    environment = await daytona_backend.DaytonaNotebookBackend().open(
+        [NotebookInput("data file;$x.json", b"{}")],
+        image="registry/image@sha256:digest",
+        limits=limits or ExecutionLimits(),
+    )
+    return sdk, environment
+
+
+def test_missing_sdk_reports_optional_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing(name: str) -> Any:
+        assert name == "daytona"
+        raise ImportError(name)
+
+    monkeypatch.setattr(daytona_backend.importlib, "import_module", missing)
+    with pytest.raises(NotebookBackendUnavailable, match="daytona.*extra"):
+        daytona_backend._load_daytona()
+
+
+def test_incompatible_sdk_version_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        daytona_backend.importlib, "import_module", lambda name: object()
+    )
+    monkeypatch.setattr(daytona_backend, "version", lambda name: "0.168.0")
+    with pytest.raises(NotebookBackendUnavailable, match="requires daytona==0.143.0"):
+        daytona_backend._load_daytona()
+
+
+def test_incompatible_sdk_symbols_are_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        daytona_backend.importlib, "import_module", lambda name: object()
+    )
+    monkeypatch.setattr(daytona_backend, "version", lambda name: "0.143.0")
+    with pytest.raises(NotebookBackendUnavailable, match="missing: AsyncDaytona"):
+        daytona_backend._load_daytona()
+
+
+async def test_open_uses_root_wrapper_blocked_network_and_immutable_staging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    client = sdk.clients[0]
+    params = client.create_params
+    assert params is not None
+    image = FakeImageFactory.created[0]
+    assert image.parent == "registry/image@sha256:digest"
+    assert image.commands == ["USER root", "WORKDIR /home/jovyan"]
+    assert params.image is image
+    assert params.name.startswith("sqlsaber-notebook-")
+    assert params.labels == {"application": "sqlsaber", "purpose": "notebook"}
+    assert params.os_user == "root"
+    assert params.network_block_all is True
+    assert params.ephemeral is True
+    assert params.auto_stop_interval == 1440
+    assert params.resources.cpu == 4
+    assert params.resources.memory == 8
+    assert client.create_timeout == 600
+    assert environment.remote_root.startswith("/home/jovyan/sqlsaber-notebook-")
+    assert (
+        environment.sandbox.fs.files[f"{environment.inputs_path}/data file;$x.json"]
+        == b"{}"
+    )
+    commands = [call[1] for call in environment.sandbox.process.calls]
+    assert any(command[:3] == ("chown", "-R", "root:root") for command in commands)
+    assert any(command[:3] == ("chmod", "-R", "a-w") for command in commands)
+    assert any(
+        command[:5] == (daytona_backend._RUNUSER, "-u", "jovyan", "--", "jupyter")
+        for command in commands
+    )
+    await environment.close()
+
+
+async def test_execute_has_clean_runs_bounded_logs_and_lazy_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    first = await environment.execute(
+        notebook_bytes(), cell_timeout=30, command_timeout=60
+    )
+    assert first.stdout == "executed\n"
+    assert [artifact.path for artifact in first.artifacts] == ["nested/result-1.txt"]
+    assert await environment.read_artifact(first.artifacts[0]) == b"run-1"
+    assert all(
+        not Path(path).exists() for path in environment.sandbox.fs.download_paths
+    )
+
+    second = await environment.execute(
+        notebook_bytes(), cell_timeout=45, command_timeout=90
+    )
+    assert [artifact.path for artifact in second.artifacts] == ["nested/result-2.txt"]
+    with pytest.raises(NotebookInfrastructureError, match="Unknown artifact"):
+        await environment.read_artifact(first.artifacts[0])
+
+    execution_calls = [
+        call
+        for call in environment.sandbox.process.calls
+        if daytona_backend._LOG_WRAPPER in call[1]
+    ]
+    assert len(execution_calls) == 2
+    assert execution_calls[0][2] == environment.run_path
+    assert execution_calls[0][3] == 60
+    assert "--ExecutePreprocessor.timeout=30" in execution_calls[0][1]
+    await environment.close()
+
+
+async def test_short_legacy_download_is_rejected_and_temporary_file_removed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    environment.sandbox.fs.short_download = True
+    with pytest.raises(NotebookInfrastructureError, match="changed during download"):
+        await environment.execute(notebook_bytes(), cell_timeout=10, command_timeout=20)
+    assert all(
+        not Path(path).exists() for path in environment.sandbox.fs.download_paths
+    )
+    await environment.close()
+
+
+async def test_preflight_failure_deletes_sandbox_and_closes_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk = fake_sdk()
+    original_client = FakeClient(sdk)
+
+    def client_factory() -> FakeClient:
+        return original_client
+
+    sdk.AsyncDaytona = client_factory
+    monkeypatch.setattr(daytona_backend, "_load_daytona", lambda: sdk)
+
+    original_create = original_client.create
+
+    async def create(*args: Any, **kwargs: Any) -> FakeSandbox:
+        sandbox = await original_create(*args, **kwargs)
+        sandbox.process.fail_preflight = True
+        return sandbox
+
+    original_client.create = create
+    with pytest.raises(NotebookImageError, match="root Daytona control"):
+        await daytona_backend.DaytonaNotebookBackend().open(
+            [], image="image", limits=ExecutionLimits()
+        )
+    assert original_client.sandbox is not None
+    assert original_client.sandbox.delete_calls == 1
+    assert original_client.closed is True
+
+
+async def test_execution_cancellation_deletes_sandbox_and_closes_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    environment.sandbox.process.hang = True
+    task = asyncio.create_task(
+        environment.execute(notebook_bytes(), cell_timeout=1, command_timeout=None)
+    )
+    while not any(
+        daytona_backend._LOG_WRAPPER in call[1]
+        for call in environment.sandbox.process.calls
+    ):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert environment.sandbox.delete_calls == 1
+    assert sdk.clients[0].closed is True
+    with pytest.raises(NotebookInfrastructureError, match="closed"):
+        await environment.list_workspace()
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_read_remote_logs", "_stop_run_processes", "_freeze_run"],
+)
+async def test_post_execution_security_failure_deletes_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+
+    async def fail() -> None:
+        raise NotebookInfrastructureError(
+            "post-execution security failed",
+            backend="daytona",
+            phase="notebook-execution",
+        )
+
+    monkeypatch.setattr(environment, method_name, fail)
+    with pytest.raises(
+        NotebookInfrastructureError,
+        match="post-execution security failed",
+    ):
+        await environment.execute(
+            notebook_bytes(),
+            cell_timeout=1,
+            command_timeout=2,
+        )
+    assert environment.sandbox.delete_calls == 1
+    assert sdk.clients[0].closed is True
+    with pytest.raises(NotebookInfrastructureError, match="closed"):
+        await environment.list_workspace()
+
+
+async def test_sdk_exec_failure_preserves_operation_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    original_exec = environment.sandbox.process.exec
+
+    async def fail_log_read(
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> Any:
+        if daytona_backend._LOG_READER_SCRIPT in shlex.split(command):
+            raise DaytonaError("toolbox failed")
+        return await original_exec(command, cwd=cwd, env=env, timeout=timeout)
+
+    monkeypatch.setattr(environment.sandbox.process, "exec", fail_log_read)
+    with pytest.raises(NotebookInfrastructureError) as raised:
+        await environment.execute(
+            notebook_bytes(),
+            cell_timeout=1,
+            command_timeout=2,
+        )
+    assert raised.value.phase == "notebook-execution"
+    assert "toolbox failed" in raised.value.diagnostics
+    assert environment.sandbox.delete_calls == 1
+    assert sdk.clients[0].closed is True
+
+
+async def test_sdk_transfer_failure_preserves_operation_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    original_download = environment.sandbox.fs.download_file
+
+    async def fail_inventory_download(*args: str) -> None:
+        if args[0] == environment.inventory_path:
+            raise DaytonaError("transfer failed")
+        await original_download(*args)
+
+    monkeypatch.setattr(
+        environment.sandbox.fs,
+        "download_file",
+        fail_inventory_download,
+    )
+    with pytest.raises(NotebookInfrastructureError) as raised:
+        await environment.execute(
+            notebook_bytes(),
+            cell_timeout=1,
+            command_timeout=2,
+        )
+    assert raised.value.phase == "artifact-inventory"
+    assert "transfer failed" in raised.value.diagnostics
+    assert environment.sandbox.delete_calls == 0
+    await environment.close()
+
+
+async def test_sdk_execution_timeout_deletes_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+
+    async def timeout(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise DaytonaTimeoutError("command timeout")
+
+    environment.sandbox.process.exec = timeout
+    with pytest.raises(NotebookExecutionTimeout):
+        await environment.execute(notebook_bytes(), cell_timeout=1, command_timeout=2)
+    assert environment.sandbox.delete_calls == 1
+    assert sdk.clients[0].closed is True
+
+
+async def test_close_is_idempotent_and_polls_until_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk, environment = await open_environment(monkeypatch)
+    await environment.close()
+    await environment.close()
+    client = sdk.clients[0]
+    assert environment.sandbox.delete_calls == 1
+    assert client.get_calls == 1
+    assert client.closed is True
+
+
+async def test_deletion_polling_times_out_when_sandbox_remains() -> None:
+    sdk = fake_sdk()
+    client = FakeClient(sdk)
+    client.sandbox = FakeSandbox(client, "still-there")
+    with pytest.raises(TimeoutError, match="still exists"):
+        await daytona_backend._wait_until_deleted(
+            client,
+            "still-there",
+            sdk,
+            timeout=0.01,
+            poll_interval=0,
+        )
+
+
+async def test_client_closes_when_sandbox_deletion_fails() -> None:
+    sdk = fake_sdk()
+    client = FakeClient(sdk)
+    sandbox = FakeSandbox(client, "delete-failure")
+
+    async def fail_delete(timeout: float | None = None) -> None:
+        del timeout
+        raise DaytonaError("delete failed")
+
+    sandbox.delete = fail_delete
+    with pytest.raises(DaytonaError, match="delete failed"):
+        await daytona_backend._delete_resources(
+            sdk,
+            client,
+            sandbox,
+            sandbox.name,
+        )
+    assert client.closed is True
+
+
+async def test_create_timeout_recovers_named_orphan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk = fake_sdk()
+    sdk.create_error = DaytonaTimeoutError("create timed out")
+    monkeypatch.setattr(daytona_backend, "_load_daytona", lambda: sdk)
+    with pytest.raises(NotebookExecutionTimeout, match="image preparation"):
+        await daytona_backend.DaytonaNotebookBackend().open(
+            [], image="image", limits=ExecutionLimits()
+        )
+    client = sdk.clients[0]
+    assert client.sandbox is not None
+    assert client.sandbox.delete_calls == 1
+    assert client.closed is True
+
+
+async def test_safe_exec_preserves_shell_metacharacters_as_single_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, environment = await open_environment(monkeypatch)
+    values = ("space value", "quote'value", "$HOME; touch nope", "line\nvalue")
+    await environment._exec("test", "printf", *values, timeout=1)
+    parsed = environment.sandbox.process.calls[-1][1]
+    assert parsed == ("printf", *values)
+    await environment.close()
+
+
+@pytest.mark.parametrize(("value", "expected"), [(4.0, 4), (2.9, 2), (1.0, 1)])
+def test_cpu_mapping_is_conservative(value: float, expected: int) -> None:
+    assert daytona_backend._daytona_cpu(value) == expected
+
+
+@pytest.mark.parametrize("value", [0.9, 0.0, float("inf"), float("nan")])
+def test_cpu_mapping_rejects_unsupported_values(value: float) -> None:
+    with pytest.raises(NotebookLimitExceeded):
+        daytona_backend._daytona_cpu(value)
+
+
+@pytest.mark.parametrize(("value", "expected"), [(8192, 8), (2047, 1), (1024, 1)])
+def test_memory_mapping_is_conservative(value: int, expected: int) -> None:
+    assert daytona_backend._daytona_memory_gib(value) == expected
+
+
+def test_memory_mapping_rejects_less_than_one_gib() -> None:
+    with pytest.raises(NotebookLimitExceeded):
+        daytona_backend._daytona_memory_gib(1023)

--- a/plugins/notebook/tests/test_notebook_daytona_integration.py
+++ b/plugins/notebook/tests/test_notebook_daytona_integration.py
@@ -73,6 +73,7 @@ async def test_live_daytona_notebook_contract_and_deletion() -> None:
         limits=ExecutionLimits(),
     )
     name = environment.sandbox_name
+    assert environment.remote_root.startswith("/tmp/sqlsaber-notebook/")
     try:
         first = await environment.execute(
             contract_notebook(),

--- a/plugins/notebook/tests/test_notebook_daytona_integration.py
+++ b/plugins/notebook/tests/test_notebook_daytona_integration.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+import pytest
+
+from sqlsaber_notebook.execution import (
+    DEFAULT_NOTEBOOK_IMAGE,
+    ExecutionLimits,
+    NotebookInput,
+    NotebookLimitExceeded,
+)
+from sqlsaber_notebook.execution.daytona import (
+    DaytonaNotebookBackend,
+    _load_daytona,
+)
+
+from _notebooks import assert_contract_result, contract_notebook
+
+
+def _single_cell_notebook(source: str) -> bytes:
+    notebook: dict[str, Any] = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "id": "cell-1",
+                "metadata": {},
+                "outputs": [],
+                "source": source.splitlines(keepends=True),
+            }
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3 (ipykernel)",
+                "language": "python",
+                "name": "python3",
+            }
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    return json.dumps(notebook).encode()
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.getenv("SQLSABER_RUN_DAYTONA_INTEGRATION") != "1",
+        reason="set SQLSABER_RUN_DAYTONA_INTEGRATION=1 for Daytona tests",
+    ),
+]
+
+
+async def _assert_deleted(name: str) -> None:
+    sdk = _load_daytona()
+    client = sdk.AsyncDaytona()
+    try:
+        with pytest.raises(sdk.DaytonaNotFoundError):
+            await client.get(name)
+    finally:
+        await client.close()
+
+
+async def test_live_daytona_notebook_contract_and_deletion() -> None:
+    backend = DaytonaNotebookBackend()
+    environment = await backend.open(
+        [NotebookInput("data.json", b'{"values":[1,2,3]}')],
+        image=DEFAULT_NOTEBOOK_IMAGE,
+        limits=ExecutionLimits(),
+    )
+    name = environment.sandbox_name
+    try:
+        first = await environment.execute(
+            contract_notebook(),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        second = await environment.execute(
+            contract_notebook(),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        assert_contract_result(first.notebook, expected_uid=1000)
+        assert_contract_result(second.notebook, expected_uid=1000)
+        assert [item.path for item in second.artifacts] == [
+            "nested/summary.txt",
+            "plot.png",
+        ]
+        summary = next(
+            item for item in second.artifacts if item.path.endswith("summary.txt")
+        )
+        plot = next(item for item in second.artifacts if item.path == "plot.png")
+        assert await environment.read_artifact(summary) == b"sum=6 counter=1"
+        assert (await environment.read_artifact(plot)).startswith(b"\x89PNG\r\n\x1a\n")
+
+        background = await environment.execute(
+            _single_cell_notebook(
+                """import subprocess
+import sys
+import time
+from pathlib import Path
+Path('background.txt').write_bytes(b'start')
+subprocess.Popen([
+    sys.executable,
+    '-c',
+    "import time; p='background.txt'; "
+    "[(open(p, 'ab').write(b'x'), time.sleep(.02)) for _ in iter(int, 1)]",
+])
+time.sleep(.1)
+"""
+            ),
+            cell_timeout=120,
+            command_timeout=600,
+        )
+        artifact = next(
+            item for item in background.artifacts if item.path == "background.txt"
+        )
+        await asyncio.sleep(0.2)
+        assert len(await environment.read_artifact(artifact)) == artifact.size
+
+        with pytest.raises(NotebookLimitExceeded, match="unsafe files"):
+            await environment.execute(
+                _single_cell_notebook(
+                    """from pathlib import Path
+Path('target.txt').write_text('target')
+Path('unsafe-link').symlink_to('target.txt')
+"""
+                ),
+                cell_timeout=120,
+                command_timeout=600,
+            )
+    finally:
+        await environment.close()
+        await environment.close()
+
+    await _assert_deleted(name)
+
+
+async def test_live_daytona_cancellation_deletes_sandbox() -> None:
+    environment = await DaytonaNotebookBackend().open(
+        [],
+        image=DEFAULT_NOTEBOOK_IMAGE,
+        limits=ExecutionLimits(),
+    )
+    name = environment.sandbox_name
+    task = asyncio.create_task(
+        environment.execute(
+            _single_cell_notebook("import time; time.sleep(300)"),
+            cell_timeout=None,
+            command_timeout=None,
+        )
+    )
+    await asyncio.sleep(2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await _assert_deleted(name)

--- a/plugins/notebook/tests/test_notebook_execution.py
+++ b/plugins/notebook/tests/test_notebook_execution.py
@@ -57,12 +57,13 @@ def test_backend_selection_is_explicit_without_fallback(
     assert resolve_notebook_backend("docker").name == "docker"
 
     assert resolve_notebook_backend("microsandbox").name == "microsandbox"
+    assert resolve_notebook_backend("daytona").name == "daytona"
 
     with pytest.raises(
         NotebookBackendUnavailable,
-        match="expected 'docker', 'microsandbox', or 'modal'",
+        match="expected 'docker', 'microsandbox', 'modal', or 'daytona'",
     ):
-        resolve_notebook_backend("daytona")
+        resolve_notebook_backend("unknown")
 
 
 def test_image_resolution(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/plugins/notebook/uv.lock
+++ b/plugins/notebook/uv.lock
@@ -19,6 +19,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -125,6 +134,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
     { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
     { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
 ]
 
 [[package]]
@@ -653,6 +674,110 @@ wheels = [
 ]
 
 [[package]]
+name = "daytona"
+version = "0.143.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "environs" },
+    { name = "httpx" },
+    { name = "multipart" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "toml" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/6c/4cc4ea64c741823ce79d495a6741634202f100c8f76d262da5ca8d94e99a/daytona-0.143.0.tar.gz", hash = "sha256:2ea75dfe1750bed2c12d3f646d2bde8af309d892b7488fc3517cc901f23b8a50", size = 125398, upload-time = "2026-02-13T14:17:54.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/fa/bdbf725c9ed8ffec3fa966f059cdc82718238868f35a5e3da62e47ed35d2/daytona-0.143.0-py3-none-any.whl", hash = "sha256:e44115fabfcd58fd8a2a2ec60ccc3dc85928d479074bd4e2c4cf8b0347c443d6", size = 155430, upload-time = "2026-02-13T14:17:52.842Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.143.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/cd/d069f206ba6d29bcc66869c4c350d997b76bed3179f4840348e884c146da/daytona_api_client-0.143.0.tar.gz", hash = "sha256:1953b9459501938d10597ec17793121f771d3efe159d6697b2e81016f7860e14", size = 140245, upload-time = "2026-02-13T14:17:01.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/09/b24a90671debd79d7daf5dcc0cd1ac620347526dde9c33c4e22c5478e094/daytona_api_client-0.143.0-py3-none-any.whl", hash = "sha256:7c3d4be0df729d3d35ced00347fbb573ab79d00864393d7ec3293dd0283dbc98", size = 393444, upload-time = "2026-02-13T14:16:59.205Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.143.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/2d/3e3aea28ef49f1acb21085d9e946620f60d8dc16469bd8f007ebaaedddb4/daytona_api_client_async-0.143.0.tar.gz", hash = "sha256:687c9cfc5761e3f5579580fd627cdc189be2d699b5c6d7e260b2edcaa5690d8a", size = 140276, upload-time = "2026-02-13T14:17:26.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/f8/2f444d3db0dfa008eaca9a359768701226802bfdcafcbbedb45c1f90fb1f/daytona_api_client_async-0.143.0-py3-none-any.whl", hash = "sha256:6fa2c9e1d39893be845cc652b04e549ff22a150ce99082bd33d0409ed572d9d3", size = 396405, upload-time = "2026-02-13T14:17:24.999Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.143.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d6/379dbc404e60b7544cac6c0ccd35ec24f50a8d33da21792acfe589194e68/daytona_toolbox_api_client-0.143.0.tar.gz", hash = "sha256:fa2c2896fe67180e43520831aa4832313bca585b83da55795ace790179df50f7", size = 64751, upload-time = "2026-02-13T14:17:05.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/56/b71bc976ec44480245f9822be9ec36747e8a73c2bfa7526414b59245286c/daytona_toolbox_api_client-0.143.0-py3-none-any.whl", hash = "sha256:9b96af06793ecbdb5c1cef9ffdff8a73bc54b6297cf493e9b27e83b49c4b38a9", size = 174361, upload-time = "2026-02-13T14:17:04.552Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.143.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ae/5affe84d1b014eded77c126e0c77643d33f9456d0c8769ce1ef41155a9db/daytona_toolbox_api_client_async-0.143.0.tar.gz", hash = "sha256:ab18a90e9a53545437bb1c47114bda8ee58c611559327148377bc39c2412bd94", size = 61769, upload-time = "2026-02-13T14:17:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/ec/f221e4e75319f119bdf932c7c79229fc55b9a121f0daa74f060674cd831d/daytona_toolbox_api_client_async-0.143.0-py3-none-any.whl", hash = "sha256:d2aa984dc386ef57f2fc7d920770ff6282a9bca412981a5092fa381b91438227", size = 175733, upload-time = "2026-02-13T14:17:10.034Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -719,6 +844,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "environs"
+version = "14.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/c7/94f97e6e74482a50b5fc798856b6cc06e8d072ab05a0b74cb5d87bd0d065/environs-14.6.0.tar.gz", hash = "sha256:ed2767588deb503209ffe4dd9bb2b39311c2e4e7e27ce2c64bf62ca83328d068", size = 35563, upload-time = "2026-02-20T04:02:08.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a8/c070e1340636acb38d4e6a7e45c46d168a462b48b9b3257e14ca0e5af79b/environs-14.6.0-py3-none-any.whl", hash = "sha256:f8fb3d6c6a55872b0c6db077a28f5a8c7b8984b7c32029613d44cef95cfc0812", size = 17205, upload-time = "2026-02-20T04:02:07.299Z" },
 ]
 
 [[package]]
@@ -1471,6 +1609,15 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1677,6 +1824,15 @@ wheels = [
 ]
 
 [[package]]
+name = "multipart"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929, upload-time = "2026-02-27T10:17:13.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061, upload-time = "2026-02-27T10:17:11.943Z" },
+]
+
+[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1689,6 +1845,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "obstore"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/8c/9ec984edd0f3b72226adfaa19b1c61b15823b35b52f311ca4af36d009d15/obstore-0.8.2.tar.gz", hash = "sha256:a467bc4e97169e2ba749981b4fd0936015428d9b8f3fb83a5528536b1b6f377f", size = 168852, upload-time = "2025-09-16T15:34:55.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/dc/60fefbb5736e69eab56657bca04ca64dc07fdeccb3814164a31b62ad066b/obstore-0.8.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bb70ce297a47392b1d9a3e310f18d59cd5ebbb9453428210fef02ed60e4d75d1", size = 3612955, upload-time = "2025-09-16T15:33:29.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/844e8f382e5a12b8a3796a05d76a03e12c7aedc13d6900419e39207d7868/obstore-0.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1619bf618428abf1f607e0b219b2e230a966dcf697b717deccfa0983dd91f646", size = 3346564, upload-time = "2025-09-16T15:33:30.698Z" },
+    { url = "https://files.pythonhosted.org/packages/89/73/8537f99e09a38a54a6a15ede907aa25d4da089f767a808f0b2edd9c03cec/obstore-0.8.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4605c3ed7c9515aeb4c619b5f7f2c9986ed4a79fe6045e536b5e59b804b1476", size = 3460809, upload-time = "2025-09-16T15:33:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/99/7714dec721e43f521d6325a82303a002cddad089437640f92542b84e9cc8/obstore-0.8.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce42670417876dd8668cbb8659e860e9725e5f26bbc86449fd259970e2dd9d18", size = 3692081, upload-time = "2025-09-16T15:33:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/4ac4175fe95a24c220a96021c25c432bcc0c0212f618be0737184eebbaad/obstore-0.8.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a3e893b2a06585f651c541c1972fe1e3bf999ae2a5fda052ee55eb7e6516f5", size = 3957466, upload-time = "2025-09-16T15:33:34.528Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/caa288fb735484fc5cb019bdf3d896eaccfae0ac4622e520d05692c46790/obstore-0.8.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08462b32f95a9948ed56ed63e88406e2e5a4cae1fde198f9682e0fb8487100ed", size = 3951293, upload-time = "2025-09-16T15:33:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/d380239da2d6a1fda82e17df5dae600a404e8a93a065784518ff8325d5f6/obstore-0.8.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a0bf7763292a8fc47d01cd66e6f19002c5c6ad4b3ed4e6b2729f5e190fa8a0d", size = 3766199, upload-time = "2025-09-16T15:33:36.904Z" },
+    { url = "https://files.pythonhosted.org/packages/28/41/d391be069d3da82969b54266948b2582aeca5dd735abeda4d63dba36e07b/obstore-0.8.2-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:bcd47f8126cb192cbe86942b8f73b1c45a651ce7e14c9a82c5641dfbf8be7603", size = 3529678, upload-time = "2025-09-16T15:33:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4c/4862fdd1a3abde459ee8eea699b1797df638a460af235b18ca82c8fffb72/obstore-0.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:57eda9fd8c757c3b4fe36cf3918d7e589cc1286591295cc10b34122fa36dd3fd", size = 3698079, upload-time = "2025-09-16T15:33:39.696Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/014e747bc53b570059c27e3565b2316fbe5c107d4134551f4cd3e24aa667/obstore-0.8.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ea44442aad8992166baa69f5069750979e4c5d9ffce772e61565945eea5774b9", size = 3687154, upload-time = "2025-09-16T15:33:40.92Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/6db5f8edd93028e5b8bfbeee15e6bd3e56f72106107d31cb208b57659de4/obstore-0.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:41496a3ab8527402db4142aaaf0d42df9d7d354b13ba10d9c33e0e48dd49dd96", size = 3773444, upload-time = "2025-09-16T15:33:42.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e5/c9e2cc540689c873beb61246e1615d6e38301e6a34dec424f5a5c63c1afd/obstore-0.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43da209803f052df96c7c3cbec512d310982efd2407e4a435632841a51143170", size = 3939315, upload-time = "2025-09-16T15:33:43.252Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c9/bb53280ca50103c1ffda373cdc9b0f835431060039c2897cbc87ddd92e42/obstore-0.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:1836f5dcd49f9f2950c75889ab5c51fb290d3ea93cdc39a514541e0be3af016e", size = 3978234, upload-time = "2025-09-16T15:33:44.393Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5d/8c3316cc958d386d5e6ab03e9db9ddc27f8e2141cee4a6777ae5b92f3aac/obstore-0.8.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:212f033e53fe6e53d64957923c5c88949a400e9027f7038c705ec2e9038be563", size = 3612027, upload-time = "2025-09-16T15:33:45.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4d/699359774ce6330130536d008bfc32827fab0c25a00238d015a5974a3d1d/obstore-0.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bee21fa4ba148d08fa90e47a96df11161661ed31e09c056a373cb2154b0f2852", size = 3344686, upload-time = "2025-09-16T15:33:47.185Z" },
+    { url = "https://files.pythonhosted.org/packages/82/37/55437341f10512906e02fd9fa69a8a95ad3f2f6a916d3233fda01763d110/obstore-0.8.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4c66594b59832ff1ced4c72575d9beb8b5f9b4e404ac1150a42bfb226617fd50", size = 3459860, upload-time = "2025-09-16T15:33:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/51/4245a616c94ee4851965e33f7a563ab4090cc81f52cc73227ff9ceca2e46/obstore-0.8.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:089f33af5c2fe132d00214a0c1f40601b28f23a38e24ef9f79fb0576f2730b74", size = 3691648, upload-time = "2025-09-16T15:33:49.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/4e2fb24171e3ca3641a4653f006be826e7e17634b11688a5190553b00b83/obstore-0.8.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d87f658dfd340d5d9ea2d86a7c90d44da77a0db9e00c034367dca335735110cf", size = 3956867, upload-time = "2025-09-16T15:33:51.082Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/b703115361c798c9c1744e1e700d5908d904a8c2e2bd38bec759c9ffb469/obstore-0.8.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e2e4fa92828c4fbc2d487f3da2d3588701a1b67d9f6ca3c97cc2afc912e9c63", size = 3950599, upload-time = "2025-09-16T15:33:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/53/20/08c6dc0f20c1394e2324b9344838e4e7af770cdcb52c30757a475f50daeb/obstore-0.8.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab440e89c5c37a8ec230857dd65147d4b923e0cada33297135d05e0f937d696a", size = 3765865, upload-time = "2025-09-16T15:33:53.291Z" },
+    { url = "https://files.pythonhosted.org/packages/77/20/77907765e29b2eba6bd8821872284d91170d7084f670855b2dfcb249ea14/obstore-0.8.2-cp313-cp313-manylinux_2_24_aarch64.whl", hash = "sha256:b9beed107c5c9cd995d4a73263861fcfbc414d58773ed65c14f80eb18258a932", size = 3529807, upload-time = "2025-09-16T15:33:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f5/f629d39cc30d050f52b1bf927e4d65c1cc7d7ffbb8a635cd546b5c5219a0/obstore-0.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b75b4e7746292c785e31edcd5aadc8b758238372a19d4c5e394db5c305d7d175", size = 3693629, upload-time = "2025-09-16T15:33:56.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/106763fd10f2a1cb47f2ef1162293c78ad52f4e73223d8d43fc6b755445d/obstore-0.8.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:f33e6c366869d05ab0b7f12efe63269e631c5450d95d6b4ba4c5faf63f69de70", size = 3686176, upload-time = "2025-09-16T15:33:57.247Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/d2ccb6f32feeca906d5a7c4255340df5262af8838441ca06c9e4e37b67d5/obstore-0.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:12c885a9ce5ceb09d13cc186586c0c10b62597eff21b985f6ce8ff9dab963ad3", size = 3773081, upload-time = "2025-09-16T15:33:58.475Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/40d1cc504cefc89c9b3dd8874287f3fddc7d963a8748d6dffc5880222013/obstore-0.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4accc883b93349a81c9931e15dd318cc703b02bbef2805d964724c73d006d00e", size = 3938589, upload-time = "2025-09-16T15:33:59.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/916c6777222db3271e9fb3cf9a97ed92b3a9b3e465bdeec96de9ab809d53/obstore-0.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:ec850adf9980e5788a826ccfd5819989724e2a2f712bfa3258e85966c8d9981e", size = 3977768, upload-time = "2025-09-16T15:34:01.25Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/61/66f8dc98bbf5613bbfe5bf21747b4c8091442977f4bd897945895ab7325c/obstore-0.8.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1431e40e9bb4773a261e51b192ea6489d0799b9d4d7dbdf175cdf813eb8c0503", size = 3623364, upload-time = "2025-09-16T15:34:02.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/66/6d527b3027e42f625c8fc816ac7d19b0d6228f95bfe7666e4d6b081d2348/obstore-0.8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ddb39d4da303f50b959da000aa42734f6da7ac0cc0be2d5a7838b62c97055bb9", size = 3347764, upload-time = "2025-09-16T15:34:04.236Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/c00103302b620192ea447a948921ad3fed031ce3d19e989f038e1183f607/obstore-0.8.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e01f4e13783db453e17e005a4a3ceff09c41c262e44649ba169d253098c775e8", size = 3460981, upload-time = "2025-09-16T15:34:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d9/bfe4ed4b1aebc45b56644dd5b943cf8e1673505cccb352e66878a457e807/obstore-0.8.2-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df0fc2d0bc17caff9b538564ddc26d7616f7e8b7c65b1a3c90b5048a8ad2e797", size = 3692711, upload-time = "2025-09-16T15:34:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/13/47/cd6c2cbb18e1f40c77e7957a4a03d2d83f1859a2e876a408f1ece81cad4c/obstore-0.8.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e439d06c99a140348f046c9f598ee349cc2dcd9105c15540a4b231f9cc48bbae", size = 3958362, upload-time = "2025-09-16T15:34:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ea/5ee82bf23abd71c7d6a3f2d008197ae8f8f569d41314c26a8f75318245be/obstore-0.8.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e37d9046669fcc59522d0faf1d105fcbfd09c84cccaaa1e809227d8e030f32c", size = 3957082, upload-time = "2025-09-16T15:34:09.477Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ee/46650405e50fdaa8d95f30375491f9c91fac9517980e8a28a4a6af66927f/obstore-0.8.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2646fdcc4bbe92dc2bb5bcdff15574da1211f5806c002b66d514cee2a23c7cb8", size = 3775539, upload-time = "2025-09-16T15:34:10.726Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/348a7ebebe2ca3d94dfc75344ea19675ae45472823e372c1852844078307/obstore-0.8.2-cp314-cp314-manylinux_2_24_aarch64.whl", hash = "sha256:e31a7d37675056d93dfc244605089dee67f5bba30f37c88436623c8c5ad9ba9d", size = 3535048, upload-time = "2025-09-16T15:34:12.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/b7a16cc0da91a4b902d47880ad24016abfe7880c63f7cdafda45d89a2f91/obstore-0.8.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:656313dd8170dde0f0cd471433283337a63912e8e790a121f7cc7639c83e3816", size = 3699035, upload-time = "2025-09-16T15:34:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
 ]
 
 [[package]]
@@ -1766,6 +1971,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/79/95be90c555fd7efde79dcba36ea5c668815aa2d0a4250b63687e0f91c74a/opentelemetry_instrumentation_aiohttp_client-0.60b1.tar.gz", hash = "sha256:d0e7d5aa057791ca4d9090b0d3c9982f253c1a24b6bc78a734fc18d8dd97927b", size = 15907, upload-time = "2025-12-11T13:36:44.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/f4/1a1ec632c86269750ae833c8fbdd4c8d15316eb1c21e3544e34791c805ee/opentelemetry_instrumentation_aiohttp_client-0.60b1-py3-none-any.whl", hash = "sha256:34c5097256a30b16c5a2a88a409ed82b92972a494c43212c85632d204a78c2a1", size = 12694, upload-time = "2025-12-11T13:35:35.034Z" },
 ]
 
 [[package]]
@@ -2933,10 +3154,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
-    { name = "sqlsaber-notebook", extras = ["modal"], editable = "." },
+    { name = "sqlsaber-notebook", extras = ["daytona", "modal"], editable = "." },
     { name = "sqlsaber-sandbox", editable = "../sandbox" },
     { name = "sqlsaber-viz", editable = "../viz" },
 ]
@@ -2952,6 +3174,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+daytona = [
+    { name = "daytona" },
+]
 microsandbox = [
     { name = "microsandbox" },
 ]
@@ -2961,6 +3186,7 @@ modal = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "daytona" },
     { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
     { name = "modal" },
     { name = "pytest" },
@@ -2969,16 +3195,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.143.0" },
     { name = "microsandbox", marker = "extra == 'microsandbox'", specifier = ">=0.6.6,<0.7" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4,<2" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "pillow", specifier = ">=11,<13" },
     { name = "sqlsaber", editable = "../../" },
 ]
-provides-extras = ["microsandbox", "modal"]
+provides-extras = ["daytona", "microsandbox", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "daytona", specifier = "==0.143.0" },
     { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "modal", specifier = ">=1.4,<2" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -3348,79 +3576,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.1"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/52/748c014f07f4e0e170c8932de7e647a1511d5ab3049cd978797136aee577/websockets-16.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b6aa3f7ad345cf3862c21f4fbf2ef5e14d911348476c2845e137c091fe3a3f0b", size = 179798, upload-time = "2026-07-10T06:31:09.664Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/5e/2a2e64d977d084e49d37c187c26c056daaff41965be7300cd5dbde6f8b07/websockets-16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b43fcfb521ac2f34ba80b7b8ea16303e4ad82dd8af667bf40839ad3a5d37b164", size = 177478, upload-time = "2026-07-10T06:31:11.072Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/12/5b85b4e75d697e548a94962ce5c036b05dd21cb9545759d555c5586422fc/websockets-16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2bd3e12cd9afbe2baedae0b1eeade8ba64329b60fe2f9abdc966bd10fd2c2ef5", size = 177746, upload-time = "2026-07-10T06:31:12.386Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/62/79b1c8f0cee0da648b4899e1c5b0dbd3aa59846985136a54854db6827ab4/websockets-16.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f41979c8623df9bd30d949d82010a8fda5c56ff12cd8508a5b7272b6d4b53a", size = 187345, upload-time = "2026-07-10T06:31:13.754Z" },
-    { url = "https://files.pythonhosted.org/packages/25/34/b7c5c52c2f24280e1c017acb7ad491a566750a5cceca7f3cf999373bba21/websockets-16.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a24d1f35aef07d794a16c853c688e74956c50239bec37b4f2de080056046419b", size = 188581, upload-time = "2026-07-10T06:31:15.075Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/37/604193bebcbeffe96fdf795960b83a15d600880c64dc17ec9c31c5b3427d/websockets-16.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0c64c024ddf7a35331b21fcddb562a039c275d2c82e8c2d12939e7da23997270", size = 191362, upload-time = "2026-07-10T06:31:16.395Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b4/5ee27575b367d7110d4d13945e2a9de067ec84dc71e54b87f01e38550d9a/websockets-16.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3e99757f5baafe20fc598e202ea6f5b0b265186ad38d0a17bd8beca16296955", size = 189216, upload-time = "2026-07-10T06:31:17.776Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/22/3e2dcc78d85fc5d9d814895ce6d07d0dfacc0f6aaa1d151f2b8c8d772299/websockets-16.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:353f3bc6e058ac1ccab4b3588e8598837a8c04cfc8351233e6d523be675d844c", size = 187971, upload-time = "2026-07-10T06:31:19.152Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/2f/cd271717b93d5ee19626cb5e38a85baab745c86e33db7c31a3ac729b31b8/websockets-16.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0352f5b38b40e857b6428d468fa21dbb4dd4a567d933c26d9831b4efe1b92f43", size = 185381, upload-time = "2026-07-10T06:31:20.665Z" },
-    { url = "https://files.pythonhosted.org/packages/78/91/6ad6f2f1426317b5001bd490534208c7360636b35bac1dec2e0c22bfc40e/websockets-16.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70bd789afab579602968c39f21cb925466505f3edff22f0ae852bca54978a4f9", size = 188015, upload-time = "2026-07-10T06:31:22.024Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/6d/533733132ab4c07540efd4a8f0b9a435d3a5059b2f26cc476ace1abf7f45/websockets-16.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d0fb4b46f121eccd539353baebd1083a8767a9a351109453d1d1caecd1ba40c2", size = 186619, upload-time = "2026-07-10T06:31:23.376Z" },
-    { url = "https://files.pythonhosted.org/packages/08/73/16c059f3d73b3331eba10793704afa4faa9939234fb08ef7dca35794e8f0/websockets-16.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c14b6634af01541e4efe2954fd8f263386f7aa6d37c01e55dd8109fd17661452", size = 188497, upload-time = "2026-07-10T06:31:25.024Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/89/9a8fae7dd2acdcfb1a8844c29fe42b518a04b64fce38a0923b6290e452f1/websockets-16.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:a58532c49a851bcb481e58c1be23b315c17fe2fbbed509d75aeea12f543d2c15", size = 186051, upload-time = "2026-07-10T06:31:26.291Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/40/b240c7dd6a0e0c59c1f68377cc3015263521080c327c15f5e753c1f6d378/websockets-16.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4e969170c3b08e1d8dabd990fef1fa702c4233aeaabec33f871806e444f6a0e4", size = 187029, upload-time = "2026-07-10T06:31:27.605Z" },
-    { url = "https://files.pythonhosted.org/packages/50/35/524e3fac40e47d6fdcf6c4b2c95ef1bc8a97e01593c90eff86621df7b716/websockets-16.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff9b000064b88787ba9f7a3cb2af2b68a658ca5aad76458a46469e7124b678a0", size = 187308, upload-time = "2026-07-10T06:31:28.927Z" },
-    { url = "https://files.pythonhosted.org/packages/00/13/56840cf62c8859af6ba22b9529da937332468c80f32b598753e8a66d3990/websockets-16.1-cp312-cp312-win32.whl", hash = "sha256:b9f5d83f80f4d7c4bba6d97f3755ac05850c784dce0fd2ab371c4e41172f53ff", size = 180161, upload-time = "2026-07-10T06:31:30.316Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ff/87eb9eb44cb62424a8d729834f2b0515a47e2669fabec29820268f4d50a1/websockets-16.1-cp312-cp312-win_amd64.whl", hash = "sha256:6852c9f653966c16109d3b6f31181fd734f7914927e3f0fa1117af7a18c9aa21", size = 180462, upload-time = "2026-07-10T06:31:31.708Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
-    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
-    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
-    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
-    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
-    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
-    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
-    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
-    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
-    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
-    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
-    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
-    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
-    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
-    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
-    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
-    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
-    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "ruff>=0.12.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
-    "sqlsaber-notebook[modal]",
+    "sqlsaber-notebook[daytona,modal]",
     "microsandbox>=0.6.6,<0.7; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')",
     "sqlsaber-sandbox",
     "sqlsaber-viz",

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -62,6 +62,9 @@ def _fg(r: int, g: int, b: int) -> Callable[[str], str]:
 
 
 _SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+# saber-tui clamps this ceiling to the component width on every render. A large
+# sentinel therefore means "use available width" and remains responsive to resize.
+_RESPONSIVE_IMAGE_MAX_CELLS = 2**31 - 1
 
 
 def _bg(r: int, g: int, b: int) -> Callable[[str], str]:
@@ -558,7 +561,7 @@ class _PanelTUIView:
         mime_type: str,
         *,
         filename: str | None = None,
-        max_width_cells: int = 60,
+        max_width_cells: int | None = 60,
         max_height_cells: int | None = None,
     ) -> Image:
         component = self.app._create_image(
@@ -667,7 +670,7 @@ class ChatApp:
         mime_type: str,
         *,
         filename: str | None = None,
-        max_width_cells: int = 60,
+        max_width_cells: int | None = 60,
         max_height_cells: int | None = None,
     ) -> Image:
         """Append a terminal-native image with saber-tui's text fallback."""
@@ -724,7 +727,7 @@ class ChatApp:
         mime_type: str,
         *,
         filename: str | None,
-        max_width_cells: int,
+        max_width_cells: int | None,
         max_height_cells: int | None,
     ) -> Image:
         return Image(
@@ -734,7 +737,11 @@ class ChatApp:
             theme=ImageTheme(fallback_color=self.theme.muted_fg),
             options=ImageOptions(
                 filename=filename,
-                max_width_cells=max_width_cells,
+                max_width_cells=(
+                    max_width_cells
+                    if max_width_cells is not None
+                    else _RESPONSIVE_IMAGE_MAX_CELLS
+                ),
                 max_height_cells=max_height_cells,
             ),
         )

--- a/src/sqlsaber/tools/base.py
+++ b/src/sqlsaber/tools/base.py
@@ -19,7 +19,7 @@ class ToolResultPanel(Protocol):
         mime_type: str,
         *,
         filename: str | None = None,
-        max_width_cells: int = 60,
+        max_width_cells: int | None = 60,
         max_height_cells: int | None = None,
     ) -> object: ...
 

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -704,6 +704,13 @@ def test_chat_app_appends_native_terminal_image() -> None:
     assert component in app.chat_container.children
     assert component.render(80)[0].startswith("\x1b_G")
 
+    responsive = app.append_image(
+        png.getvalue(),
+        "image/png",
+        max_width_cells=None,
+    )
+    assert responsive.options.max_width_cells == tui_chat._RESPONSIVE_IMAGE_MAX_CELLS
+
 
 def test_ansi_block_wraps_once_per_width(monkeypatch) -> None:
     calls = 0

--- a/uv.lock
+++ b/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.168.0"
+version = "0.143.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -675,27 +675,26 @@ dependencies = [
     { name = "daytona-toolbox-api-client" },
     { name = "daytona-toolbox-api-client-async" },
     { name = "deprecated" },
+    { name = "environs" },
     { name = "httpx" },
+    { name = "multipart" },
     { name = "obstore" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
     { name = "toml" },
-    { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/09/e016783f18fea3edd4454bc8603022b0ee7b16e36a620afb395550f49b21/daytona-0.168.0.tar.gz", hash = "sha256:ed9a6679a719f8f9f1f0258232a958a52f1f71c4f598e53e7c871e696ad81a40", size = 121009, upload-time = "2026-04-21T12:36:06.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/6c/4cc4ea64c741823ce79d495a6741634202f100c8f76d262da5ca8d94e99a/daytona-0.143.0.tar.gz", hash = "sha256:2ea75dfe1750bed2c12d3f646d2bde8af309d892b7488fc3517cc901f23b8a50", size = 125398, upload-time = "2026-02-13T14:17:54.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/c5/57b67fe3325c6621597ef0385e3853d0cbb2b9fb35de93d11900b6889568/daytona-0.168.0-py3-none-any.whl", hash = "sha256:c771d167f039646fa722dcf14ec0db0df4a5d08db87980147eaa492af19f5a14", size = 149933, upload-time = "2026-04-21T12:36:05.081Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fa/bdbf725c9ed8ffec3fa966f059cdc82718238868f35a5e3da62e47ed35d2/daytona-0.143.0-py3-none-any.whl", hash = "sha256:e44115fabfcd58fd8a2a2ec60ccc3dc85928d479074bd4e2c4cf8b0347c443d6", size = 155430, upload-time = "2026-02-13T14:17:52.842Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.168.0"
+version = "0.143.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -703,14 +702,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/de/b81025befab5137c09118f8d4bbe3c63730f558e9686534bf342a9944894/daytona_api_client-0.168.0.tar.gz", hash = "sha256:66027ecbeb16818a7622a20fe2d140360814315f4fd8afcfbf48b63d285af528", size = 147805, upload-time = "2026-04-21T12:34:42.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/cd/d069f206ba6d29bcc66869c4c350d997b76bed3179f4840348e884c146da/daytona_api_client-0.143.0.tar.gz", hash = "sha256:1953b9459501938d10597ec17793121f771d3efe159d6697b2e81016f7860e14", size = 140245, upload-time = "2026-02-13T14:17:01.395Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/fc/fc07d1ccddc131f47777bd98570c2112cd7dea93efc5a6102b24618a4974/daytona_api_client-0.168.0-py3-none-any.whl", hash = "sha256:bab0391c03a52ad238237b4f32ad38798bcd89ce4fde75e0905a1d28d66020de", size = 407334, upload-time = "2026-04-21T12:34:40.147Z" },
+    { url = "https://files.pythonhosted.org/packages/48/09/b24a90671debd79d7daf5dcc0cd1ac620347526dde9c33c4e22c5478e094/daytona_api_client-0.143.0-py3-none-any.whl", hash = "sha256:7c3d4be0df729d3d35ced00347fbb573ab79d00864393d7ec3293dd0283dbc98", size = 393444, upload-time = "2026-02-13T14:16:59.205Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.168.0"
+version = "0.143.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -720,14 +719,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/f7/1317ca795002b130887ee3aacff587bb81f7909f53f374e02c657050f354/daytona_api_client_async-0.168.0.tar.gz", hash = "sha256:b0aac0269f1f61f8d7859706b883883d703c7802ad559027f96e4ab309523a82", size = 147986, upload-time = "2026-04-21T12:35:29.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/2d/3e3aea28ef49f1acb21085d9e946620f60d8dc16469bd8f007ebaaedddb4/daytona_api_client_async-0.143.0.tar.gz", hash = "sha256:687c9cfc5761e3f5579580fd627cdc189be2d699b5c6d7e260b2edcaa5690d8a", size = 140276, upload-time = "2026-02-13T14:17:26.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6c/4a5751f2d21b75346e6d29457bbeef349a703326490778d988a8ea890116/daytona_api_client_async-0.168.0-py3-none-any.whl", hash = "sha256:ab4cc748bf04627744c68ca861329b965649e4dffff9e39e4ee1d3ff5a10a79c", size = 410413, upload-time = "2026-04-21T12:35:28.2Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f8/2f444d3db0dfa008eaca9a359768701226802bfdcafcbbedb45c1f90fb1f/daytona_api_client_async-0.143.0-py3-none-any.whl", hash = "sha256:6fa2c9e1d39893be845cc652b04e549ff22a150ce99082bd33d0409ed572d9d3", size = 396405, upload-time = "2026-02-13T14:17:24.999Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.168.0"
+version = "0.143.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -735,14 +734,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/64/15d4c1059ad4948bc0d5efe8940f9b8a1963d9faf77e8f508c27461eccbe/daytona_toolbox_api_client-0.168.0.tar.gz", hash = "sha256:d675a021750b7d9d5ac2cfdb6ed31bebd13c5d4e9704405d7561498520235678", size = 69723, upload-time = "2026-04-21T12:35:20Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d6/379dbc404e60b7544cac6c0ccd35ec24f50a8d33da21792acfe589194e68/daytona_toolbox_api_client-0.143.0.tar.gz", hash = "sha256:fa2c2896fe67180e43520831aa4832313bca585b83da55795ace790179df50f7", size = 64751, upload-time = "2026-02-13T14:17:05.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/45/cc43c908b1ca4c2290e4747bb0335aa8c49791ca2e526563b29d92723a1a/daytona_toolbox_api_client-0.168.0-py3-none-any.whl", hash = "sha256:a4c0b58a6e1f36eaa8249246380afcbc5851b1c31c3f1b3d3e4fa714428747f7", size = 187619, upload-time = "2026-04-21T12:35:18.387Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/b71bc976ec44480245f9822be9ec36747e8a73c2bfa7526414b59245286c/daytona_toolbox_api_client-0.143.0-py3-none-any.whl", hash = "sha256:9b96af06793ecbdb5c1cef9ffdff8a73bc54b6297cf493e9b27e83b49c4b38a9", size = 174361, upload-time = "2026-02-13T14:17:04.552Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.168.0"
+version = "0.143.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -752,9 +751,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/c3/6a3a5960f9dff6cf06757ad067db5b45eae14e71c71d98f58a969362d81f/daytona_toolbox_api_client_async-0.168.0.tar.gz", hash = "sha256:bc3dc6d2b3dd5b4a38f1d66a8fe309433fcf633642869435ac89db9ea6612ab1", size = 66787, upload-time = "2026-04-21T12:35:30.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/ae/5affe84d1b014eded77c126e0c77643d33f9456d0c8769ce1ef41155a9db/daytona_toolbox_api_client_async-0.143.0.tar.gz", hash = "sha256:ab18a90e9a53545437bb1c47114bda8ee58c611559327148377bc39c2412bd94", size = 61769, upload-time = "2026-02-13T14:17:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/1847b2043256fd1b457f715fcbe54228a791390f583a5d203e603e943c17/daytona_toolbox_api_client_async-0.168.0-py3-none-any.whl", hash = "sha256:06977245e7b723b296634991b2ecf203196ecae5fa50485e5a3e9a4757a253e4", size = 189045, upload-time = "2026-04-21T12:35:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ec/f221e4e75319f119bdf932c7c79229fc55b9a121f0daa74f060674cd831d/daytona_toolbox_api_client_async-0.143.0-py3-none-any.whl", hash = "sha256:d2aa984dc386ef57f2fc7d920770ff6282a9bca412981a5092fa381b91438227", size = 175733, upload-time = "2026-02-13T14:17:10.034Z" },
 ]
 
 [[package]]
@@ -875,6 +874,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "environs"
+version = "14.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/c7/94f97e6e74482a50b5fc798856b6cc06e8d072ab05a0b74cb5d87bd0d065/environs-14.6.0.tar.gz", hash = "sha256:ed2767588deb503209ffe4dd9bb2b39311c2e4e7e27ce2c64bf62ca83328d068", size = 35563, upload-time = "2026-02-20T04:02:08.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a8/c070e1340636acb38d4e6a7e45c46d168a462b48b9b3257e14ca0e5af79b/environs-14.6.0-py3-none-any.whl", hash = "sha256:f8fb3d6c6a55872b0c6db077a28f5a8c7b8984b7c32029613d44cef95cfc0812", size = 17205, upload-time = "2026-02-20T04:02:07.299Z" },
 ]
 
 [[package]]
@@ -1646,6 +1658,15 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1850,6 +1871,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multipart"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929, upload-time = "2026-02-27T10:17:13.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061, upload-time = "2026-02-27T10:17:11.943Z" },
 ]
 
 [[package]]
@@ -3160,7 +3190,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
-    { name = "sqlsaber-notebook", extra = ["modal"] },
+    { name = "sqlsaber-notebook", extra = ["daytona", "modal"] },
     { name = "sqlsaber-sandbox" },
     { name = "sqlsaber-viz" },
 ]
@@ -3192,7 +3222,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
-    { name = "sqlsaber-notebook", extras = ["modal"], editable = "plugins/notebook" },
+    { name = "sqlsaber-notebook", extras = ["daytona", "modal"], editable = "plugins/notebook" },
     { name = "sqlsaber-sandbox", editable = "plugins/sandbox" },
     { name = "sqlsaber-viz", editable = "plugins/viz" },
 ]
@@ -3208,22 +3238,27 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+daytona = [
+    { name = "daytona" },
+]
 modal = [
     { name = "modal" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.143.0" },
     { name = "microsandbox", marker = "extra == 'microsandbox'", specifier = ">=0.6.6,<0.7" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4,<2" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "pillow", specifier = ">=11,<13" },
     { name = "sqlsaber", editable = "." },
 ]
-provides-extras = ["microsandbox", "modal"]
+provides-extras = ["daytona", "microsandbox", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "daytona", specifier = "==0.143.0" },
     { name = "microsandbox", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.6.6,<0.7" },
     { name = "modal", specifier = ">=1.4,<2" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
## Summary

- add an opt-in Daytona notebook execution backend pinned to `daytona==0.143.0` for the deployed legacy control plane
- run notebook code as `jovyan` behind a root-control image wrapper with immutable inputs, blocked networking, bounded transfers, and deletion polling
- harden trusted control paths against notebook-side replacement and treat already-deleted ephemeral sandboxes as successful cleanup
- add unit and opt-in credentialed integration coverage, dependency extras, lockfile updates, and provider documentation
- make notebook plot previews responsive to the available terminal width instead of enforcing an 80x24-cell cap

## Testing

- `uv run pytest -q` — 1181 passed, 6 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx ty check src/ plugins/notebook/src/`
- `uv run pytest plugins/sandbox/tests -q` — 11 passed

The credentialed Daytona contract and cancellation tests passed during implementation. A later live rerun was blocked before sandbox creation because the configured Daytona endpoint was unreachable; no SQLsaber sandbox was created by that attempt.
