### PR TITLE
fix: expose run-level usage limits

### DIFF
--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,30 +7,6 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
-#### Pydantic AI capabilities migration
-
-- Requires `pydantic-ai>=2.9,<3`. Model names must include a provider prefix and pydantic-ai's graceful end strategy is now the default.
-- Adds public `SqlTools` and `Knowledge` capabilities, plus `SQLSaberOptions.extra_capabilities`, for composing SQLsaber with other pydantic-ai agents.
-- Replaces the `sqlsaber.tools` plugin entry-point group with `sqlsaber.capabilities`. Plugin authors must export a `capability(context)` factory; see the [plugin porting guide](/guides/plugins#building-a-plugin).
-- Removes `ToolRegistry`, `ToolRunDeps`, and the unused `SQLSaberOptions.tools`, `providers`, and `hooks` placeholders. Tool overrides remain available through `SQLSaberOptions.tool_overrides` and are delivered when plugin capabilities are constructed.
-- Delivers the system prompt as non-persisted pydantic-ai instructions and uses one provider-neutral persona. Existing custom system prompts still replace SQLsaber's built-in persona and SQL guidance.
-- Maps thinking levels through pydantic-ai's unified `Thinking` capability. Anthropic support now targets newer models with adaptive thinking; SQLsaber no longer configures legacy `budget_tokens` or related `max_tokens` headroom itself.
-- Inherits pydantic-ai v2's graceful end strategy: function calls emitted beside a final text response execute instead of being skipped.
-
-#### Durable artifact storage
-
-- Replaces the write-only `ArtifactPublisher` API with the breaking `ArtifactStore` publish/get protocol; there are no compatibility aliases or legacy filesystem migration.
-- The CLI persists capability artifacts privately under its user-data directory and retains them while referenced by saved threads.
-- Embedded applications opt in through `SQLSaberOptions.artifact_store`; injected stores are application-owned and receive current context for tenant-aware retrieval.
-- Exposes descriptors through `SQLSaberResult.artifacts` and verified bytes through `SQLSaber.get_artifact()` while keeping binary data out of model and thread history.
-- Adds `saber threads artifacts THREAD_ID` plus link-only artifact metadata in transcript and HTML replay.
-
-#### Reusable notebook artifact publication
-
-- Adds lazily exported `publish_analysis(result, store=..., context=...)` so direct `sqlsaber-notebook` callers and managed SQLsaber share one canonical notebook/plot/generated-file publication mapping.
-- Keeps `analyze()` storage-independent and preserves explicit standalone `--output` behavior.
-- Reconstructs bounded notebook Markdown and deduplicated plots from verified retained publications during thread show/resume, with generic artifact fallback for missing or invalid notebooks.
-
 ---
 
 ## [0.70.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-v0.69.0...sqlsaber-v0.70.0) (2026-08-03)

--- a/docs/src/content/docs/sdk/results-and-streaming.mdx
+++ b/docs/src/content/docs/sdk/results-and-streaming.mdx
@@ -27,6 +27,33 @@ print(result.messages)   # messages from this run (incl. tool calls / SQL)
 | `.query_results` | Durable complete-query-result descriptors created during this run.      |
 | `.artifacts`    | Durable artifact references published by capabilities during this run.   |
 
+## Controlling run usage
+
+Pass Pydantic AI's `UsageLimits` to `query()` when a long-horizon task needs a
+larger request budget or when the embedding application needs token or tool-call
+limits:
+
+```python
+from pydantic_ai.usage import UsageLimits
+
+result = await saber.query(
+    "Investigate the revenue anomaly thoroughly",
+    usage_limits=UsageLimits(request_limit=200),
+)
+```
+
+When `usage_limits` is omitted, SQLsaber preserves Pydantic AI's safe default
+(`request_limit=50`). Set a field to `None` only when the embedding application
+explicitly intends to disable that limit, for example
+`UsageLimits(request_limit=None)`.
+
+The managed notebook analyst always shares the parent's live usage counter, so its
+model requests are included exactly once in `result.usage`. When the caller
+explicitly passes `usage_limits`, the analyst inherits that budget. When the caller
+omits `usage_limits`, the analyst itself is uncapped (`request_limit=None`) rather
+than silently acquiring Pydantic AI's per-agent default; the parent SQLsaber run
+still retains its safe default.
+
 ## Retrieving complete query results
 
 Complete rows are deliberately absent from model history. Use the descriptors on

--- a/plugins/notebook/src/sqlsaber_notebook/analyst.py
+++ b/plugins/notebook/src/sqlsaber_notebook/analyst.py
@@ -72,7 +72,11 @@ async def analyze(
     usage_limits: UsageLimits | None = None,
     parent_usage: RunUsage | None = None,
 ) -> AnalysisResult:
-    """Run one bounded notebook-analysis environment and always clean it up."""
+    """Run one notebook-analysis environment and always clean it up.
+
+    Omitted ``usage_limits`` leave the analyst uncapped; managed SQLsaber supplies
+    limits only when its embedding caller explicitly selected them.
+    """
 
     if not goal.strip():
         raise ValueError("Analysis goal cannot be empty")
@@ -91,14 +95,18 @@ async def analyze(
         include_snapshot_images=include_snapshot_images,
     )
     agent = build_analyst_agent(model, model_provider=model_provider)
-    child_usage = RunUsage()
+    run_usage = parent_usage if parent_usage is not None else RunUsage()
+    effective_usage_limits = usage_limits or UsageLimits(request_limit=None)
     try:
+        # Avoid provisioning a local or remote notebook when the next model
+        # request is already prohibited by the aggregate parent budget.
+        effective_usage_limits.check_before_request(run_usage)
         await session.ensure_environment()
         result = await agent.run(
             goal_prompt(goal),
             deps=session,
-            usage=child_usage,
-            usage_limits=usage_limits,
+            usage=run_usage,
+            usage_limits=effective_usage_limits,
         )
         images, files = await _harvest_artifacts(
             session,
@@ -112,8 +120,6 @@ async def analyze(
             provenance=_infer_provenance(session),
         )
     finally:
-        if parent_usage is not None:
-            parent_usage.incr(child_usage)
         await _bounded_shielded_close(session)
 
 

--- a/plugins/notebook/src/sqlsaber_notebook/capability.py
+++ b/plugins/notebook/src/sqlsaber_notebook/capability.py
@@ -8,13 +8,14 @@ import logging
 import re
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 
 from PIL import Image, UnidentifiedImageError
 from pydantic_ai import RunContext, ToolReturn
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.usage import UsageLimits
 from rich.color import Color
 from rich.console import Console
 from rich.markdown import Markdown
@@ -40,6 +41,7 @@ from sqlsaber.query_results import (
     QueryResultStore,
     QueryResultUnavailable,
 )
+from sqlsaber.run_usage import current_usage_limits
 from sqlsaber.tools.base import Tool, ToolResultTUI
 from sqlsaber.utils.json_utils import json_dumps
 
@@ -71,6 +73,21 @@ _MAX_DISPLAY_RESULTS = 2
 class _NotebookDisplay:
     markdown: str
     images: tuple[bytes, ...]
+
+
+def _nested_usage_limits() -> UsageLimits:
+    """Resolve child limits from the parent run's explicit limit selection."""
+    parent_limits = current_usage_limits()
+    if parent_limits is None:
+        return UsageLimits(request_limit=None)
+    if parent_limits.tool_calls_limit is None:
+        return parent_limits
+    # The successful parent analyze_data call is counted after execute returns.
+    # Reserve room for it in the child's derived limit without mutating the parent.
+    return replace(
+        parent_limits,
+        tool_calls_limit=max(0, parent_limits.tool_calls_limit - 1),
+    )
 
 
 class AnalyzeDataTool(Tool):
@@ -130,6 +147,7 @@ class AnalyzeDataTool(Tool):
                 image=resolve_notebook_image(),
                 include_snapshot_images=supports_notebook_images(model_name, provider),
                 collect_files=store is not None,
+                usage_limits=_nested_usage_limits(),
                 parent_usage=ctx.usage,
             )
             markdown, notebook_images = render_notebook_bytes(result.notebook)
@@ -327,6 +345,9 @@ class Notebook(SqlSaberCapability):
             self.tool.execute,
             name=self.tool.name,
             takes_ctx=True,
+            # Notebook delegation must run as a barrier so sibling parent tools
+            # are fully accounted before the nested agent checks shared limits.
+            sequential=True,
         )
 
     @property

--- a/plugins/notebook/tests/test_notebook_analyst.py
+++ b/plugins/notebook/tests/test_notebook_analyst.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 import nbformat
+import pytest
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -13,7 +15,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 from sqlsaber_notebook.analyst import (
     _cache_settings,
     analyze,
@@ -50,6 +52,79 @@ async def test_immediate_text_answer_is_allowed_and_usage_merges_once() -> None:
     assert result.answer == "success (no tool calls)"
     assert nbformat.reads(result.notebook.decode(), as_version=4).cells == []
     assert result.files == []
+    assert parent_usage.requests == 5
+    assert backend.environments[0].closed is True
+
+
+async def test_omitted_usage_limits_leave_direct_analysis_unlimited() -> None:
+    backend = FakeNotebookBackend(_executor)
+    parent_usage = RunUsage(requests=50)
+
+    result = await analyze(
+        "Give an answer",
+        Workspace(()),
+        model=TestModel(call_tools=[]),
+        model_provider="test",
+        backend=backend,
+        parent_usage=parent_usage,
+    )
+
+    assert result.answer == "success (no tool calls)"
+    assert parent_usage.requests == 51
+
+
+async def test_exhausted_request_budget_skips_environment_provisioning() -> None:
+    backend = FakeNotebookBackend(_executor)
+
+    with pytest.raises(UsageLimitExceeded, match="request_limit of 5"):
+        await analyze(
+            "Inspect the workspace",
+            Workspace(()),
+            model=TestModel(call_tools=[]),
+            model_provider="test",
+            backend=backend,
+            usage_limits=UsageLimits(request_limit=5),
+            parent_usage=RunUsage(requests=5),
+        )
+
+    assert backend.environments == []
+
+
+async def test_nested_analysis_shares_parent_budget_and_usage() -> None:
+    def respond(messages, info) -> ModelResponse:
+        del info
+        if any(
+            isinstance(part, ToolReturnPart)
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        ):
+            return ModelResponse(parts=[TextPart(content="finished")])
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="list_workspace",
+                    args={},
+                    tool_call_id="workspace-call",
+                )
+            ]
+        )
+
+    backend = FakeNotebookBackend(_executor)
+    parent_usage = RunUsage(requests=4)
+    usage_limits = UsageLimits(request_limit=5)
+
+    with pytest.raises(UsageLimitExceeded, match="request_limit of 5"):
+        await analyze(
+            "Inspect the workspace",
+            Workspace(()),
+            model=FunctionModel(respond),
+            model_provider="test",
+            backend=backend,
+            usage_limits=usage_limits,
+            parent_usage=parent_usage,
+        )
+
     assert parent_usage.requests == 5
     assert backend.environments[0].closed is True
 

--- a/plugins/notebook/tests/test_notebook_capability.py
+++ b/plugins/notebook/tests/test_notebook_capability.py
@@ -16,7 +16,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolReturnPart,
 )
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 from rich.console import Console
 from sqlsaber_notebook import capability as capability_module
 from sqlsaber_notebook.capability import (
@@ -29,6 +29,7 @@ from sqlsaber_notebook.result import AnalysisResult, ArtifactRef
 
 from sqlsaber.artifacts import InMemoryArtifactStore
 from sqlsaber.query_results import InMemoryQueryResultStore
+from sqlsaber.run_usage import bind_usage_limits
 
 
 def _ctx(messages: list[Any], *, tool_call_id: str = "analysis-call") -> Any:
@@ -36,6 +37,7 @@ def _ctx(messages: list[Any], *, tool_call_id: str = "analysis-call") -> Any:
         messages=messages,
         tool_call_id=tool_call_id,
         usage=RunUsage(),
+        usage_limits=UsageLimits(request_limit=200),
         run_id="run-1",
         conversation_id="conversation-1",
         metadata={"tenant_id": "acme"},
@@ -280,15 +282,17 @@ async def test_analyze_tool_renders_notebook_and_child_answer(
         capability_module, "resolve_notebook_image", lambda: "test-image"
     )
     tool = AnalyzeDataTool(cast(Any, context))
+    run_ctx = _ctx(messages)
 
-    returned = await tool.execute(_ctx(messages), "Calculate the total")
+    returned = await tool.execute(run_ctx, "Calculate the total")
 
     assert isinstance(returned, ToolReturn)
     assert returned.return_value == "The calculated answer is 10."
     assert returned.content is None
     assert returned.metadata["files"] == ["result_rows.json"]
     assert captured["collect_files"] is False
-    assert captured["parent_usage"] is not None
+    assert captured["usage_limits"].request_limit is None
+    assert captured["parent_usage"] is run_ctx.usage
 
     request_tui = _RecordingTUI()
     assert tool.render_executing_tui(request_tui, {"goal": "Calculate the total"})
@@ -350,6 +354,28 @@ async def test_analyze_tool_renders_notebook_and_child_answer(
         rich_returned.return_value,
         tool_call_id="rich-analysis-call",
     )
+
+
+def test_nested_usage_limits_are_unlimited_without_explicit_parent_limits() -> None:
+    nested = capability_module._nested_usage_limits()
+
+    assert nested == UsageLimits(request_limit=None)
+
+
+def test_nested_usage_limits_inherit_explicit_parent_budget() -> None:
+    parent = UsageLimits(
+        request_limit=200,
+        tool_calls_limit=10,
+        total_tokens_limit=1_000_000,
+    )
+
+    with bind_usage_limits(parent):
+        nested = capability_module._nested_usage_limits()
+
+    assert nested.request_limit == 200
+    assert nested.tool_calls_limit == 9
+    assert nested.total_tokens_limit == 1_000_000
+    assert parent.tool_calls_limit == 10
 
 
 @pytest.mark.asyncio
@@ -537,3 +563,4 @@ def test_installed_capability_is_always_registered() -> None:
     notebook = capability_module.capability(cast(Any, SimpleNamespace()))
     assert isinstance(notebook, Notebook)
     assert notebook.tool.name == "analyze_data"
+    assert notebook.get_toolset().tools["analyze_data"].sequential is True

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -7,6 +7,7 @@ from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import AbstractCapability, ProcessHistory, Thinking
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
 from pydantic_ai.models.anthropic import AnthropicModelSettings
+from pydantic_ai.usage import UsageLimits
 
 from sqlsaber.agents.model_factory import UNIFIED_EFFORT_MAP, build_model
 from sqlsaber.artifacts import ArtifactFailureMode, ArtifactStore
@@ -23,6 +24,7 @@ from sqlsaber.overrides import ToolOveridesInput, normalize_tool_overides
 from sqlsaber.prompts.persona import PERSONA
 from sqlsaber.query_result_resolution import compact_legacy_query_result_history
 from sqlsaber.query_results import InMemoryQueryResultStore, QueryResultStore
+from sqlsaber.run_usage import bind_usage_limits
 from sqlsaber.tools.base import Tool
 
 
@@ -221,15 +223,18 @@ class SQLSaberAgent:
         *,
         conversation_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> Any:
         """Run the agent without occupying the embedding agent's deps slot."""
-        return await self.agent.run(
-            prompt,
-            message_history=message_history,
-            conversation_id=conversation_id,
-            metadata=metadata,
-            event_stream_handler=event_stream_handler,
-        )
+        with bind_usage_limits(usage_limits):
+            return await self.agent.run(
+                prompt,
+                message_history=message_history,
+                conversation_id=conversation_id,
+                metadata=metadata,
+                usage_limits=usage_limits,
+                event_stream_handler=event_stream_handler,
+            )
 
     async def close(self) -> None:
         """Close capability and wrapper resources without masking cleanup failures."""

--- a/src/sqlsaber/api.py
+++ b/src/sqlsaber/api.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Protocol, Self
 
 from pydantic_ai import RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
+from pydantic_ai.usage import UsageLimits
 
 from sqlsaber.artifact_resolution import artifact_references_from_messages
 from sqlsaber.artifacts import (
@@ -140,6 +141,7 @@ class SQLSaber:
         *,
         conversation_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> SQLSaberResult:
         """Run a natural language query against the database.
 
@@ -151,6 +153,8 @@ class SQLSaber:
             conversation_id: Stable Pydantic AI conversation identifier for the run.
             metadata: Application metadata available to capabilities, such as tenant
                 and user identifiers used when publishing artifacts.
+            usage_limits: Optional Pydantic AI limits for this run. When omitted,
+                Pydantic AI's safe defaults apply.
 
         Returns:
             A SQLSaberResult object (subclass of str) containing the agent's response.
@@ -162,6 +166,7 @@ class SQLSaber:
             event_stream_handler=event_stream_handler,
             conversation_id=conversation_id,
             metadata=metadata,
+            usage_limits=usage_limits,
         )
 
         content = ""

--- a/src/sqlsaber/run_usage.py
+++ b/src/sqlsaber/run_usage.py
@@ -1,0 +1,27 @@
+"""Run-local usage-limit intent shared with nested SQLSaber agents."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from pydantic_ai.usage import UsageLimits
+
+_EXPLICIT_USAGE_LIMITS: ContextVar[UsageLimits | None] = ContextVar(
+    "sqlsaber_explicit_usage_limits",
+    default=None,
+)
+
+
+def current_usage_limits() -> UsageLimits | None:
+    """Return limits explicitly supplied to the current SQLSaber run, if any."""
+    return _EXPLICIT_USAGE_LIMITS.get()
+
+
+@contextmanager
+def bind_usage_limits(usage_limits: UsageLimits | None) -> Iterator[None]:
+    """Make a run's explicit limit selection available to nested agents."""
+    token = _EXPLICIT_USAGE_LIMITS.set(usage_limits)
+    try:
+        yield
+    finally:
+        _EXPLICIT_USAGE_LIMITS.reset(token)

--- a/src/sqlsaber/session.py
+++ b/src/sqlsaber/session.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from pydantic_ai import RunContext
 from pydantic_ai.messages import AgentStreamEvent, ModelMessage
+from pydantic_ai.usage import UsageLimits
 
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
 from sqlsaber.config.database import DatabaseConfigManager
@@ -110,6 +111,7 @@ class SQLSaberSession:
         *,
         conversation_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        usage_limits: UsageLimits | None = None,
     ) -> Any:
         """Run a natural language query against the configured database."""
         run_result = await self.agent.run(
@@ -118,6 +120,7 @@ class SQLSaberSession:
             event_stream_handler=event_stream_handler,
             conversation_id=conversation_id,
             metadata=metadata,
+            usage_limits=usage_limits,
         )
 
         if self.thread_manager is not None:

--- a/tests/test_agents/test_pydantic_ai_agent.py
+++ b/tests/test_agents/test_pydantic_ai_agent.py
@@ -3,12 +3,14 @@
 from types import SimpleNamespace
 
 import pytest
+from pydantic_ai.usage import UsageLimits
 
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
 from sqlsaber.capabilities.base import SqlSaberCapability
 from sqlsaber.database.sqlite import SQLiteConnection
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.knowledge.sqlite_store import SQLiteKnowledgeStore
+from sqlsaber.run_usage import current_usage_limits
 from sqlsaber.tools.knowledge_tool import SearchKnowledgeTool
 
 
@@ -73,12 +75,22 @@ class TestSQLSaberAgentDeps:
         async def fake_run(prompt: str, **kwargs):
             _ = prompt
             captured.update(kwargs)
+            captured["bound_usage_limits"] = current_usage_limits()
             return SimpleNamespace(output="ok")
 
         monkeypatch.setattr(agent.agent, "run", fake_run)
 
-        await agent.run("hello")
+        usage_limits = UsageLimits(request_limit=200)
+        await agent.run("hello", usage_limits=usage_limits)
         assert "deps" not in captured
+        assert captured["usage_limits"] is usage_limits
+        assert captured["bound_usage_limits"] is usage_limits
+
+        captured.clear()
+        await agent.run("use defaults")
+        assert "deps" not in captured
+        assert captured["usage_limits"] is None
+        assert captured["bound_usage_limits"] is None
         viz = agent._tools["viz"]
         assert viz.model_overide.model_name == "openai:gpt-5-mini"
         assert viz.model_overide.api_key == "override-api-key"

--- a/tests/test_api/test_options.py
+++ b/tests/test_api/test_options.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from pydantic_ai.capabilities import Capability
+from pydantic_ai.usage import UsageLimits
 
 from sqlsaber import (
     InMemoryArtifactStore,
@@ -108,10 +109,12 @@ async def test_artifact_options_and_run_context_reach_managed_agent(
         return FakeResult()
 
     monkeypatch.setattr(saber.agent, "run", fake_run)
+    usage_limits = UsageLimits(request_limit=200)
     result = await saber.query(
         "analyze",
         conversation_id="conversation-1",
         metadata={"tenant_id": "acme"},
+        usage_limits=usage_limits,
     )
 
     assert result == "answer"
@@ -120,6 +123,11 @@ async def test_artifact_options_and_run_context_reach_managed_agent(
     assert saber.agent._artifact_failure_mode == "best_effort"
     assert captured["conversation_id"] == "conversation-1"
     assert captured["metadata"] == {"tenant_id": "acme"}
+    assert captured["usage_limits"] is usage_limits
+
+    captured.clear()
+    await saber.query("use defaults")
+    assert captured["usage_limits"] is None
     await saber.close()
 
 


### PR DESCRIPTION
## Summary

- expose a keyword-only `usage_limits` argument through `SQLSaber.query`, `SQLSaberSession.query`, and `SQLSaberAgent.run`
- preserve Pydantic AI's safe parent-run default when callers omit limits
- propagate explicitly selected run limits to managed notebook analysis while sharing the parent usage counter for exact aggregate accounting
- leave notebook analysis uncapped when the embedding caller did not explicitly select limits
- use Pydantic AI's per-response sequential tool barrier and derive the nested tool-call budget without mutating parent limits
- document the SDK API and add an unreleased changelog entry

## Validation

- `uv run pytest -q` — 1214 passed, 6 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx ty check src/`
- `uvx ty check plugins/notebook/src/`
- `cd docs && npm run build`
