### PR TITLE
chore: add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "SQLsaber",
+  "install": "set -e; if ! command -v uv >/dev/null 2>&1; then curl -LsSf https://astral.sh/uv/install.sh | sh; fi; export PATH=\"$HOME/.local/bin:$PATH\"; uv sync --locked --all-extras --dev"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,4 @@ Note: Prefer `uv run ruff ...` over `uvx ruff ...` to avoid hitting user-level u
 - Include tests for new behavior and bug fixes; prefer async tests for async code.
 - Use fixtures from `tests/conftest.py` where possible.
 - Tests must pass without errors always.
+- Cloud Agent VMs export `FORCE_COLOR=0`, which Rich treats as "force terminal" and flips the display-detection tests (`tests/test_tools/test_display.py`, and table/markdown rendering assertions elsewhere) into the wrong branch. Run the suite the way CI does, without that variable: `env -u FORCE_COLOR uv run python -m pytest`. GitHub Actions does not set `FORCE_COLOR`, so CI is unaffected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for SQLsaber so future agents boot into a ready-to-use VM.

- Adds `.cursor/environment.json` (repo-file managed, version-controlled config).
- `install` is idempotent and self-contained: it bootstraps `uv` if missing (the base image does not ship it), then runs the CI-equivalent locked sync — `uv sync --locked --all-extras --dev`.
- No `start`/`terminals`: SQLsaber is a CLI tool with no long-running services.
- Documents a non-obvious `FORCE_COLOR` testing gotcha in `AGENTS.md`.

## Why the `FORCE_COLOR` note

Cloud Agent VMs export `FORCE_COLOR=0`. Rich treats the mere presence of `FORCE_COLOR` as "force terminal mode", which flips the display-detection tests into the wrong rendering branch (raw markdown vs. rich markup). GitHub Actions does not set the variable, so CI is unaffected. Running the suite the way CI does — `env -u FORCE_COLOR uv run python -m pytest` — keeps it green in the VM too.

## Validation

Local (this VM):
- Install runs to completion and is idempotent (second run is a no-op resolve).
- `uv run ruff check .` — clean.
- `uv run ruff format --check .` — 233 files already formatted.
- `env -u FORCE_COLOR uv run python -m pytest` — 1274 passed, 6 skipped.
- `saber --help`/`--version` work; warm CLI startup ~0.37s (under the 0.5s budget in `AGENTS.md`).
- Core SQL engine end-to-end against the sample `legislators.db`: schema introspection, read-only aggregation, and the write-guard blocking a `DELETE`.
- Full agentic flow (OpenAI model): the agent introspected the schema, generated + executed SQL, and answered a question about the sample DB.

Prebuilt environment build + fresh agent:
- Draft build from `main` **SUCCEEDED** (`uv sync --locked` reinstalled all 194 packages, exit 0, snapshot ready).
- A fresh Cloud Agent booted from that build verified: `uv 0.12.7` and Python `3.12.3` on PATH, dependencies pre-installed (no re-sync), CLI works, display tests 18/18, and the core SQL engine returned `12759` legislators with the read-only guard enforced.

## Demo

The real `saber` CLI answering a question end-to-end against the sample SQLite database:

[saber CLI answering a question end-to-end against legislators.db](https://cursor.com/artifacts/c/art-0d75223a-fc1b-404b-aaaa-d6584a9abdef)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aca4e39-9ece-44ed-aba8-1b31f280ae9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aca4e39-9ece-44ed-aba8-1b31f280ae9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

