### PR TITLE
feat: improve automation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ saber -d sales -d analytics "Compare last month's revenue to web sessions"
 | Compare multiple databases | `saber -d sales -d analytics "compare revenue to traffic"` |
 | Save a KPI definition | `saber knowledge add "Revenue KPI" "Recognized revenue from shipped orders only"` |
 | Resume previous analysis | `saber threads list` then `saber threads resume <id>` |
+| Automate a thread follow-up | `saber --thread <id> "compare with last quarter"` |
 | Use deeper reasoning | `saber --thinking "analyze retention by cohort"` |
 
 ## Knowledge base

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -75,12 +75,18 @@ To remove stored credentials for a provider:
 
 ```bash
 saber auth reset
+
+# Non-interactive
+saber auth reset openai --yes
 ```
 
 This will:
 
 1. Ask you to select which provider to reset
 2. Remove the stored API key from your OS credentials store
+
+When a provider is supplied directly, no selection prompt is needed. Destructive
+commands require confirmation in a terminal or an explicit `--yes` in automation.
 
 ### Multiple Providers
 

--- a/docs/src/content/docs/guides/database-setup.mdx
+++ b/docs/src/content/docs/guides/database-setup.mdx
@@ -23,6 +23,17 @@ saber db add my-database
 
 This will prompt you for all necessary connection details.
 
+For scripts and coding agents, provide every required value and disable prompts:
+
+```bash
+# Local database
+saber db add local --type sqlite --database ./local.db --no-interactive
+
+# Server database; keep the password out of argv and shell history
+printf '%s' "$DB_PASSWORD" | saber db add analytics --no-interactive \
+  --host db.example.com --database analytics --username agent --password-stdin
+```
+
 You can also attach an optional description to a connection. Descriptions are
 shown to the agent when [several databases are connected at once](/guides/multi-database)
 to help it pick the right one:
@@ -110,6 +121,9 @@ saber db test my-database
 
 ```bash
 saber db remove my-database
+
+# Non-interactive, explicit deletion
+saber db remove my-database --yes
 ```
 
 ### Connecting to Multiple Databases

--- a/docs/src/content/docs/guides/knowledge.mdx
+++ b/docs/src/content/docs/guides/knowledge.mdx
@@ -75,6 +75,9 @@ Remove one entry:
 
 ```bash
 saber knowledge remove a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Non-interactive
+saber knowledge remove a1b2c3d4-e5f6-7890-abcd-ef1234567890 --yes
 ```
 
 Clear all entries for a database:
@@ -83,7 +86,7 @@ Clear all entries for a database:
 saber knowledge clear
 
 # Skip confirmation
-saber knowledge clear --force
+saber knowledge clear --yes
 ```
 
 ### How the Tool Is Used

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -52,6 +52,13 @@ This interactive command lets you:
   This list is long - type to search and filter the list.
 </Aside>
 
+For scripts and coding agents, set the model and thinking level directly without
+fetching the model list or opening a prompt:
+
+```bash
+saber models set openai:gpt-5 --thinking-level medium
+```
+
 #### Subagent Overrides
 
 You can override the model used by subagents like handoff and viz without changing
@@ -60,6 +67,9 @@ the main model:
 ```bash
 saber models set --agent handoff
 saber models set --agent viz
+
+# Direct, non-interactive override
+saber models set openai:gpt-5 --agent handoff
 ```
 
 If no override is set, the subagent uses the main model.
@@ -70,6 +80,7 @@ Return to the original default (Claude Opus 4.6):
 
 ```bash
 saber models reset
+saber models reset --yes
 ```
 
 ### Getting Help

--- a/docs/src/content/docs/guides/threads.md
+++ b/docs/src/content/docs/guides/threads.md
@@ -63,9 +63,31 @@ saber threads resume bb7b4d72
 This:
 - Loads the full conversation context
 - Connects to the same database used in the original thread
-- Uses the same model from the original conversation
+- Uses the currently configured model
 - Allows you to continue where you left off in interactive mode
 
+For one non-interactive follow-up, pass the thread to the root query command:
+
+```bash
+saber --thread bb7b4d72 "Now compare that with last quarter"
+```
+
+This loads the saved message history, keeps the same thread ID, and uses the
+stored configured database. Pass `-d DATABASE` to override it.
+
+### Prune Old Threads Safely
+
+Preview cleanup before deleting anything:
+
+```bash
+saber threads prune --days 30 --dry-run
+```
+
+Run the deletion interactively, or make the intent explicit in automation:
+
+```bash
+saber threads prune --days 30 --yes
+```
 
 ### Sharing Threads
 
@@ -77,7 +99,6 @@ saber threads show abc123 > analysis_report.md
 cat analysis_report.md
 ```
 
-
 ### Getting Help
 
 Check thread commands and options:
@@ -87,6 +108,7 @@ saber threads --help
 saber threads list --help
 saber threads resume --help
 saber threads artifacts --help
+saber threads prune --help
 ```
 
 ### What's Next?

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -26,6 +26,9 @@ saber -d "postgresql://user:pass@host:5432/db" "User statistics for 2024"
 
 # With multiple databases (repeat -d)
 saber -d sales -d analytics "Compare revenue to web sessions"
+
+# Continue a saved thread with one non-interactive follow-up
+saber --thread a1b2c3d4 "Now compare that with last quarter"
 ```
 
 **Parameters:**
@@ -35,6 +38,7 @@ saber -d sales -d analytics "Compare revenue to web sessions"
 - `--thinking` / `--no-thinking` - Enable/disable extended thinking/reasoning mode
 - `--allow-dangerous` - Allow INSERT/UPDATE/DELETE and restricted DDL (CREATE TABLE/VIEW/INDEX, ALTER TABLE). DROP/TRUNCATE and admin/security operations remain blocked; UPDATE/DELETE require WHERE.
 - `--system-prompt` - Custom system prompt text or path to a file (overrides built-in prompt)
+- `--thread` - Continue a saved thread non-interactively. Requires a query; uses the stored configured database unless `-d` overrides it.
 
 **Global Options:**
 
@@ -79,7 +83,13 @@ Remove stored credentials for a provider.
 
 ```bash
 saber auth reset
+
+# Non-interactive
+saber auth reset openai --yes
 ```
+
+Pass the provider directly for automation. `--yes` skips confirmation; without it,
+the command prompts only when attached to an interactive terminal.
 
 ---
 
@@ -95,6 +105,13 @@ Add a new database connection.
 
 ```bash
 saber db add my-database [OPTIONS]
+
+# Non-interactive SQLite setup
+saber db add local --type sqlite --database ./local.db --no-interactive
+
+# Read a server password from stdin instead of an argument or prompt
+printf '%s' "$DB_PASSWORD" | saber db add analytics --no-interactive \
+  --host db.example.com --database analytics --username agent --password-stdin
 ```
 
 **Parameters:**
@@ -115,6 +132,7 @@ saber db add my-database [OPTIONS]
 - `--ssl-cert` - SSL client certificate file path
 - `--ssl-key` - SSL client private key file path
 - `--interactive/--no-interactive` - Use interactive mode (default: true)
+- `--password-stdin` - Read the database password from stdin. Requires `--no-interactive`.
 
 **SSL Modes:**
 
@@ -204,9 +222,11 @@ Remove a database connection.
 
 ```bash
 saber db remove my-database
+saber db remove my-database --yes
 ```
 
-**Confirmation required** - Will prompt before deletion.
+**Confirmation required** - Will prompt before deletion in a terminal. Use `--yes`
+for a deliberate non-interactive removal.
 
 ---
 
@@ -334,6 +354,7 @@ saber knowledge remove ENTRY_ID [OPTIONS]
 **Options:**
 
 - `-d, --database` - Database connection name (uses default if not specified)
+- `--yes` - Skip confirmation prompt (required when no interactive terminal is available)
 
 #### `saber knowledge clear`
 
@@ -348,7 +369,7 @@ saber knowledge clear [OPTIONS]
 **Options:**
 
 - `-d, --database` - Database connection name (uses default if not specified)
-- `-f, --force` - Skip confirmation prompt
+- `--yes` - Skip confirmation prompt
 
 ### `saber models`
 
@@ -371,12 +392,18 @@ Set the default model and configure thinking level.
 **Usage:**
 
 ```bash
+# Interactive selection
 saber models set
+
+# Direct, non-interactive selection
+saber models set openai:gpt-5 --thinking-level medium
+saber models set openai:gpt-5 --agent handoff
 ```
 
 **Options:**
 
 - `--agent` - Target agent to configure (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
+- `--thinking-level` - Main-model thinking mode: `off`, `minimal`, `low`, `medium`, `high`, or `maximum`.
 
 #### `saber models current`
 
@@ -400,11 +427,13 @@ Reset to the default model (Claude Sonnet 4).
 
 ```bash
 saber models reset
+saber models reset --agent handoff --yes
 ```
 
 **Options:**
 
 - `--agent` - Reset a specific agent (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
+- `--yes` - Skip confirmation prompt (required when no interactive terminal is available).
 
 ---
 
@@ -414,12 +443,13 @@ Manage syntax highlighting theme settings.
 
 #### `saber theme set`
 
-Interactively select a syntax highlighting theme from all available Pygments themes.
+Select a syntax highlighting theme. Omit the theme name to browse interactively.
 
 **Usage:**
 
 ```bash
 saber theme set
+saber theme set dracula
 ```
 
 You can also set themes via environment variable:
@@ -437,7 +467,10 @@ Reset to the default theme (nord).
 
 ```bash
 saber theme reset
+saber theme reset --yes
 ```
+
+`--yes` skips confirmation and is required when no interactive terminal is available.
 
 ---
 
@@ -516,13 +549,20 @@ saber threads resume a1b2c3d4 [OPTIONS]
 **Features:**
 
 - Loads full conversation context
-- Uses same model as original thread
+- Uses the currently configured model
 - Reconnects to the original database(s), including [multi-database](/guides/multi-database) threads
 - Continues where conversation left off in interactive mode
 
 :::note
 Automatic resume requires every database in the thread to be a saved connection. If a thread used an ad-hoc connection string or file path, resume it with explicit `-d` flags.
 :::
+
+For one automated follow-up rather than an interactive session, use the root
+command:
+
+```bash
+saber --thread a1b2c3d4 "Now compare that with last quarter"
+```
 
 #### `saber threads prune`
 
@@ -532,7 +572,15 @@ Clean up old conversation threads.
 
 ```bash
 saber threads prune
+saber threads prune --days 30 --dry-run
+saber threads prune --days 30 --yes
 ```
+
+**Options:**
+
+- `-n, --days` - Delete threads older than this many days (default: 30)
+- `--dry-run` - Report how many threads would be deleted without deleting them
+- `--yes` - Skip confirmation prompt (required when no interactive terminal is available)
 
 ---
 

--- a/src/sqlsaber/cli/auth.py
+++ b/src/sqlsaber/cli/auth.py
@@ -1,12 +1,14 @@
 """Authentication CLI commands."""
 
 import os
+import sys
+from typing import Annotated
 
 import cyclopts
 import keyring
-import keyring.errors
 import questionary
 
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config import providers
 from sqlsaber.config.api_keys import APIKeyManager
 from sqlsaber.config.auth import AuthConfigManager
@@ -14,18 +16,24 @@ from sqlsaber.config.logging import get_logger
 from sqlsaber.theme.manager import create_console
 
 console = create_console()
+error_console = create_console(stderr=True)
 config_manager = AuthConfigManager()
 logger = get_logger(__name__)
 
 auth_app = cyclopts.App(
     name="auth",
     help="Manage authentication configuration",
+    help_epilogue=("Examples:\n\nsaber auth status\n\nsaber auth reset openai --yes"),
 )
 
 
-@auth_app.command
+@auth_app.command(help_epilogue="Example:\n\nsaber auth setup")
 def setup():
-    """Configure authentication for SQLsaber (API keys)."""
+    """Configure authentication for SQLsaber (API keys).
+
+    Example:
+        saber auth setup
+    """
     import asyncio
 
     from sqlsaber.application.auth_setup import setup_auth
@@ -48,16 +56,21 @@ def setup():
     logger.info("auth.setup.complete", success=bool(success), provider=str(provider))
 
     if not success:
-        console.print("\n[warning]No authentication configured.[/warning]")
+        error_console.print("[error]Error: no authentication was configured.[/error]")
+        raise SystemExit(1)
 
     console.print(
         "\nYou can change this anytime by running [info]saber auth setup[/info] again."
     )
 
 
-@auth_app.command
+@auth_app.command(help_epilogue="Example:\n\nsaber auth status")
 def status():
-    """Show current authentication configuration and provider key status."""
+    """Show current authentication configuration and provider key status.
+
+    Example:
+        saber auth status
+    """
     logger.info("auth.status.start")
     auth_method = config_manager.get_auth_method()
 
@@ -89,20 +102,54 @@ def status():
     logger.info("auth.status.complete", method=str(auth_method))
 
 
-@auth_app.command
-def reset():
-    """Reset stored API key credentials for a selected provider."""
+@auth_app.command(
+    help_epilogue=("Examples:\n\nsaber auth reset\n\nsaber auth reset openai --yes")
+)
+def reset(
+    provider: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Provider to reset (omit to select interactively)"),
+    ] = None,
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
+):
+    """Reset stored API key credentials for a selected provider.
+
+    Examples:
+        saber auth reset
+        saber auth reset openai --yes
+    """
     console.print("\n[bold]SQLsaber Authentication Reset[/bold]\n")
 
-    provider = questionary.select(
-        "Select provider to reset:",
-        choices=providers.all_keys(),
-    ).ask()
+    if provider is None:
+        if not sys.stdin.isatty():
+            error_console.print(
+                "[error]Error: PROVIDER is required when stdin is not a terminal.[/error]\n"
+                "  Example: saber auth reset openai --yes"
+            )
+            raise SystemExit(2)
+        provider = questionary.select(
+            "Select provider to reset:",
+            choices=providers.all_keys(),
+        ).ask()
 
     if provider is None:
         console.print("[warning]Reset cancelled.[/warning]")
         logger.info("auth.reset.cancelled_no_provider")
         return
+
+    canonical_provider = providers.canonical(provider.strip().lower())
+    if canonical_provider is None:
+        choices = ", ".join(providers.all_keys())
+        error_console.print(
+            f"[error]Error: unsupported provider '{provider}'.[/error]\n"
+            f"  Choose from: {choices}\n"
+            "  Example: saber auth reset openai --yes"
+        )
+        raise SystemExit(2)
+    provider = canonical_provider
 
     api_key_manager = APIKeyManager()
     service = api_key_manager._get_service_name(provider)
@@ -116,10 +163,12 @@ def reset():
         logger.info("auth.reset.nothing_to_reset", provider=provider)
         return
 
-    confirmed = questionary.confirm(
-        f"Remove the stored {provider.title()} API key from your keyring?",
-        default=False,
-    ).ask()
+    confirmed = confirm_action(
+        yes=yes,
+        prompt=f"Remove the stored {provider.title()} API key from your keyring?",
+        non_interactive_command=f"saber auth reset {provider} --yes",
+        error_console=error_console,
+    )
 
     if not confirmed:
         console.print("Reset cancelled.")
@@ -130,13 +179,12 @@ def reset():
         keyring.delete_password(service, provider)
         console.print(f"Removed {provider} API key from keyring", style="green")
         logger.info("auth.reset.api_key_removed", provider=provider)
-    except keyring.errors.PasswordDeleteError:
-        pass
     except Exception as e:
-        console.print(f"Warning: Could not remove API key: {e}", style="warning")
+        error_console.print(f"[error]Error: could not remove API key: {e}[/error]")
         logger.warning(
             "auth.reset.api_key_remove_failed", provider=provider, error=str(e)
         )
+        raise SystemExit(1) from None
 
     console.print("\n[success]✓ Reset complete.[/success]")
     logger.info("auth.reset.complete", provider=provider)

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -46,6 +46,12 @@ class CLIError(Exception):
 app = cyclopts.App(
     name="sqlsaber",
     help="SQLsaber - Open-source agentic SQL assistant for your database",
+    help_epilogue=(
+        "Examples:\n\n"
+        'saber "show me all users"\n\n'
+        'echo "top customers by revenue" | saber\n\n'
+        'saber --thread THREAD_ID "now compare that with last quarter"'
+    ),
 )
 
 app.command(create_auth_app(), name="auth")
@@ -56,6 +62,7 @@ app.command(create_theme_app(), name="theme")
 app.command(create_threads_app(), name="threads")
 
 console = create_console()
+error_console = create_console(stderr=True)
 
 
 @app.meta.default
@@ -82,6 +89,7 @@ def meta_handler(
         saber -d "postgresql://user:pass@host:5432/db" "show users"  # PostgreSQL connection string
         saber -d "mysql://user:pass@host:3306/db" "show users"       # MySQL connection string
         saber -d "duckdb:///data.duckdb" "show users"                 # DuckDB connection string
+        saber --thread THREAD_ID "now compare that with last quarter" # Continue a saved thread
         echo "show me all users" | saber       # Read query from stdin
         cat query.txt | saber                  # Read query from file via stdin
     """
@@ -123,6 +131,13 @@ def query(
             help="Custom system prompt text or path to a file (overrides built-in prompt)",
         ),
     ] = None,
+    thread: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            ["--thread"],
+            help="Continue a saved thread non-interactively",
+        ),
+    ] = None,
 ):
     """Run a query against the database or start interactive mode.
 
@@ -142,18 +157,22 @@ def query(
         saber -d "postgresql://user:pass@host:5432/db" "show users"  # PostgreSQL connection string
         saber -d "mysql://user:pass@host:3306/db" "show users"       # MySQL connection string
         saber -d "duckdb:///data.duckdb" "show users"                 # DuckDB connection string
+        saber --thread THREAD_ID "now compare that with last quarter" # Continue a saved thread
         echo "show me all users" | saber  # Read query from stdin
     """
 
     async def run_session():
         schedule_update_check(console)
 
+        selected_database: str | list[str] | None = database
+
         log = get_logger(__name__)
         log.info(
             "cli.session.start",
             argv=sys.argv[1:],
-            database=database,
+            database=selected_database,
             has_query=query_text is not None,
+            thread_id=thread,
             thinking=thinking,
             allow_dangerous=allow_dangerous,
             system_prompt_provided=system_prompt is not None,
@@ -166,10 +185,13 @@ def query(
         from sqlsaber.cli.query_results import cli_query_result_store
         from sqlsaber.cli.streaming import StreamingQueryHandler
         from sqlsaber.cli.usage import SessionUsage, request_usages_from_run_result
+        from sqlsaber.config.database import DatabaseConfigManager
         from sqlsaber.database.resolver import DatabaseResolutionError
         from sqlsaber.options import SQLSaberOptions
         from sqlsaber.session import SQLSaberSession
+        from sqlsaber.threads import ThreadStorage
         from sqlsaber.threads.manager import ThreadManager
+        from sqlsaber.threads.metadata import resolve_thread_database_selector
 
         # Check if query_text is None and stdin has data
         actual_query = query_text
@@ -180,8 +202,59 @@ def query(
                 # If stdin was empty, fall back to interactive mode
                 actual_query = None
 
+        message_history = None
+        thread_manager = ThreadManager()
+        if thread is not None:
+            if actual_query is None:
+                raise CLIError(
+                    "A query is required with --thread. Example: "
+                    f'saber --thread {thread} "follow-up question"',
+                    exit_code=2,
+                )
+            store = ThreadStorage()
+            stored_thread = await store.get_thread(thread)
+            if stored_thread is None:
+                raise CLIError(
+                    f"Thread not found: {thread}. List threads with: saber threads list"
+                )
+            message_history = await store.get_thread_messages(thread)
+            if selected_database is None:
+                try:
+                    selected_database = resolve_thread_database_selector(
+                        database_name=stored_thread.database_name,
+                        extra_metadata=stored_thread.extra_metadata,
+                    )
+                except ValueError as exc:
+                    raise CLIError(
+                        f"Invalid thread metadata: {exc}. Retry with: "
+                        f'saber --thread {thread} --database DATABASE "follow-up question"'
+                    ) from None
+                if not selected_database:
+                    raise CLIError(
+                        "No database is stored with this thread. Retry with: "
+                        f'saber --thread {thread} --database DATABASE "follow-up question"'
+                    )
+                config_manager = DatabaseConfigManager()
+                selectors = (
+                    [selected_database]
+                    if isinstance(selected_database, str)
+                    else selected_database
+                )
+                missing = [
+                    selector
+                    for selector in selectors
+                    if config_manager.get_database(selector) is None
+                ]
+                if missing:
+                    raise CLIError(
+                        "The thread database is not configured for automatic "
+                        "continuation. Retry with: "
+                        f'saber --thread {thread} --database DATABASE "follow-up question"'
+                    )
+            thread_manager = ThreadManager(initial_thread_id=thread, storage=store)
+
         # Check if onboarding is needed (only for interactive mode or when no database is configured)
-        if needs_onboarding(database):
+        if needs_onboarding(selected_database):
             # Run onboarding flow
             log.debug("cli.onboarding.start")
             onboarding_success = await run_onboarding()
@@ -191,11 +264,10 @@ def query(
                     "Setup incomplete. Please configure your database and try again."
                 )
             log.info("cli.onboarding.complete", success=True)
-        thread_manager = ThreadManager()
         try:
             session = SQLSaberSession(
                 SQLSaberOptions(
-                    database=database,
+                    database=selected_database,
                     thinking_enabled=thinking,
                     allow_dangerous=allow_dangerous,
                     system_prompt=system_prompt,
@@ -240,6 +312,7 @@ def query(
                 run = await streaming_handler.execute_streaming_query(
                     actual_query,
                     run_query=session.query,
+                    message_history=message_history,
                 )
 
                 # Track and display session usage
@@ -259,7 +332,10 @@ def query(
                 thread_id = thread_manager.current_thread_id
                 if thread_id:
                     console.print(
-                        f"[dim]You can continue this thread using:[/dim] saber threads resume {thread_id}"
+                        "[dim]Continue non-interactively:[/dim] "
+                        f'saber --thread {thread_id} "follow-up question"\n'
+                        "[dim]Continue interactively:[/dim] "
+                        f"saber threads resume {thread_id}"
                     )
                     log.info("thread.save.success", thread_id=thread_id)
             else:
@@ -288,7 +364,7 @@ def query(
         asyncio.run(run_session())
     except CLIError as e:
         get_logger(__name__).error("cli.error", error=str(e))
-        console.print(f"[error]Error:[/error] {e}")
+        error_console.print(f"[error]Error:[/error] {e}")
         sys.exit(e.exit_code)
 
 

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -1,7 +1,6 @@
 """Database management CLI commands."""
 
 import asyncio
-import getpass
 import sys
 from pathlib import Path
 from typing import Annotated
@@ -10,6 +9,7 @@ import cyclopts
 import questionary
 from rich.table import Table
 
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
 from sqlsaber.config.logging import get_logger
 from sqlsaber.theme.manager import create_console
@@ -18,6 +18,7 @@ type SchemaList = list[str]
 
 # Global instances for CLI commands
 console = create_console()
+error_console = create_console(stderr=True)
 config_manager = DatabaseConfigManager()
 logger = get_logger(__name__)
 
@@ -25,6 +26,12 @@ logger = get_logger(__name__)
 db_app = cyclopts.App(
     name="db",
     help="Manage database connections",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber db list\n\n"
+        "saber db add analytics\n\n"
+        "saber db test analytics"
+    ),
 )
 
 
@@ -50,7 +57,14 @@ def _parse_schema_list(raw: str | None) -> SchemaList:
     return _normalize_schema_list(raw.split(","))
 
 
-@db_app.command
+@db_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber db add analytics\n\n"
+        "saber db add local --type sqlite --database ./local.db --no-interactive\n\n"
+        "printf '%s' \"$DB_PASSWORD\" | saber db add analytics --no-interactive --host HOST --database DB --username USER --password-stdin"
+    )
+)
 def add(
     name: Annotated[str, cyclopts.Parameter(help="Name for the database connection")],
     type: Annotated[
@@ -115,12 +129,25 @@ def add(
     interactive: Annotated[
         bool,
         cyclopts.Parameter(
-            ["--interactive", "--no-interactive"],
+            ["--interactive"],
             help="Use interactive mode",
         ),
     ] = True,
+    password_stdin: Annotated[
+        bool,
+        cyclopts.Parameter(
+            ["--password-stdin"],
+            help="Read the database password from stdin (requires --no-interactive)",
+        ),
+    ] = False,
 ) -> None:
-    """Add a new database connection."""
+    """Add a new database connection.
+
+    Examples:
+        saber db add analytics
+        saber db add local --type sqlite --database ./local.db --no-interactive
+        printf '%s' "$DB_PASSWORD" | saber db add analytics --no-interactive --type postgresql --host db.example.com --database analytics --username agent --password-stdin
+    """
     logger.info(
         "db.add.start",
         name=name,
@@ -128,6 +155,23 @@ def add(
         interactive=bool(interactive),
         has_password=False,
     )
+
+    supported_types = {"postgresql", "mysql", "sqlite", "duckdb"}
+    if type not in supported_types:
+        error_console.print(
+            f"[error]Error: unsupported database type '{type}'.[/error]\n"
+            "  Choose from: postgresql, mysql, sqlite, duckdb\n"
+            "  Example: saber db add analytics --type postgresql"
+        )
+        raise SystemExit(2)
+    if interactive and password_stdin:
+        error_console.print(
+            "[error]Error: --password-stdin requires --no-interactive.[/error]\n"
+            "  Example: printf '%s' \"$DB_PASSWORD\" | saber db add analytics "
+            "--no-interactive --host HOST --database DB --username USER "
+            "--password-stdin"
+        )
+        raise SystemExit(2)
 
     if interactive:
         # Interactive mode - prompt for all required fields
@@ -165,22 +209,26 @@ def add(
         # Non-interactive mode - use provided values or defaults
         if type == "sqlite":
             if not database:
-                console.print(
-                    "[bold error]Error:[/bold error] Database file path is required for SQLite"
+                error_console.print(
+                    "[error]Error: database file path is required for SQLite.[/error]\n"
+                    "  Example: saber db add local --no-interactive --type sqlite "
+                    "--database ./local.db"
                 )
                 logger.error("db.add.missing_path", db_type="sqlite")
-                sys.exit(1)
+                raise SystemExit(2)
             host = "localhost"
             port = 0
             username = "sqlite"
             password = ""
         elif type == "duckdb":
             if database is None:
-                console.print(
-                    "[bold error]Error:[/bold error] Database file path is required for DuckDB"
+                error_console.print(
+                    "[error]Error: database file path is required for DuckDB.[/error]\n"
+                    "  Example: saber db add warehouse --no-interactive --type duckdb "
+                    "--database ./warehouse.duckdb"
                 )
                 logger.error("db.add.missing_path", db_type="duckdb")
-                raise SystemExit(1)
+                raise SystemExit(2)
             database = str(Path(database).expanduser().resolve())
             host = "localhost"
             port = 0
@@ -188,20 +236,35 @@ def add(
             password = ""
         else:
             if not all([host, database, username]):
-                console.print(
-                    "[bold error]Error:[/bold error] Host, database, and username are required"
+                error_console.print(
+                    "[error]Error: --host, --database, and --username are required "
+                    "in non-interactive mode.[/error]\n"
+                    "  Example: saber db add analytics --no-interactive "
+                    "--host HOST --database DB --username USER"
                 )
                 logger.error("db.add.missing_fields")
-                sys.exit(1)
+                raise SystemExit(2)
 
             if port is None:
                 port = 5432 if type == "postgresql" else 3306
 
-            password = (
-                getpass.getpass("Password (stored in your OS keychain): ")
-                if questionary.confirm("Enter password?").ask()
-                else ""
-            )
+            if password_stdin:
+                if sys.stdin.isatty():
+                    error_console.print(
+                        "[error]Error: --password-stdin requires piped stdin.[/error]\n"
+                        "  Example: printf '%s' \"$DB_PASSWORD\" | saber db add "
+                        "analytics --no-interactive --host HOST --database DB "
+                        "--username USER --password-stdin"
+                    )
+                    raise SystemExit(2)
+                password = sys.stdin.read().rstrip("\r\n")
+                if not password:
+                    error_console.print(
+                        "[error]Error: --password-stdin received an empty password.[/error]"
+                    )
+                    raise SystemExit(2)
+            else:
+                password = ""
         exclude_schema_list = _parse_schema_list(exclude_schemas)
 
     # Create database config
@@ -242,13 +305,17 @@ def add(
 
     except Exception as e:
         logger.exception("db.add.error", name=name, error=str(e))
-        console.print(f"[bold error]Error adding database:[/bold error] {e}")
+        error_console.print(f"[error]Error adding database:[/error] {e}")
         sys.exit(1)
 
 
-@db_app.command(name="list")
+@db_app.command(name="list", help_epilogue="Example:\n\nsaber db list")
 def list_databases() -> None:
-    """List all configured database connections."""
+    """List all configured database connections.
+
+    Example:
+        saber db list
+    """
     logger.info("db.list.start")
     databases = config_manager.list_databases()
     default_name = config_manager.get_default_name()
@@ -298,7 +365,13 @@ def list_databases() -> None:
     logger.info("db.list.complete", count=len(databases))
 
 
-@db_app.command
+@db_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber db exclude analytics --add audit,temp\n\n"
+        "saber db exclude analytics --clear"
+    )
+)
 def exclude(
     name: Annotated[
         str,
@@ -333,7 +406,12 @@ def exclude(
         ),
     ] = False,
 ) -> None:
-    """Update excluded schemas for a database connection."""
+    """Update excluded schemas for a database connection.
+
+    Examples:
+        saber db exclude analytics --add audit,temp
+        saber db exclude analytics --clear
+    """
     logger.info(
         "db.exclude.start",
         name=name,
@@ -344,8 +422,9 @@ def exclude(
     )
     db_config = config_manager.get_database(name)
     if db_config is None:
-        console.print(
-            f"[bold error]Error: Database connection '{name}' not found[/bold error]"
+        error_console.print(
+            f"[error]Error: database connection '{name}' not found.[/error]\n"
+            "  List connections with: saber db list"
         )
         logger.error("db.exclude.not_found", name=name)
         raise SystemExit(1)
@@ -360,8 +439,9 @@ def exclude(
         ]
     )
     if actions_selected > 1:
-        console.print(
-            "[bold error]Error: Specify only one of --set, --add, --remove, or --clear[/bold error]"
+        error_console.print(
+            "[error]Error: specify only one of --set, --add, --remove, or --clear.[/error]\n"
+            "  Example: saber db exclude analytics --add audit,temp"
         )
         logger.error("db.exclude.multiple_actions", name=name)
         sys.exit(1)
@@ -408,32 +488,49 @@ def exclude(
     logger.info("db.exclude.success", name=name, count=len(db_config.exclude_schemas))
 
 
-@db_app.command
+@db_app.command(
+    help_epilogue=(
+        "Examples:\n\nsaber db remove analytics\n\nsaber db remove analytics --yes"
+    )
+)
 def remove(
     name: Annotated[
         str, cyclopts.Parameter(help="Name of the database connection to remove")
     ],
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
 ) -> None:
-    """Remove a database connection."""
+    """Remove a database connection.
+
+    Examples:
+        saber db remove analytics
+        saber db remove analytics --yes
+    """
     logger.info("db.remove.start", name=name)
     if not config_manager.get_database(name):
-        console.print(
-            f"[bold error]Error: Database connection '{name}' not found[/bold error]"
+        error_console.print(
+            f"[error]Error: database connection '{name}' not found.[/error]\n"
+            "  List connections with: saber db list"
         )
         logger.error("db.remove.not_found", name=name)
         sys.exit(1)
 
-    if questionary.confirm(
-        f"Are you sure you want to remove database connection '{name}'?"
-    ).ask():
+    if confirm_action(
+        yes=yes,
+        prompt=f"Remove database connection '{name}'?",
+        non_interactive_command=f"saber db remove {name} --yes",
+        error_console=error_console,
+    ):
         if config_manager.remove_database(name):
             console.print(
                 f"[success]Successfully removed database connection '{name}'[/success]"
             )
             logger.info("db.remove.success", name=name)
         else:
-            console.print(
-                f"[bold error]Error: Failed to remove database connection '{name}'[/bold error]"
+            error_console.print(
+                f"[error]Error: failed to remove database connection '{name}'.[/error]"
             )
             logger.error("db.remove.failed", name=name)
             sys.exit(1)
@@ -442,18 +539,23 @@ def remove(
         logger.info("db.remove.cancelled", name=name)
 
 
-@db_app.command
+@db_app.command(help_epilogue="Example:\n\nsaber db set-default analytics")
 def set_default(
     name: Annotated[
         str,
         cyclopts.Parameter(help="Name of the database connection to set as default"),
     ],
 ) -> None:
-    """Set the default database connection."""
+    """Set the default database connection.
+
+    Example:
+        saber db set-default analytics
+    """
     logger.info("db.default.start", name=name)
     if not config_manager.get_database(name):
-        console.print(
-            f"[bold error]Error: Database connection '{name}' not found[/bold error]"
+        error_console.print(
+            f"[error]Error: database connection '{name}' not found.[/error]\n"
+            "  List connections with: saber db list"
         )
         logger.error("db.default.not_found", name=name)
         sys.exit(1)
@@ -464,14 +566,12 @@ def set_default(
         )
         logger.info("db.default.success", name=name)
     else:
-        console.print(
-            f"[bold error]Error: Failed to set '{name}' as default[/bold error]"
-        )
+        error_console.print(f"[error]Error: failed to set '{name}' as default.[/error]")
         logger.error("db.default.failed", name=name)
         sys.exit(1)
 
 
-@db_app.command
+@db_app.command(help_epilogue=("Examples:\n\nsaber db test\n\nsaber db test analytics"))
 def test(
     name: Annotated[
         str | None,
@@ -480,7 +580,12 @@ def test(
         ),
     ] = None,
 ) -> None:
-    """Test a database connection."""
+    """Test a database connection.
+
+    Examples:
+        saber db test
+        saber db test analytics
+    """
     logger.info("db.test.start")
 
     async def test_connection():
@@ -490,19 +595,18 @@ def test(
         if name:
             db_config = config_manager.get_database(name)
             if db_config is None:
-                console.print(
-                    f"[bold error]Error: Database connection '{name}' not found[/bold error]"
+                error_console.print(
+                    f"[error]Error: database connection '{name}' not found.[/error]\n"
+                    "  List connections with: saber db list"
                 )
                 logger.error("db.test.not_found", name=name)
                 raise SystemExit(1)
         else:
             db_config = config_manager.get_default_database()
             if db_config is None:
-                console.print(
-                    "[bold error]Error: No default database configured[/bold error]"
-                )
-                console.print(
-                    "Use 'sqlsaber db add <name>' to add a database connection"
+                error_console.print(
+                    "[error]Error: no default database configured.[/error]\n"
+                    "  Add one with: saber db add <name>"
                 )
                 logger.error("db.test.no_default")
                 raise SystemExit(1)
@@ -532,7 +636,7 @@ def test(
                 ),
                 error=str(e),
             )
-            console.print(f"[bold error]✗ Connection failed: {e}[/bold error]")
+            error_console.print(f"[error]Connection failed: {e}[/error]")
             sys.exit(1)
 
     asyncio.run(test_connection())

--- a/src/sqlsaber/cli/knowledge.py
+++ b/src/sqlsaber/cli/knowledge.py
@@ -8,20 +8,24 @@ from collections.abc import Coroutine
 from typing import Annotated, TypeVar
 
 import cyclopts
-import questionary
 from rich.table import Table
 
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.config.logging import get_logger
 from sqlsaber.knowledge.manager import KnowledgeManager
 from sqlsaber.theme.manager import create_console
 
 console = create_console()
+error_console = create_console(stderr=True)
 config_manager = DatabaseConfigManager()
 logger = get_logger(__name__)
 knowledge_app = cyclopts.App(
     name="knowledge",
     help="Manage database-specific knowledge entries",
+    help_epilogue=(
+        'Examples:\n\nsaber knowledge list\n\nsaber knowledge search "shipped revenue"'
+    ),
 )
 _knowledge_manager: KnowledgeManager | None = None
 T = TypeVar("T")
@@ -52,8 +56,9 @@ def _get_database_name(database: str | None = None) -> str:
     if database:
         db_config = config_manager.get_database(database)
         if not db_config:
-            console.print(
-                f"[bold error]Error:[/bold error] Database connection '{database}' not found."
+            error_console.print(
+                f"[error]Error: database connection '{database}' not found.[/error]\n"
+                "  List connections with: saber db list"
             )
             logger.error("knowledge.db.not_found", database=database)
             raise SystemExit(1)
@@ -61,16 +66,22 @@ def _get_database_name(database: str | None = None) -> str:
 
     db_config = config_manager.get_default_database()
     if db_config is None:
-        console.print(
-            "[bold error]Error:[/bold error] No database connections configured."
+        error_console.print(
+            "[error]Error: no database connections configured.[/error]\n"
+            "  Add one with: saber db add <name>"
         )
-        console.print("Use 'sqlsaber db add <name>' to add a database connection.")
         logger.error("knowledge.db.none_configured")
         raise SystemExit(1)
     return db_config.name
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        'saber knowledge add "Revenue KPI" "Recognized shipped revenue"\n\n'
+        'saber knowledge add "Revenue KPI" "Recognized shipped revenue" --database analytics --source finance-wiki'
+    )
+)
 def add(
     name: Annotated[str, cyclopts.Parameter(help="Knowledge entry name")],
     description: Annotated[str, cyclopts.Parameter(help="Knowledge description")],
@@ -96,7 +107,12 @@ def add(
         ),
     ] = None,
 ):
-    """Add knowledge for the specified database."""
+    """Add knowledge for the specified database.
+
+    Examples:
+        saber knowledge add "Revenue KPI" "Recognized shipped revenue"
+        saber knowledge add "Revenue KPI" "Recognized shipped revenue" --database analytics --source finance-wiki
+    """
     database_name = _get_database_name(database)
     logger.info("knowledge.add.start", database=database_name, source=source)
 
@@ -111,7 +127,7 @@ def add(
             )
         )
     except Exception as exc:
-        console.print(f"[bold error]Error adding knowledge:[/bold error] {exc}")
+        error_console.print(f"[error]Error adding knowledge:[/error] {exc}")
         logger.exception("knowledge.add.error", database=database_name, error=str(exc))
         raise SystemExit(1)
 
@@ -123,7 +139,11 @@ def add(
     logger.info("knowledge.add.success", database=database_name, id=entry.id)
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue=(
+        "Examples:\n\nsaber knowledge list\n\nsaber knowledge list --database analytics"
+    )
+)
 def list(
     database: Annotated[
         str | None,
@@ -133,7 +153,12 @@ def list(
         ),
     ] = None,
 ):
-    """List all knowledge entries for the specified database."""
+    """List all knowledge entries for the specified database.
+
+    Examples:
+        saber knowledge list
+        saber knowledge list --database analytics
+    """
     database_name = _get_database_name(database)
     logger.info("knowledge.list.start", database=database_name)
 
@@ -167,7 +192,9 @@ def list(
     logger.info("knowledge.list.complete", database=database_name, count=len(entries))
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue="Example:\n\nsaber knowledge show ENTRY_ID --database analytics"
+)
 def show(
     entry_id: Annotated[str, cyclopts.Parameter(help="Knowledge entry ID")],
     database: Annotated[
@@ -178,14 +205,20 @@ def show(
         ),
     ] = None,
 ):
-    """Show a full knowledge entry."""
+    """Show a full knowledge entry.
+
+    Example:
+        saber knowledge show ENTRY_ID --database analytics
+    """
     database_name = _get_database_name(database)
     logger.info("knowledge.show.start", database=database_name, id=entry_id)
 
     entry = _run(_manager().get_knowledge(database_name, entry_id))
     if entry is None:
-        console.print(
-            f"[bold error]Error:[/bold error] Knowledge entry '{entry_id}' not found for database '{database_name}'"
+        error_console.print(
+            f"[error]Error: knowledge entry '{entry_id}' not found for database "
+            f"'{database_name}'.[/error]\n"
+            f"  List entries with: saber knowledge list --database {database_name}"
         )
         logger.error("knowledge.show.not_found", database=database_name, id=entry_id)
         raise SystemExit(1)
@@ -204,7 +237,13 @@ def show(
         console.print(f"\n[bold]Source:[/bold] {entry.source}")
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        'saber knowledge search "shipped revenue"\n\n'
+        'saber knowledge search "shipped revenue" --database analytics --limit 5'
+    )
+)
 def search(
     query: Annotated[str, cyclopts.Parameter(help="Search query")],
     database: Annotated[
@@ -222,7 +261,12 @@ def search(
         ),
     ] = 10,
 ):
-    """Search knowledge entries for the specified database."""
+    """Search knowledge entries for the specified database.
+
+    Examples:
+        saber knowledge search "shipped revenue"
+        saber knowledge search "shipped revenue" --database analytics --limit 5
+    """
     database_name = _get_database_name(database)
     logger.info("knowledge.search.start", database=database_name, limit=limit)
 
@@ -252,7 +296,13 @@ def search(
     logger.info("knowledge.search.complete", database=database_name, count=len(entries))
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber knowledge remove ENTRY_ID\n\n"
+        "saber knowledge remove ENTRY_ID --database analytics --yes"
+    )
+)
 def remove(
     entry_id: Annotated[str, cyclopts.Parameter(help="Knowledge entry ID")],
     database: Annotated[
@@ -262,18 +312,41 @@ def remove(
             help="Database connection name (uses default if not specified)",
         ),
     ] = None,
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
 ):
-    """Remove a specific knowledge entry by ID."""
+    """Remove a specific knowledge entry by ID.
+
+    Examples:
+        saber knowledge remove ENTRY_ID
+        saber knowledge remove ENTRY_ID --database analytics --yes
+    """
     database_name = _get_database_name(database)
     logger.info("knowledge.remove.start", database=database_name, id=entry_id)
 
     entry = _run(_manager().get_knowledge(database_name, entry_id))
     if entry is None:
-        console.print(
-            f"[bold error]Error:[/bold error] Knowledge entry '{entry_id}' not found for database '{database_name}'"
+        error_console.print(
+            f"[error]Error: knowledge entry '{entry_id}' not found for database "
+            f"'{database_name}'.[/error]\n"
+            f"  List entries with: saber knowledge list --database {database_name}"
         )
         logger.error("knowledge.remove.not_found", database=database_name, id=entry_id)
         raise SystemExit(1)
+
+    if not confirm_action(
+        yes=yes,
+        prompt=f"Remove knowledge entry '{entry.name}'?",
+        non_interactive_command=(
+            f"saber knowledge remove {entry_id} --database {database_name} --yes"
+        ),
+        error_console=error_console,
+    ):
+        console.print("Operation cancelled")
+        logger.info("knowledge.remove.cancelled", database=database_name, id=entry_id)
+        return
 
     if _run(_manager().remove_knowledge(database_name, entry_id)):
         console.print(
@@ -282,14 +355,20 @@ def remove(
         logger.info("knowledge.remove.success", database=database_name, id=entry_id)
         return
 
-    console.print(
-        f"[bold error]Error:[/bold error] Failed to remove knowledge entry '{entry_id}'"
+    error_console.print(
+        f"[error]Error: failed to remove knowledge entry '{entry_id}'.[/error]"
     )
     logger.error("knowledge.remove.failed", database=database_name, id=entry_id)
     raise SystemExit(1)
 
 
-@knowledge_app.command
+@knowledge_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber knowledge clear --database analytics\n\n"
+        "saber knowledge clear --database analytics --yes"
+    )
+)
 def clear(
     database: Annotated[
         str | None,
@@ -298,17 +377,24 @@ def clear(
             help="Database connection name (uses default if not specified)",
         ),
     ] = None,
-    force: Annotated[
+    yes: Annotated[
         bool,
         cyclopts.Parameter(
-            ["--force", "-f"],
+            ["--yes"],
             help="Skip confirmation prompt",
         ),
     ] = False,
 ):
-    """Clear all knowledge entries for the specified database."""
+    """Clear all knowledge entries for the specified database.
+
+    Examples:
+        saber knowledge clear --database analytics
+        saber knowledge clear --database analytics --yes
+    """
     database_name = _get_database_name(database)
-    logger.info("knowledge.clear.start", database=database_name, force=bool(force))
+    logger.info(
+        "knowledge.clear.start", database=database_name, confirmation_skipped=bool(yes)
+    )
 
     entries = _run(_manager().list_knowledge(database_name))
     if not entries:
@@ -318,14 +404,21 @@ def clear(
         logger.info("knowledge.clear.nothing", database=database_name)
         return
 
-    if not force:
+    if not yes:
         console.print(
             f"[warning]About to clear {len(entries)} knowledge entries for database '{database_name}'[/warning]"
         )
-        if not questionary.confirm("Are you sure you want to proceed?").ask():
-            console.print("Operation cancelled")
-            logger.info("knowledge.clear.cancelled", database=database_name)
-            return
+    if not confirm_action(
+        yes=yes,
+        prompt="Clear all knowledge entries?",
+        non_interactive_command=(
+            f"saber knowledge clear --database {database_name} --yes"
+        ),
+        error_console=error_console,
+    ):
+        console.print("Operation cancelled")
+        logger.info("knowledge.clear.cancelled", database=database_name)
+        return
 
     cleared_count = _run(_manager().clear_knowledge(database_name))
     console.print(

--- a/src/sqlsaber/cli/models.py
+++ b/src/sqlsaber/cli/models.py
@@ -7,10 +7,10 @@ from typing import Annotated, Any, TypedDict
 
 import cyclopts
 import httpx
-import questionary
 from questionary import Choice
 from rich.table import Table
 
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config import providers
 from sqlsaber.config.logging import get_logger
 from sqlsaber.config.settings import SUBAGENT_KEYS, Config, ThinkingLevel
@@ -18,12 +18,18 @@ from sqlsaber.theme.manager import create_console
 
 # Global instances for CLI commands
 console = create_console()
+error_console = create_console(stderr=True)
 logger = get_logger(__name__)
 
 # Create the model management CLI app
 models_app = cyclopts.App(
     name="models",
     help="Select and manage models",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber models current\n\n"
+        "saber models set openai:gpt-5 --thinking-level medium"
+    ),
 )
 
 AGENT_CHOICES: tuple[str, ...] = ("main", *SUBAGENT_KEYS)
@@ -133,7 +139,7 @@ class ModelManager:
                 logger.info("models.fetch.success", count=len(results))
                 return results
         except Exception as e:
-            console.print(f"[error]Error fetching models: {e}[/error]")
+            error_console.print(f"[error]Error fetching models: {e}[/error]")
             logger.warning("models.fetch.error", error=str(e))
             return []
 
@@ -150,7 +156,7 @@ class ModelManager:
             logger.info("models.set.success", model=model_id)
             return True
         except Exception as e:
-            console.print(f"[error]Error setting model: {e}[/error]")
+            error_console.print(f"[error]Error setting model: {e}[/error]")
             logger.error("models.set.error", model=model_id, error=str(e))
             return False
 
@@ -170,9 +176,13 @@ def _normalize_agent(agent: str) -> str:
     return normalized
 
 
-@models_app.command(name="list")
+@models_app.command(name="list", help_epilogue="Example:\n\nsaber models list")
 def list_models() -> None:
-    """List available AI models."""
+    """List available AI models.
+
+    Example:
+        saber models list
+    """
     logger.info("models.list.start")
 
     async def fetch_and_display() -> None:
@@ -180,11 +190,12 @@ def list_models() -> None:
         models = await model_manager.fetch_available_models()
 
         if not models:
-            console.print(
-                "[warning]No models available or failed to fetch models[/warning]"
+            error_console.print(
+                "[error]Error: no models were returned.[/error]\n"
+                "  Check your network connection, then retry: saber models list"
             )
             logger.info("models.list.empty")
-            return
+            raise SystemExit(1)
 
         table = Table(title="Available Models")
         table.add_column("Provider", style="magenta")
@@ -238,6 +249,20 @@ def _get_thinking_level_choices() -> list[Choice]:
     ]
 
 
+def _resolve_thinking_level(value: str) -> tuple[bool, ThinkingLevel]:
+    """Resolve a CLI thinking value into enabled state and level."""
+    normalized = value.strip().lower()
+    if normalized == "off":
+        return False, Config().model.thinking_level
+    try:
+        return True, ThinkingLevel(normalized)
+    except ValueError:
+        choices = "off, " + ", ".join(level.value for level in ThinkingLevel)
+        raise ValueError(
+            f"Invalid thinking level '{value}'. Choose from: {choices}."
+        ) from None
+
+
 async def _prompt_thinking_level(prompter: Any) -> tuple[bool, ThinkingLevel]:
     """Prompt user to configure thinking level.
 
@@ -269,8 +294,22 @@ async def _prompt_thinking_level(prompter: Any) -> tuple[bool, ThinkingLevel]:
     return True, level
 
 
-@models_app.command(name="set")
+@models_app.command(
+    name="set",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber models set\n\n"
+        "saber models set openai:gpt-5 --thinking-level medium\n\n"
+        "saber models set openai:gpt-5 --agent handoff"
+    ),
+)
 def set_model_command(
+    model: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Provider-prefixed model ID (omit to select interactively)",
+        ),
+    ] = None,
     agent: Annotated[
         str,
         cyclopts.Parameter(
@@ -278,15 +317,81 @@ def set_model_command(
             help="Target agent (main, handoff, viz, notebook)",
         ),
     ] = "main",
+    thinking_level: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            ["--thinking-level"],
+            help="Thinking level for the main model (off, minimal, low, medium, high, maximum)",
+        ),
+    ] = None,
 ) -> None:
-    """Set the AI model to use."""
+    """Set the AI model to use.
+
+    Examples:
+        saber models set
+        saber models set anthropic:claude-sonnet-4-5-20250929 --thinking-level medium
+        saber models set openai:gpt-5 --agent handoff
+    """
     logger.info("models.set.start")
 
     try:
         target_agent = _normalize_agent(agent)
     except ValueError as exc:
-        console.print(f"[error]{exc}[/error]")
-        sys.exit(1)
+        error_console.print(
+            f"[error]Error: {exc}[/error]\n"
+            "  Example: saber models set openai:gpt-5 --agent handoff"
+        )
+        raise SystemExit(2)
+
+    if thinking_level is not None and target_agent != "main":
+        error_console.print(
+            "[error]Error: --thinking-level applies only to the main model.[/error]\n"
+            "  Example: saber models set openai:gpt-5 --agent handoff"
+        )
+        raise SystemExit(2)
+
+    resolved_thinking: tuple[bool, ThinkingLevel] | None = None
+    if thinking_level is not None:
+        try:
+            resolved_thinking = _resolve_thinking_level(thinking_level)
+        except ValueError as exc:
+            error_console.print(
+                f"[error]Error: {exc}[/error]\n"
+                "  Example: saber models set openai:gpt-5 --thinking-level medium"
+            )
+            raise SystemExit(2) from None
+
+    if model is not None:
+        model = model.strip()
+        provider_name, separator, model_name = model.partition(":")
+        if (
+            not separator
+            or not model_name
+            or providers.canonical(provider_name) is None
+        ):
+            provider_choices = ", ".join(providers.all_keys())
+            error_console.print(
+                "[error]Error: MODEL must use a supported PROVIDER:MODEL ID.[/error]\n"
+                f"  Providers: {provider_choices}\n"
+                "  Example: saber models set openai:gpt-5 --thinking-level medium"
+            )
+            raise SystemExit(2)
+        if target_agent == "main":
+            if not model_manager.set_model(model):
+                raise SystemExit(1)
+            console.print(f"[success]✓ Model set to: {model}[/success]")
+            if resolved_thinking is not None:
+                thinking_enabled, level = resolved_thinking
+                Config().model.set_thinking(thinking_enabled, level)
+                thinking_status = level.value if thinking_enabled else "disabled"
+                console.print(f"[success]✓ Thinking: {thinking_status}[/success]")
+        else:
+            Config().model.set_subagent_model(target_agent, model)
+            console.print(
+                f"[success]✓ {target_agent.title()} model set to: {model}[/success]"
+            )
+        logger.info("models.set.done", model=model, agent=target_agent)
+        return
 
     async def interactive_set() -> None:
         from sqlsaber.application.model_selection import choose_model, fetch_models
@@ -296,7 +401,10 @@ def set_model_command(
         models = await fetch_models(model_manager)
 
         if not models:
-            console.print("[error]Failed to fetch models. Cannot set model.[/error]")
+            error_console.print(
+                "[error]Error: failed to fetch models; cannot set a model.[/error]\n"
+                "  Set one directly with: saber models set PROVIDER:MODEL"
+            )
             logger.error("models.set.no_models")
             sys.exit(1)
 
@@ -316,26 +424,29 @@ def set_model_command(
                     )
 
                     # Prompt for thinking level configuration
-                    thinking_enabled, thinking_level = await _prompt_thinking_level(
-                        prompter
-                    )
+                    if resolved_thinking is None:
+                        thinking_enabled, selected_level = await _prompt_thinking_level(
+                            prompter
+                        )
+                    else:
+                        thinking_enabled, selected_level = resolved_thinking
                     config = Config()
-                    config.model.set_thinking(thinking_enabled, thinking_level)
+                    config.model.set_thinking(thinking_enabled, selected_level)
 
                     if thinking_enabled:
                         console.print(
-                            f"[success]✓ Thinking: {thinking_level.value}[/success]"
+                            f"[success]✓ Thinking: {selected_level.value}[/success]"
                         )
                     else:
                         console.print("[success]✓ Thinking: disabled[/success]")
                     logger.info(
                         "models.set.thinking",
                         enabled=thinking_enabled,
-                        level=thinking_level.value,
+                        level=selected_level.value,
                         agent=target_agent,
                     )
                 else:
-                    console.print("[error]✗ Failed to set model[/error]")
+                    error_console.print("[error]Error: failed to set model.[/error]")
                     logger.error(
                         "models.set.failed", model=selected_model, agent=target_agent
                     )
@@ -358,7 +469,12 @@ def set_model_command(
     asyncio.run(interactive_set())
 
 
-@models_app.command(name="current")
+@models_app.command(
+    name="current",
+    help_epilogue=(
+        "Examples:\n\nsaber models current\n\nsaber models current --agent handoff"
+    ),
+)
 def current_model(
     agent: Annotated[
         str | None,
@@ -368,7 +484,12 @@ def current_model(
         ),
     ] = None,
 ) -> None:
-    """Show the currently configured model and thinking settings."""
+    """Show the currently configured model and thinking settings.
+
+    Examples:
+        saber models current
+        saber models current --agent handoff
+    """
     current = model_manager.get_current_model()
     config = Config()
     thinking_enabled = config.model.thinking_enabled
@@ -378,8 +499,11 @@ def current_model(
         try:
             target_agent = _normalize_agent(agent)
         except ValueError as exc:
-            console.print(f"[error]{exc}[/error]")
-            sys.exit(1)
+            error_console.print(
+                f"[error]Error: {exc}[/error]\n"
+                "  Example: saber models current --agent handoff"
+            )
+            raise SystemExit(2)
 
         if target_agent == "main":
             console.print(f"Current model: [info]{current}[/info]")
@@ -437,7 +561,12 @@ def current_model(
     )
 
 
-@models_app.command(name="reset")
+@models_app.command(
+    name="reset",
+    help_epilogue=(
+        "Examples:\n\nsaber models reset\n\nsaber models reset --agent handoff --yes"
+    ),
+)
 def reset_model_command(
     agent: Annotated[
         str,
@@ -446,52 +575,62 @@ def reset_model_command(
             help="Reset model for agent (main, handoff, viz, notebook)",
         ),
     ] = "main",
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
 ) -> None:
-    """Reset to the default model."""
+    """Reset to the default model.
+
+    Examples:
+        saber models reset
+        saber models reset --agent handoff --yes
+    """
     logger.info("models.reset.start")
 
     try:
         target_agent = _normalize_agent(agent)
     except ValueError as exc:
-        console.print(f"[error]{exc}[/error]")
-        sys.exit(1)
+        error_console.print(
+            f"[error]Error: {exc}[/error]\n"
+            "  Example: saber models reset --agent handoff --yes"
+        )
+        raise SystemExit(2)
 
-    async def interactive_reset() -> None:
-        if target_agent == "main":
-            if await questionary.confirm(
-                f"Reset to default model ({ModelManager.DEFAULT_MODEL})?"
-            ).ask_async():
-                if model_manager.reset_model():
-                    console.print(
-                        f"[success]✓ Model reset to default: {ModelManager.DEFAULT_MODEL}[/success]"
-                    )
-                    logger.info(
-                        "models.reset.done",
-                        model=ModelManager.DEFAULT_MODEL,
-                        agent=target_agent,
-                    )
-                else:
-                    console.print("[error]✗ Failed to reset model[/error]")
-                    logger.error("models.reset.failed", agent=target_agent)
-                    sys.exit(1)
-            else:
-                console.print("[warning]Operation cancelled[/warning]")
-                logger.info("models.reset.cancelled", agent=target_agent)
-        else:
-            if await questionary.confirm(
-                f"Clear {target_agent} model override (use main model)?"
-            ).ask_async():
-                config = Config()
-                config.model.set_subagent_model(target_agent, None)
-                console.print(
-                    f"[success]✓ {target_agent.title()} model override cleared[/success]"
-                )
-                logger.info("models.reset.subagent", agent=target_agent)
-            else:
-                console.print("[warning]Operation cancelled[/warning]")
-                logger.info("models.reset.cancelled", agent=target_agent)
+    prompt = (
+        f"Reset to default model ({ModelManager.DEFAULT_MODEL})?"
+        if target_agent == "main"
+        else f"Clear {target_agent} model override (use main model)?"
+    )
+    command = f"saber models reset --agent {target_agent} --yes"
+    if not confirm_action(
+        yes=yes,
+        prompt=prompt,
+        non_interactive_command=command,
+        error_console=error_console,
+    ):
+        console.print("[warning]Operation cancelled[/warning]")
+        logger.info("models.reset.cancelled", agent=target_agent)
+        return
 
-    asyncio.run(interactive_reset())
+    if target_agent == "main":
+        if not model_manager.reset_model():
+            error_console.print("[error]Error: failed to reset model.[/error]")
+            logger.error("models.reset.failed", agent=target_agent)
+            raise SystemExit(1)
+        console.print(
+            f"[success]✓ Model reset to default: {ModelManager.DEFAULT_MODEL}[/success]"
+        )
+        logger.info(
+            "models.reset.done",
+            model=ModelManager.DEFAULT_MODEL,
+            agent=target_agent,
+        )
+        return
+
+    Config().model.set_subagent_model(target_agent, None)
+    console.print(f"[success]✓ {target_agent.title()} model override cleared[/success]")
+    logger.info("models.reset.subagent", agent=target_agent)
 
 
 def create_models_app() -> cyclopts.App:

--- a/src/sqlsaber/cli/safety.py
+++ b/src/sqlsaber/cli/safety.py
@@ -1,0 +1,25 @@
+"""Shared safety checks for destructive CLI commands."""
+
+import sys
+
+import questionary
+from rich.console import Console
+
+
+def confirm_action(
+    *,
+    yes: bool,
+    prompt: str,
+    non_interactive_command: str,
+    error_console: Console,
+) -> bool:
+    """Confirm an action or require an explicit flag when stdin is not a TTY."""
+    if yes:
+        return True
+    if not sys.stdin.isatty():
+        error_console.print(
+            "[error]Error: confirmation requires an interactive terminal.[/error]\n"
+            f"  Re-run with: {non_interactive_command}"
+        )
+        raise SystemExit(2)
+    return bool(questionary.confirm(prompt, default=False).ask())

--- a/src/sqlsaber/cli/theme.py
+++ b/src/sqlsaber/cli/theme.py
@@ -5,22 +5,26 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Annotated
 
 import cyclopts
 import questionary
 from platformdirs import user_config_dir
 from pygments.styles import get_all_styles
 
-from sqlsaber.theme.manager import DEFAULT_THEME_NAME, create_console
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config.logging import get_logger
+from sqlsaber.theme.manager import DEFAULT_THEME_NAME, create_console
 
 console = create_console()
+error_console = create_console(stderr=True)
 logger = get_logger(__name__)
 
 # Create the theme management CLI app
 theme_app = cyclopts.App(
     name="theme",
     help="Manage theme settings",
+    help_epilogue=("Examples:\n\nsaber theme set dracula\n\nsaber theme reset --yes"),
 )
 
 
@@ -72,7 +76,7 @@ class ThemeManager:
             self._save_config(config)
             return True
         except Exception as e:
-            console.print(f"[error]Error setting theme: {e}[/error]")
+            error_console.print(f"[error]Error setting theme: {e}[/error]")
             logger.error("theme.set.error", theme=theme_name, error=str(e))
             return False
 
@@ -83,7 +87,7 @@ class ThemeManager:
                 self.config_file.unlink()
             return True
         except Exception as e:
-            console.print(f"[error]Error resetting theme: {e}[/error]")
+            error_console.print(f"[error]Error resetting theme: {e}[/error]")
             logger.error("theme.reset.error", error=str(e))
             return False
 
@@ -95,13 +99,47 @@ class ThemeManager:
 theme_manager = ThemeManager()
 
 
-@theme_app.command
-def set():
-    """Set the theme to use for syntax highlighting."""
+@theme_app.command(
+    help_epilogue=("Examples:\n\nsaber theme set\n\nsaber theme set dracula")
+)
+def set(
+    theme_name: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Pygments theme name (omit to select interactively)"),
+    ] = None,
+):
+    """Set the theme to use for syntax highlighting.
+
+    Examples:
+        saber theme set
+        saber theme set dracula
+    """
     logger.info("theme.set.start")
 
+    themes = theme_manager.get_available_themes()
+    if theme_name is not None:
+        theme_name = theme_name.strip().lower()
+        if theme_name not in themes:
+            error_console.print(
+                f"[error]Error: unknown theme '{theme_name}'.[/error]\n"
+                "  Run 'saber theme set' in a terminal to browse available themes.\n"
+                "  Example: saber theme set dracula"
+            )
+            raise SystemExit(2)
+        if not theme_manager.set_theme(theme_name):
+            raise SystemExit(1)
+        console.print(f"[success]✓ Theme set to: {theme_name}[/success]")
+        logger.info("theme.set.done", theme=theme_name)
+        return
+
+    if not sys.stdin.isatty():
+        error_console.print(
+            "[error]Error: THEME is required when stdin is not a terminal.[/error]\n"
+            "  Example: saber theme set dracula"
+        )
+        raise SystemExit(2)
+
     async def interactive_set():
-        themes = theme_manager.get_available_themes()
         current_theme = theme_manager.get_current_theme()
 
         # Create choices with current theme highlighted
@@ -126,7 +164,7 @@ def set():
                 console.print(f"[success]✓ Theme set to: {selected_theme}[/success]")
                 logger.info("theme.set.done", theme=selected_theme)
             else:
-                console.print("[error]✗ Failed to set theme[/error]")
+                error_console.print("[error]Error: failed to set theme.[/error]")
                 sys.exit(1)
         else:
             console.print("[warning]Operation cancelled[/warning]")
@@ -135,9 +173,31 @@ def set():
     asyncio.run(interactive_set())
 
 
-@theme_app.command
-def reset():
-    """Reset to the default theme."""
+@theme_app.command(
+    help_epilogue=("Examples:\n\nsaber theme reset\n\nsaber theme reset --yes")
+)
+def reset(
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
+):
+    """Reset to the default theme.
+
+    Examples:
+        saber theme reset
+        saber theme reset --yes
+    """
+
+    if not confirm_action(
+        yes=yes,
+        prompt=f"Reset theme to {DEFAULT_THEME_NAME}?",
+        non_interactive_command="saber theme reset --yes",
+        error_console=error_console,
+    ):
+        console.print("[warning]Operation cancelled[/warning]")
+        logger.info("theme.reset.cancelled")
+        return
 
     if theme_manager.reset_theme():
         console.print(
@@ -145,7 +205,7 @@ def reset():
         )
         logger.info("theme.reset.done", theme=DEFAULT_THEME_NAME)
     else:
-        console.print("[error]✗ Failed to reset theme[/error]")
+        error_console.print("[error]Error: failed to reset theme.[/error]")
         sys.exit(1)
 
 

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -15,6 +15,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
+from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config.logging import get_logger
 from sqlsaber.theme.manager import create_console, get_theme_manager
 
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
 
 # Globals consistent with other CLI modules
 console = create_console()
+error_console = create_console(stderr=True)
 tm = get_theme_manager()
 logger = get_logger(__name__)
 
@@ -33,6 +35,12 @@ logger = get_logger(__name__)
 threads_app = cyclopts.App(
     name="threads",
     help="Manage SQLsaber threads",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber threads list\n\n"
+        "saber threads show THREAD_ID\n\n"
+        "saber threads prune --days 30 --dry-run"
+    ),
 )
 
 
@@ -182,7 +190,14 @@ def _render_transcript(
         console.print("")
 
 
-@threads_app.command(name="list")
+@threads_app.command(
+    name="list",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber threads list\n\n"
+        "saber threads list --database analytics --limit 10"
+    ),
+)
 def list_threads(
     database: Annotated[
         str | None,
@@ -193,7 +208,12 @@ def list_threads(
         cyclopts.Parameter(["--limit", "-n"], help="Max threads to return"),
     ] = 50,
 ):
-    """List threads (optionally filtered by database)."""
+    """List threads (optionally filtered by database).
+
+    Examples:
+        saber threads list
+        saber threads list --database analytics --limit 10
+    """
     from sqlsaber.threads import ThreadStorage
 
     logger.info("threads.cli.list.start", database=database, limit=limit)
@@ -221,20 +241,27 @@ def list_threads(
     logger.info("threads.cli.list.complete", count=len(threads))
 
 
-@threads_app.command
+@threads_app.command(help_epilogue="Example:\n\nsaber threads show THREAD_ID")
 def show(
     thread_id: Annotated[str, cyclopts.Parameter(help="Thread ID")],
 ):
-    """Show thread metadata and render the full transcript."""
+    """Show thread metadata and render the full transcript.
+
+    Example:
+        saber threads show THREAD_ID
+    """
     from sqlsaber.threads import ThreadStorage
 
     logger.info("threads.cli.show.start", thread_id=thread_id)
     store = ThreadStorage()
     thread = asyncio.run(store.get_thread(thread_id))
     if not thread:
-        console.print(f"[error]Thread not found:[/error] {thread_id}")
+        error_console.print(
+            f"[error]Error: thread not found: {thread_id}[/error]\n"
+            "  List threads with: saber threads list"
+        )
         logger.error("threads.cli.show.not_found", thread_id=thread_id)
-        return
+        raise SystemExit(1)
     msgs = asyncio.run(store.get_thread_messages(thread_id))
     from sqlsaber.cli.query_results import (
         cli_query_result_store,
@@ -297,11 +324,18 @@ def show(
     logger.info("threads.cli.show.complete", thread_id=thread_id)
 
 
-@threads_app.command(name="artifacts")
+@threads_app.command(
+    name="artifacts",
+    help_epilogue="Example:\n\nsaber threads artifacts THREAD_ID",
+)
 def list_artifacts(
     thread_id: Annotated[str, cyclopts.Parameter(help="Thread ID")],
 ):
-    """List durable artifacts referenced by a retained thread."""
+    """List durable artifacts referenced by a retained thread.
+
+    Example:
+        saber threads artifacts THREAD_ID
+    """
 
     from sqlsaber.threads import ThreadStorage
 
@@ -317,8 +351,11 @@ def list_artifacts(
 
         thread = await store.get_thread(thread_id)
         if thread is None:
-            console.print(f"[error]Thread not found:[/error] {thread_id}")
-            return
+            error_console.print(
+                f"[error]Error: thread not found: {thread_id}[/error]\n"
+                "  List threads with: saber threads list"
+            )
+            raise SystemExit(1)
         messages = await store.get_thread_messages(thread_id)
         references = artifact_references_from_messages(messages)
         if not references:
@@ -369,7 +406,13 @@ def list_artifacts(
     asyncio.run(_run())
 
 
-@threads_app.command
+@threads_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber threads resume THREAD_ID\n\n"
+        "saber threads resume THREAD_ID --database analytics"
+    )
+)
 def resume(
     thread_id: Annotated[str, cyclopts.Parameter(help="Thread ID to resume")],
     database: Annotated[
@@ -380,7 +423,12 @@ def resume(
         ),
     ] = None,
 ):
-    """Render transcript, then resume thread in interactive mode."""
+    """Render transcript, then resume thread in interactive mode.
+
+    Examples:
+        saber threads resume THREAD_ID
+        saber threads resume THREAD_ID --database analytics
+    """
     from sqlsaber.threads import ThreadStorage
 
     logger.info("threads.cli.resume.start", thread_id=thread_id, database=database)
@@ -400,9 +448,12 @@ def resume(
 
         thread = await store.get_thread(thread_id)
         if not thread:
-            console.print(f"[error]Thread not found:[/error] {thread_id}")
+            error_console.print(
+                f"[error]Error: thread not found: {thread_id}[/error]\n"
+                "  List threads with: saber threads list"
+            )
             logger.error("threads.cli.resume.not_found", thread_id=thread_id)
-            return
+            raise SystemExit(1)
         if database is not None:
             db_selector = database
         else:
@@ -412,19 +463,23 @@ def resume(
                     extra_metadata=thread.extra_metadata,
                 )
             except ValueError as e:
-                console.print(f"[error]Thread metadata error:[/error] {e}")
+                error_console.print(
+                    f"[error]Error: invalid thread metadata: {e}[/error]\n"
+                    f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+                )
                 logger.error(
                     "threads.cli.resume.metadata_invalid",
                     thread_id=thread_id,
                     error=str(e),
                 )
-                return
+                raise SystemExit(1) from None
         if not db_selector:
-            console.print(
-                "[error]No database specified or stored with this thread.[/error]"
+            error_console.print(
+                "[error]Error: no database is specified or stored with this thread.[/error]\n"
+                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
             )
             logger.error("threads.cli.resume.no_database", thread_id=thread_id)
-            return
+            raise SystemExit(1)
         if database is None:
             config_mgr = DatabaseConfigManager()
             selectors = [db_selector] if isinstance(db_selector, str) else db_selector
@@ -434,16 +489,17 @@ def resume(
                 if config_mgr.get_database(selector) is None
             ]
             if missing:
-                console.print(
-                    "[error]Thread database is not configured for automatic "
-                    "resume.[/error] Resume it with explicit --database/-d options."
+                error_console.print(
+                    "[error]Error: the thread database is not configured for automatic "
+                    "resume.[/error]\n"
+                    f"  Retry with: saber threads resume {thread_id} --database DATABASE"
                 )
                 logger.error(
                     "threads.cli.resume.database_not_configured",
                     thread_id=thread_id,
                     missing=missing,
                 )
-                return
+                raise SystemExit(1)
         history = await store.get_thread_messages(thread_id)
         session_thread_manager = ThreadManager(
             initial_thread_id=thread_id, storage=store
@@ -460,11 +516,14 @@ def resume(
                 )
             )
         except DatabaseResolutionError as e:
-            console.print(f"[error]Database resolution error:[/error] {e}")
+            error_console.print(
+                f"[error]Error resolving database: {e}[/error]\n"
+                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+            )
             logger.error(
                 "threads.cli.resume.resolve_failed", thread_id=thread_id, error=str(e)
             )
-            return
+            raise SystemExit(1) from None
 
         try:
             if console.is_terminal:
@@ -535,7 +594,13 @@ def resume(
     asyncio.run(_run())
 
 
-@threads_app.command
+@threads_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber threads prune --days 30 --dry-run\n\n"
+        "saber threads prune --days 30 --yes"
+    )
+)
 def prune(
     days: Annotated[
         int,
@@ -543,12 +608,54 @@ def prune(
             ["--days", "-n"], help="Delete threads older than this many days"
         ),
     ] = 30,
+    dry_run: Annotated[
+        bool,
+        cyclopts.Parameter(["--dry-run"], help="Show how many threads would be pruned"),
+    ] = False,
+    yes: Annotated[
+        bool,
+        cyclopts.Parameter(["--yes"], help="Skip confirmation prompt"),
+    ] = False,
 ):
-    """Prune old threads by last activity timestamp."""
+    """Prune old threads by last activity timestamp.
+
+    Examples:
+        saber threads prune --days 30 --dry-run
+        saber threads prune --days 30 --yes
+    """
     from sqlsaber.threads import ThreadStorage
 
     logger.info("threads.cli.prune.start", days=days)
     store = ThreadStorage()
+
+    if days < 1:
+        error_console.print(
+            "[error]Error: --days must be at least 1.[/error]\n"
+            "  Example: saber threads prune --days 30 --dry-run"
+        )
+        raise SystemExit(2)
+
+    prunable = asyncio.run(store.count_prunable_threads(older_than_days=days))
+    if dry_run:
+        console.print(
+            f"[info]Dry run: {prunable} thread(s) older than {days} day(s) would be pruned.[/info]"
+        )
+        logger.info("threads.cli.prune.dry_run", days=days, count=prunable)
+        return
+    if prunable == 0:
+        console.print(
+            f"[success]No threads older than {days} day(s) to prune.[/success]"
+        )
+        return
+    if not confirm_action(
+        yes=yes,
+        prompt=f"Prune {prunable} thread(s) older than {days} day(s)?",
+        non_interactive_command=f"saber threads prune --days {days} --yes",
+        error_console=error_console,
+    ):
+        console.print("[warning]Operation cancelled[/warning]")
+        logger.info("threads.cli.prune.cancelled", days=days)
+        return
 
     async def _run() -> None:
         deleted = await store.prune_threads(older_than_days=days)
@@ -579,7 +686,13 @@ def prune(
     asyncio.run(_run())
 
 
-@threads_app.command
+@threads_app.command(
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber threads export THREAD_ID\n\n"
+        "saber threads export THREAD_ID --output analysis.html"
+    )
+)
 def export(
     thread_id: Annotated[str, cyclopts.Parameter(help="Thread ID")],
     output: Annotated[
@@ -590,7 +703,12 @@ def export(
         ),
     ] = None,
 ):
-    """Export a thread transcript as a standalone HTML file."""
+    """Export a thread transcript as a standalone HTML file.
+
+    Examples:
+        saber threads export THREAD_ID
+        saber threads export THREAD_ID --output analysis.html
+    """
     from sqlsaber.cli.html_export import render_thread_html
     from sqlsaber.threads import ThreadStorage
 
@@ -604,9 +722,12 @@ def export(
     async def _run() -> None:
         thread = await store.get_thread(thread_id)
         if not thread:
-            console.print(f"[error]Thread not found:[/error] {thread_id}")
+            error_console.print(
+                f"[error]Error: thread not found: {thread_id}[/error]\n"
+                "  List threads with: saber threads list"
+            )
             logger.error("threads.cli.share.not_found", thread_id=thread_id)
-            return
+            raise SystemExit(1)
 
         messages = await store.get_thread_messages(thread_id)
         from sqlsaber.cli.query_results import (

--- a/src/sqlsaber/threads/storage.py
+++ b/src/sqlsaber/threads/storage.py
@@ -319,6 +319,22 @@ class ThreadStorage:
             logger.warning("threads.delete_failed", thread_id=thread_id, error=str(e))
             return False
 
+    async def count_prunable_threads(self, older_than_days: int = 30) -> int:
+        """Count threads whose last activity is older than the cutoff."""
+        await self._init_db()
+        cutoff = time.time() - older_than_days * 24 * 3600
+        try:
+            async with aiosqlite.connect(self.db_path) as db:
+                async with db.execute(
+                    "SELECT COUNT(*) FROM threads WHERE last_activity_at < ?",
+                    (cutoff,),
+                ) as cur:
+                    row = await cur.fetchone()
+                    return int(row[0]) if row else 0
+        except Exception as e:  # pragma: no cover
+            logger.warning("threads.prune_count_failed", error=str(e))
+            return 0
+
     async def prune_threads(self, older_than_days: int = 30) -> int:
         """Delete threads whose last_activity_at is older than the cutoff.
 

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -1,0 +1,282 @@
+"""Coverage for non-interactive, agent-friendly CLI behavior."""
+
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sqlsaber.cli import database as database_cli
+from sqlsaber.cli import models as models_cli
+from sqlsaber.cli import theme as theme_cli
+from sqlsaber.cli import threads as threads_cli
+from sqlsaber.cli.commands import app, query
+from sqlsaber.config.settings import ThinkingLevel
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        [],
+        ["auth", "reset"],
+        ["db", "add"],
+        ["db", "remove"],
+        ["knowledge", "remove"],
+        ["knowledge", "clear"],
+        ["models", "set"],
+        ["models", "reset"],
+        ["theme", "set"],
+        ["theme", "reset"],
+        ["threads", "prune"],
+    ],
+)
+def test_affected_help_includes_examples(command, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        app([*command, "--help"])
+
+    assert exc_info.value.code == 0
+    assert "Example" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["auth", "reset"],
+        ["db", "remove"],
+        ["knowledge", "remove"],
+        ["knowledge", "clear"],
+        ["models", "reset"],
+        ["theme", "reset"],
+        ["threads", "prune"],
+    ],
+)
+def test_destructive_help_has_only_the_yes_confirmation_option(command, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        app([*command, "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--yes" in output
+    assert "--force" not in output
+    assert " -y" not in output
+
+
+def test_models_set_directly_without_fetching_or_prompting():
+    config = MagicMock()
+    with (
+        patch.object(
+            models_cli.model_manager, "set_model", return_value=True
+        ) as set_model,
+        patch.object(
+            models_cli.model_manager,
+            "fetch_available_models",
+            side_effect=AssertionError("direct model selection must not fetch"),
+        ),
+        patch.object(models_cli, "Config", return_value=config),
+    ):
+        models_cli.set_model_command(
+            "openai:gpt-5", thinking_level=ThinkingLevel.HIGH.value
+        )
+
+    set_model.assert_called_once_with("openai:gpt-5")
+    config.model.set_thinking.assert_called_once_with(True, ThinkingLevel.HIGH)
+
+
+def test_models_set_rejects_unsupported_provider(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        models_cli.set_model_command("unknown:model")
+
+    assert exc_info.value.code == 2
+    assert "supported PROVIDER:MODEL" in capsys.readouterr().err
+
+
+def test_theme_set_directly_without_prompting():
+    with (
+        patch.object(
+            theme_cli.theme_manager,
+            "get_available_themes",
+            return_value=["dracula", "nord"],
+        ),
+        patch.object(
+            theme_cli.theme_manager, "set_theme", return_value=True
+        ) as set_theme,
+        patch.object(
+            theme_cli.questionary,
+            "select",
+            side_effect=AssertionError("direct theme selection must not prompt"),
+        ),
+    ):
+        theme_cli.set("dracula")
+
+    set_theme.assert_called_once_with("dracula")
+
+
+def test_db_add_reads_password_from_stdin_without_prompting():
+    manager = MagicMock()
+    manager.list_databases.return_value = [object()]
+    stdin = StringIO("not-a-real-secret\n")
+
+    with (
+        patch.object(database_cli, "config_manager", manager),
+        patch.object(database_cli.sys, "stdin", stdin),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        database_cli.db_app(
+            [
+                "add",
+                "analytics",
+                "--host",
+                "db.example.com",
+                "--database",
+                "analytics",
+                "--username",
+                "agent",
+                "--no-interactive",
+                "--password-stdin",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    saved_config, saved_password = manager.add_database.call_args.args
+    assert saved_config.name == "analytics"
+    assert saved_password == "not-a-real-secret"
+
+
+def test_destructive_command_requires_yes_without_a_terminal(capsys):
+    manager = MagicMock()
+    manager.get_database.return_value = object()
+
+    with (
+        patch.object(database_cli, "config_manager", manager),
+        patch.object(database_cli.sys, "stdin", StringIO()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        database_cli.remove("analytics")
+
+    assert exc_info.value.code == 2
+    assert "saber db remove analytics --yes" in capsys.readouterr().err
+    manager.remove_database.assert_not_called()
+
+
+def test_destructive_command_accepts_yes_without_a_terminal():
+    manager = MagicMock()
+    manager.get_database.return_value = object()
+    manager.remove_database.return_value = True
+
+    with (
+        patch.object(database_cli, "config_manager", manager),
+        patch.object(database_cli.sys, "stdin", StringIO()),
+    ):
+        database_cli.remove("analytics", yes=True)
+
+    manager.remove_database.assert_called_once_with("analytics")
+
+
+def test_invalid_input_uses_stderr_and_usage_exit_code(capsys):
+    with (
+        patch.object(
+            theme_cli.theme_manager,
+            "get_available_themes",
+            return_value=["dracula", "nord"],
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        theme_cli.set("not-a-theme")
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "unknown theme 'not-a-theme'" in captured.err
+    assert "unknown theme" not in captured.out
+
+
+def test_threads_prune_dry_run_does_not_delete(capsys):
+    store = MagicMock()
+    store.count_prunable_threads = AsyncMock(return_value=3)
+    store.prune_threads = AsyncMock()
+
+    with patch("sqlsaber.threads.ThreadStorage", return_value=store):
+        threads_cli.prune(days=30, dry_run=True)
+
+    assert "3 thread(s)" in capsys.readouterr().out
+    store.prune_threads.assert_not_awaited()
+
+
+def test_root_thread_option_continues_with_saved_history():
+    history = [object(), object()]
+    stored_thread = SimpleNamespace(
+        id="thread-1",
+        database_name="analytics",
+        extra_metadata=None,
+    )
+    store = MagicMock()
+    store.get_thread = AsyncMock(return_value=stored_thread)
+    store.get_thread_messages = AsyncMock(return_value=history)
+    captured: dict[str, object] = {}
+
+    class FakeThreadManager:
+        def __init__(self, initial_thread_id=None, storage=None):
+            captured["initial_thread_id"] = initial_thread_id
+            captured["storage"] = storage
+            self.current_thread_id = initial_thread_id
+
+    class FakeDatabaseConfigManager:
+        def get_database(self, name):
+            return object() if name == "analytics" else None
+
+    class FakeSession:
+        def __init__(self, options):
+            captured["options"] = options
+            self.db_name = "analytics"
+            self.connection = object()
+            self.query_result_store = object()
+            self.query = AsyncMock()
+            self.agent = SimpleNamespace(
+                display_registry={},
+                db_type="sqlite",
+                config=SimpleNamespace(model=SimpleNamespace(name="openai:gpt-5")),
+            )
+
+        async def close(self):
+            captured["closed"] = True
+
+    class FakeStreamingQueryHandler:
+        def __init__(self, *args):
+            pass
+
+        async def execute_streaming_query(
+            self, user_query, *, run_query, message_history
+        ):
+            captured["query"] = user_query
+            captured["run_query"] = run_query
+            captured["history"] = message_history
+            return None
+
+    with (
+        patch("sqlsaber.threads.ThreadStorage", return_value=store),
+        patch("sqlsaber.threads.manager.ThreadManager", FakeThreadManager),
+        patch(
+            "sqlsaber.config.database.DatabaseConfigManager",
+            FakeDatabaseConfigManager,
+        ),
+        patch("sqlsaber.session.SQLSaberSession", FakeSession),
+        patch(
+            "sqlsaber.cli.streaming.StreamingQueryHandler",
+            FakeStreamingQueryHandler,
+        ),
+        patch("sqlsaber.cli.artifacts.cli_artifact_store", return_value=object()),
+        patch(
+            "sqlsaber.cli.query_results.cli_query_result_store", return_value=object()
+        ),
+        patch("sqlsaber.cli.commands.needs_onboarding", return_value=False),
+        patch("sqlsaber.cli.commands.schedule_update_check"),
+    ):
+        query("Compare this year", thread="thread-1")
+
+    options = captured["options"]
+    assert options.database == "analytics"
+    assert options.thread_manager.current_thread_id == "thread-1"
+    assert captured["initial_thread_id"] == "thread-1"
+    assert captured["storage"] is store
+    assert captured["history"] is history
+    assert captured["query"] == "Compare this year"
+    assert captured["closed"] is True

--- a/tests/test_cli/test_auth_reset.py
+++ b/tests/test_cli/test_auth_reset.py
@@ -2,19 +2,15 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from sqlsaber.cli.auth import reset as auth_reset
 
 
 @patch("sqlsaber.cli.auth.keyring.delete_password")
 @patch("sqlsaber.cli.auth.keyring.get_password")
-@patch("sqlsaber.cli.auth.questionary.confirm")
-@patch("sqlsaber.cli.auth.questionary.select")
-def test_reset_openai_api_key(
-    mock_select, mock_confirm, mock_get_password, mock_delete
-):
+def test_reset_openai_api_key(mock_get_password, mock_delete):
     """Removes OpenAI API key when present in keyring."""
-    mock_select.return_value.ask.return_value = "openai"
-    mock_confirm.return_value.ask.return_value = True
 
     def fake_get_password(service: str, provider: str):
         if service == "sqlsaber-openai-api-key" and provider == "openai":
@@ -23,21 +19,15 @@ def test_reset_openai_api_key(
 
     mock_get_password.side_effect = fake_get_password
 
-    auth_reset()
+    auth_reset("openai", yes=True)
 
     mock_delete.assert_called_once_with("sqlsaber-openai-api-key", "openai")
 
 
 @patch("sqlsaber.cli.auth.keyring.delete_password")
 @patch("sqlsaber.cli.auth.keyring.get_password")
-@patch("sqlsaber.cli.auth.questionary.confirm")
-@patch("sqlsaber.cli.auth.questionary.select")
-def test_reset_anthropic_api_key_only(
-    mock_select, mock_confirm, mock_get_password, mock_delete
-):
+def test_reset_anthropic_api_key_only(mock_get_password, mock_delete):
     """Removes Anthropic API key when present in keyring."""
-    mock_select.return_value.ask.return_value = "anthropic"
-    mock_confirm.return_value.ask.return_value = True
 
     def fake_get_password(service: str, provider: str):
         if service == "sqlsaber-anthropic-api-key" and provider == "anthropic":
@@ -46,19 +36,30 @@ def test_reset_anthropic_api_key_only(
 
     mock_get_password.side_effect = fake_get_password
 
-    auth_reset()
+    auth_reset("anthropic", yes=True)
 
     mock_delete.assert_called_once_with("sqlsaber-anthropic-api-key", "anthropic")
 
 
 @patch("sqlsaber.cli.auth.keyring.delete_password")
 @patch("sqlsaber.cli.auth.keyring.get_password")
-@patch("sqlsaber.cli.auth.questionary.select")
-def test_reset_no_credentials_noop(mock_select, mock_get_password, mock_delete):
+def test_reset_no_credentials_noop(mock_get_password, mock_delete):
     """If no credentials are stored, reset is a no-op for that provider."""
-    mock_select.return_value.ask.return_value = "groq"
     mock_get_password.return_value = None
 
-    auth_reset()
+    auth_reset("groq", yes=True)
 
     mock_delete.assert_not_called()
+
+
+@patch("sqlsaber.cli.auth.keyring.delete_password", side_effect=RuntimeError("locked"))
+@patch("sqlsaber.cli.auth.keyring.get_password", return_value="stored-key")
+def test_reset_delete_failure_exits_nonzero(mock_get_password, mock_delete, capsys):
+    """Credential deletion failures are reported on stderr and fail the command."""
+    with pytest.raises(SystemExit) as exc_info:
+        auth_reset("openai", yes=True)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "could not remove API key" in captured.err
+    assert "Reset complete" not in captured.out

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -31,8 +31,9 @@ class TestCLICommands:
 
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
-        assert "Database connection 'nonexistent' not found" in captured.out
-        assert "sqlsaber db list" in captured.out
+        assert captured.out == ""
+        assert "Database connection 'nonexistent' not found" in captured.err
+        assert "sqlsaber db list" in captured.err
 
     def test_subcommands_registered(self, capsys):
         """Test that all subcommands are properly registered."""

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -151,15 +151,18 @@ class TestThreadsCLI:
             mock_storage = MagicMock()
             mock_storage_class.return_value = mock_storage
 
-            with patch("sqlsaber.cli.threads.console") as mock_console:
+            with patch("sqlsaber.cli.threads.error_console") as mock_error_console:
                 from sqlsaber.cli.threads import show
 
                 with patch("asyncio.run") as mock_run:
                     mock_run.return_value = None
-                    show("nonexistent-thread")
+                    with pytest.raises(SystemExit) as exc_info:
+                        show("nonexistent-thread")
 
-                mock_console.print.assert_called_with(
-                    "[error]Thread not found:[/error] nonexistent-thread"
+                assert exc_info.value.code == 1
+                mock_error_console.print.assert_called_with(
+                    "[error]Error: thread not found: nonexistent-thread[/error]\n"
+                    "  List threads with: saber threads list"
                 )
 
     def test_show_thread_found(self, sample_threads, sample_messages):
@@ -445,15 +448,18 @@ class TestThreadsCLI:
                 FakeDatabaseConfigManager,
             ),
             patch("sqlsaber.session.SQLSaberSession") as mock_session,
-            patch("sqlsaber.cli.threads.console") as mock_console,
+            patch("sqlsaber.cli.threads.error_console") as mock_error_console,
         ):
-            resume("thread-missing-db")
+            with pytest.raises(SystemExit) as exc_info:
+                resume("thread-missing-db")
 
+        assert exc_info.value.code == 1
         mock_session.assert_not_called()
         store.get_thread_messages.assert_not_awaited()
-        mock_console.print.assert_called_with(
-            "[error]Thread database is not configured for automatic "
-            "resume.[/error] Resume it with explicit --database/-d options."
+        mock_error_console.print.assert_called_with(
+            "[error]Error: the thread database is not configured for automatic "
+            "resume.[/error]\n"
+            "  Retry with: saber threads resume thread-missing-db --database DATABASE"
         )
 
     def test_build_turn_slices_basic(self, sample_messages):
@@ -526,13 +532,16 @@ class TestThreadsCLI:
             mock_storage.get_thread = AsyncMock(return_value=None)
             mock_storage_class.return_value = mock_storage
 
-            with patch("sqlsaber.cli.threads.console") as mock_console:
+            with patch("sqlsaber.cli.threads.error_console") as mock_error_console:
                 from sqlsaber.cli.threads import export
 
-                export("nonexistent-thread")
+                with pytest.raises(SystemExit) as exc_info:
+                    export("nonexistent-thread")
 
-                mock_console.print.assert_called_with(
-                    "[error]Thread not found:[/error] nonexistent-thread"
+                assert exc_info.value.code == 1
+                mock_error_console.print.assert_called_with(
+                    "[error]Error: thread not found: nonexistent-thread[/error]\n"
+                    "  List threads with: saber threads list"
                 )
 
     @pytest.mark.asyncio

--- a/tests/test_knowledge/test_cli.py
+++ b/tests/test_knowledge/test_cli.py
@@ -48,7 +48,7 @@ def test_cli_add_show_search_remove_and_list(knowledge_app, capsys):
     search_output = capsys.readouterr().out
     assert "Revenue KPI" in search_output
 
-    _run_cli(knowledge_app, ["remove", entry_id])
+    _run_cli(knowledge_app, ["remove", entry_id, "--yes"])
     remove_output = capsys.readouterr().out
     assert "removed" in remove_output.lower()
 
@@ -57,12 +57,23 @@ def test_cli_add_show_search_remove_and_list(knowledge_app, capsys):
     assert "No knowledge entries found" in list_output
 
 
-def test_cli_clear_force(knowledge_app, capsys):
+def test_cli_clear_yes(knowledge_app, capsys):
     _run_cli(knowledge_app, ["add", "One", "Description one"])
     _ = capsys.readouterr()
     _run_cli(knowledge_app, ["add", "Two", "Description two"])
     _ = capsys.readouterr()
 
-    _run_cli(knowledge_app, ["clear", "--force"])
+    _run_cli(knowledge_app, ["clear", "--yes"])
     clear_output = capsys.readouterr().out
     assert "Cleared 2 knowledge entries" in clear_output
+
+
+@pytest.mark.parametrize("removed_option", ["--force", "-f", "-y"])
+def test_cli_clear_rejects_alternate_confirmation_options(
+    knowledge_app, capsys, removed_option
+):
+    with pytest.raises(SystemExit) as exc_info:
+        knowledge_app(["clear", removed_option])
+
+    assert exc_info.value.code == 1
+    assert f'Unknown option: "{removed_option}"' in capsys.readouterr().err

--- a/tests/threads/test_threads_storage.py
+++ b/tests/threads/test_threads_storage.py
@@ -1,8 +1,10 @@
 """Tests for ThreadStorage (pydantic-ai snapshot threads)."""
 
 import tempfile
+import time
 from pathlib import Path
 
+import aiosqlite
 import pytest
 from pydantic_ai.messages import (
     ModelMessage,
@@ -136,3 +138,25 @@ async def test_list_end_delete_threads():
         assert deleted
         remaining = await store.list_threads()
         assert len(remaining) == 1
+
+
+@pytest.mark.asyncio
+async def test_count_prunable_threads():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ThreadStorage()
+        store.db_path = Path(tmp) / "threads.db"
+        old_thread = await store.save_snapshot(
+            messages_json=_messages_bytes("Old"), database_name="db"
+        )
+        await store.save_snapshot(
+            messages_json=_messages_bytes("Recent"), database_name="db"
+        )
+
+        async with aiosqlite.connect(store.db_path) as db:
+            await db.execute(
+                "UPDATE threads SET last_activity_at = ? WHERE id = ?",
+                (time.time() - 40 * 24 * 3600, old_thread),
+            )
+            await db.commit()
+
+        assert await store.count_prunable_threads(older_than_days=30) == 1


### PR DESCRIPTION
## Summary

- add complete non-interactive paths for model, theme, database, and provider configuration
- allow one-shot continuation of saved threads with restored history and database context
- standardize actionable stderr diagnostics and exit statuses
- require the single explicit `--yes` option for destructive automation and add thread-prune dry runs
- add copyable examples across command help, README, and documentation

Machine-readable/JSON output is intentionally unchanged and remains out of scope.

## Verification

- `uv run pytest -q` — 1,274 passed, 6 skipped
- focused CLI/storage suite — 65 passed
- `uv run ruff check .`
- changed-source `uvx ty check ...`
- `npm --prefix docs run build` — 20 pages built
- `.venv/bin/saber --help` — 0.41s
- `git diff --check`
