### PR TITLE
chore: add isolated CLI verification skill

### DIFF
--- a/.cursor/skills/verify-sqlsaber/.gitignore
+++ b/.cursor/skills/verify-sqlsaber/.gitignore
@@ -1,0 +1,2 @@
+state/
+artifacts/

--- a/.cursor/skills/verify-sqlsaber/SKILL.md
+++ b/.cursor/skills/verify-sqlsaber/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: verify-sqlsaber
+description: Drive the SQLsaber CLI and interactive TUI the way a user does — isolated HOME, saber subcommands, tmux for chat. Use when proving database connections, knowledge, one-shot queries, threads, or the interactive session.
+---
+
+# Verify SQLsaber
+
+SQLsaber is a terminal SQL assistant (`saber` / `sqlsaber`). The primary surface is the CLI: non-interactive subcommands plus an interactive saber-tui chat. Secondary surfaces (Python SDK, docs site, optional viz/notebook/sandbox plugins) are out of scope for this skill.
+
+There is no long-lived server. Launch installs deps once, creates an isolated `HOME`, and seeds a SQLite file plus a saved connection named `verify-sqlite`. Each drive is a `saber` process (CLI) or a tmux session (TUI) against that HOME.
+
+Never point this skill at the operator's real `~/Library/Application Support/sqlsaber` or `~/.config/sqlsaber`. Two verification HOMs can exist on disk, but this helper allows only one active run. Refuse to drive a saber process you did not start.
+
+## Launch
+
+From the repo root:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber launch
+.cursor/skills/verify-sqlsaber/control-sqlsaber doctor
+```
+
+Launch is ready when it prints `ready: saber db list shows verify-sqlite` and doctor prints only `ok` lines.
+
+What launch does:
+
+1. `uv sync` in the repo (dev command from `AGENTS.md`).
+2. Creates `$TMPDIR/sqlsaber-verify-$RUN_ID/` with a disposable `HOME`.
+3. Loads `.cursor/skills/verify-sqlsaber/seed.sql` into `$WORKDIR/verify.sqlite` (`customers`, `orders`).
+4. Runs `saber db add verify-sqlite --type sqlite --database $SEEDED_DB --no-interactive --description "verification sqlite"`.
+5. Sets `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` so API keys and DB passwords never touch the operator keychain.
+6. Sets `SQLSABER_SKIP_VERSION_CHECK=1` and `SQLSABER_LOG_FILE=$WORKDIR/sqlsaber.log`.
+
+Teardown:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber cleanup
+```
+
+Cleanup deletes the tmux session this run started (if any) and the isolated workdir. It does not delete `.cursor/skills/verify-sqlsaber/artifacts/`.
+
+## Doctor
+
+Run before driving, and again whenever output looks like the operator's real config leaked in:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber doctor
+```
+
+Doctor must report:
+
+- `version` from `saber --version` (dotted `x.y.z`, currently the checkout's package version).
+- `help` — `saber --help` contains `SQLsaber` and `SQL assistant`.
+- `isolated` — `HOME_DIR` is under `sqlsaber-verify-` and is not the operator home.
+- `config` — `database_config.json` exists under that HOME.
+- `default_db` — `saber db list` contains `verify-sqlite`.
+- `db_test` — `saber db test verify-sqlite` prints `Connection to 'verify-sqlite' successful`.
+- `keyring` — null backend.
+- `tui` — `stopped` or `running` for session `sqlsaber-verify`.
+- `auth` — whether a provider env key is visible (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`). Query and TUI chat need one; db/knowledge/theme/models-current do not.
+
+Any `FAIL` line means do not drive.
+
+Inspect paths with:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber paths
+.cursor/skills/verify-sqlsaber/control-sqlsaber path SEEDED_DB
+```
+
+`paths` prints shell-quoted `KEY=value` lines (`eval "$(... paths)"` is safe). Prefer `path SEEDED_DB` when passing one file into `cli`. On macOS config is `$HOME_DIR/Library/Application Support/sqlsaber`. On Linux config is `$HOME_DIR/.config/sqlsaber` and knowledge may be under `$HOME_DIR/.local/share/sqlsaber`. Always take file locations from `path`.
+
+## Drive
+
+Non-interactive commands go through the helper so they inherit the isolated env:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber cli -- db list
+.cursor/skills/verify-sqlsaber/control-sqlsaber cli --out artifacts/example.txt -- db test verify-sqlite
+```
+
+`cli --` is followed by arguments to `saber` (no extra `saber` token). Relative `--out` paths resolve from `.cursor/skills/verify-sqlsaber/`. The helper also writes `$out.err` and `$out.exit`.
+
+Stable handles — match these strings, not column layout (Rich wraps tables):
+
+| Action | Command | Observable |
+| --- | --- | --- |
+| Help | `cli -- --help` | `SQLsaber` and subcommands `auth`, `db`, `knowledge`, `models`, `theme`, `threads` |
+| Version | `cli -- --version` | dotted version on stdout, exit `0` |
+| Add SQLite | `cli -- db add NAME --type sqlite --database ABS_PATH --no-interactive` | `Successfully added database connection 'NAME'` |
+| First connection | (same) | also `Set 'NAME' as default database` |
+| List | `cli -- db list` | table title `Database Connections` and the connection name |
+| Test | `cli -- db test NAME` | `Testing connection to 'NAME'...` then `Connection to 'NAME' successful` |
+| Default | `cli -- db set-default NAME` | `Successfully set 'NAME' as default database` |
+| Remove | `cli -- db remove NAME --yes` | `Successfully removed database connection 'NAME'` |
+| Knowledge add | `cli -- knowledge add "Name" "Description" --sql SQL --source SRC` | `Knowledge entry added for database 'verify-sqlite'` plus `ID:` UUID |
+| Knowledge list | `cli -- knowledge list` | `Knowledge Entries for Database: verify-sqlite` or `No knowledge entries found for database 'verify-sqlite'` |
+| Knowledge search | `cli -- knowledge search "query"` | `Knowledge Search Results` with the name, or `No knowledge entries matched 'query'` |
+| Knowledge show | `cli -- knowledge show UUID` | `ID:`, `Name:`, `Description:` |
+| Knowledge remove | `cli -- knowledge remove UUID --yes` | `Knowledge entry removed from database 'verify-sqlite'` |
+| Auth status | `cli -- auth status` | `Authentication Status` |
+| Models | `cli -- models current` | `Current model:` |
+| Threads list | `cli -- threads list` | `No threads found.` or table title `Threads` |
+| Threads show | `cli -- threads show THREAD_ID` | `Thread: THREAD_ID` |
+| One-shot query | `cli -- -d verify-sqlite "natural language"` | `Connected to: verify-sqlite (sqlite)` then streamed answer. Needs a provider key. |
+| Ad-hoc file | `cli -- -d ABS_SQLITE_OR_CSV "natural language"` | skips saved-connection lookup; still needs a provider key |
+
+Destructive commands require `--yes` when stdin is not a TTY. Do not pass `--force` or `-y`.
+
+Interactive chat is a TUI (`saber-tui`). Start it only through the helper:
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui start
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui send --literal '/clear'
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui send Enter
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui capture --path artifacts/interactive-session/pane.txt
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui stop
+```
+
+Ready when the pane contains `slash commands` and a footer `DB: verify-sqlite (SQLite)`. Typing `/` on an empty editor opens the command palette (`Thinking mode`, `Handoff thread`, `Clear conversation`, `Exit`). Typed slash commands still work: `/clear`, `/thinking`, `/thinking on`, `/thinking off`, `/exit`, `/quit`. Empty editor + `Ctrl+D` exits. `Ctrl+C` interrupts a running query.
+
+A natural-language submit in the TUI calls the configured model. Without a provider key the editor prompt will stall on auth; do not treat that as a product failure of db/knowledge.
+
+## Evidence
+
+Proof artifacts go under `.cursor/skills/verify-sqlsaber/artifacts/<feature-id>/`. Cleanup must not delete that tree.
+
+Standards:
+
+- Drive `saber` through `control-sqlsaber`, not by importing `sqlsaber.cli` or writing `database_config.json` by hand.
+- Capture the command output of the action and a second read-only view of the resulting state (`db list`, `knowledge show`, `threads show`, or the TUI pane after submit).
+- For mutations, also capture the side-effect file: `database_config.json`, a `sqlite3` read of `knowledge.db`, or `threads.db` — paths from `control-sqlsaber paths`.
+- CLI proof is stdout, stderr, and exit code (`$out`, `$out.err`, `$out.exit`).
+- TUI proof is a full pane capture that shows the banner or footer identity (`SQLsaber` ASCII block or `DB: verify-sqlite`) plus the action result.
+- One-shot query and TUI chat may call a real model provider. That is the user path. Do not stub pydantic-ai. If no provider key is in the environment, record the unmet precondition and skip those entry points; do not mark them verified via unit tests.
+- `threads prune --dry-run` must be checked by listing threads before and after and confirming the same IDs remain.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui stop   # if a TUI was started
+.cursor/skills/verify-sqlsaber/control-sqlsaber cleanup
+```
+
+Cleanup kills tmux session `sqlsaber-verify` (the session launch/tui start created) and `rm -rf` on the run's `sqlsaber-verify-*` workdir only. It never `pkill saber` and never deletes `artifacts/`.
+
+## Helpers
+
+`control-sqlsaber` is executable. Invoke it with a path from the repo root, or `cd` into the skill directory.
+
+```bash
+.cursor/skills/verify-sqlsaber/control-sqlsaber launch
+.cursor/skills/verify-sqlsaber/control-sqlsaber doctor
+.cursor/skills/verify-sqlsaber/control-sqlsaber cli --out artifacts/database-connections/list.txt -- db list
+.cursor/skills/verify-sqlsaber/control-sqlsaber path SEEDED_DB
+.cursor/skills/verify-sqlsaber/control-sqlsaber paths
+.cursor/skills/verify-sqlsaber/control-sqlsaber tui start
+.cursor/skills/verify-sqlsaber/control-sqlsaber cleanup
+```
+
+`seed.sql` is verification scaffolding. Launch applies it; cleanup removes the resulting sqlite file with the workdir.
+
+Read `features/README.md` before choosing what to drive.

--- a/.cursor/skills/verify-sqlsaber/control-sqlsaber
+++ b/.cursor/skills/verify-sqlsaber/control-sqlsaber
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# Drive SQLsaber the way a user does, inside an isolated HOME.
+#
+# Usage:
+#   control-sqlsaber launch
+#   control-sqlsaber doctor
+#   control-sqlsaber cli [--out RELATIVE_OR_ABS_PATH] -- <saber-args...>
+#   control-sqlsaber tui start|send|capture|stop
+#   control-sqlsaber paths
+#   control-sqlsaber cleanup
+#
+# Relative --out and capture paths are resolved from this skill directory.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+STATE_DIR="$SKILL_DIR/state"
+STATE_FILE="$STATE_DIR/current"
+ARTIFACTS_DIR="$SKILL_DIR/artifacts"
+TMUX_SESSION="sqlsaber-verify"
+KEYRING_BACKEND="keyring.backends.null.Keyring"
+
+die() {
+  printf 'control-sqlsaber: %s\n' "$*" >&2
+  exit 1
+}
+
+have_state() {
+  [[ -f "$STATE_FILE" ]]
+}
+
+load_state() {
+  have_state || die "no active run. Start one with: $SKILL_DIR/control-sqlsaber launch"
+  # shellcheck disable=SC1090
+  source "$STATE_FILE"
+  : "${RUN_ID:?}" "${WORKDIR:?}" "${HOME_DIR:?}" "${SEEDED_DB:?}" "${CONFIG_DIR:?}"
+}
+
+resolve_path() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s\n' "$SKILL_DIR/$path"
+  fi
+}
+
+write_state() {
+  mkdir -p "$STATE_DIR"
+  cat >"$STATE_FILE" <<EOF
+RUN_ID=$(printf '%q' "$RUN_ID")
+WORKDIR=$(printf '%q' "$WORKDIR")
+HOME_DIR=$(printf '%q' "$HOME_DIR")
+SEEDED_DB=$(printf '%q' "$SEEDED_DB")
+CONFIG_DIR=$(printf '%q' "$CONFIG_DIR")
+TMUX_SESSION=$(printf '%q' "$TMUX_SESSION")
+EOF
+}
+
+isolated_env() {
+  # HOME is the isolation boundary. Do not set XDG_* — on macOS those vars
+  # split config away from the Library/Application Support layout users get.
+  cat <<EOF
+export HOME=$(printf '%q' "$HOME_DIR")
+export SQLSABER_LOG_FILE=$(printf '%q' "$WORKDIR/sqlsaber.log")
+export SQLSABER_SKIP_VERSION_CHECK=1
+export PYTHON_KEYRING_BACKEND=$(printf '%q' "$KEYRING_BACKEND")
+export TERM=xterm-256color
+export COLUMNS=200
+export LINES=50
+unset FORCE_COLOR
+unset NO_COLOR
+unset XDG_CONFIG_HOME
+unset XDG_DATA_HOME
+unset XDG_STATE_HOME
+unset XDG_CACHE_HOME
+EOF
+}
+
+run_saber() {
+  load_state
+  mkdir -p "$HOME_DIR" "$WORKDIR"
+  (
+    eval "$(isolated_env)"
+    cd "$REPO_ROOT"
+    exec uv run saber "$@"
+  )
+}
+
+cmd_launch() {
+  if have_state; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+    if [[ -n "${WORKDIR:-}" && -d "${WORKDIR:-}" ]]; then
+      die "a verification run is already active (RUN_ID=${RUN_ID:-unknown}, WORKDIR=$WORKDIR). Run cleanup first. Do not drive the operator's real SQLsaber config."
+    fi
+  fi
+
+  command -v uv >/dev/null 2>&1 || die "uv is not on PATH. Install it, then retry launch."
+
+  RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
+  WORKDIR="${TMPDIR:-/tmp}/sqlsaber-verify-$RUN_ID"
+  HOME_DIR="$WORKDIR/home"
+  SEEDED_DB="$WORKDIR/verify.sqlite"
+  mkdir -p "$HOME_DIR" "$ARTIFACTS_DIR" "$WORKDIR"
+
+  (
+    eval "$(isolated_env)"
+    cd "$REPO_ROOT"
+    uv sync
+    sqlite3 "$SEEDED_DB" <"$SKILL_DIR/seed.sql"
+    uv run saber db add verify-sqlite \
+      --type sqlite \
+      --database "$SEEDED_DB" \
+      --no-interactive \
+      --description "verification sqlite"
+  )
+
+  # platformdirs on macOS uses ~/Library/Application Support/sqlsaber; on
+  # Linux it uses ~/.config/sqlsaber. Resolve after the first write.
+  if [[ -f "$HOME_DIR/Library/Application Support/sqlsaber/database_config.json" ]]; then
+    CONFIG_DIR="$HOME_DIR/Library/Application Support/sqlsaber"
+  elif [[ -f "$HOME_DIR/.config/sqlsaber/database_config.json" ]]; then
+    CONFIG_DIR="$HOME_DIR/.config/sqlsaber"
+  else
+    CONFIG_DIR="$(dirname "$(find "$HOME_DIR" -name database_config.json -print -quit)")"
+  fi
+  [[ -n "$CONFIG_DIR" && -f "$CONFIG_DIR/database_config.json" ]] || die "launch wrote no database_config.json under $HOME_DIR"
+
+  write_state
+  printf 'launched RUN_ID=%s\n' "$RUN_ID"
+  printf 'WORKDIR=%s\n' "$WORKDIR"
+  printf 'HOME_DIR=%s\n' "$HOME_DIR"
+  printf 'CONFIG_DIR=%s\n' "$CONFIG_DIR"
+  printf 'SEEDED_DB=%s\n' "$SEEDED_DB"
+  printf 'ready: saber db list shows verify-sqlite\n'
+}
+
+cmd_doctor() {
+  load_state
+  local failed=0
+  # Subprocesses override HOME; this shell still has the operator home.
+  local real_home="${SQLSABER_VERIFY_REAL_HOME:-$HOME}"
+
+  check() {
+    local name="$1" ok="$2" detail="$3"
+    if [[ "$ok" == "1" ]]; then
+      printf 'ok   %s  %s\n' "$name" "$detail"
+    else
+      printf 'FAIL %s  %s\n' "$name" "$detail"
+      failed=1
+    fi
+  }
+
+  local version
+  version="$(run_saber --version 2>/dev/null | tr -d '[:space:]' || true)"
+  check version "$([[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] && echo 1 || echo 0)" "${version:-missing}"
+
+  local help_out
+  help_out="$(run_saber --help 2>&1 || true)"
+  check help "$([[ "$help_out" == *SQLsaber* && "$help_out" == *"SQL assistant"* ]] && echo 1 || echo 0)" "saber --help names SQLsaber"
+
+  check isolated "$([[ "$HOME_DIR" != "$real_home" && "$HOME_DIR" == *sqlsaber-verify-* ]] && echo 1 || echo 0)" "HOME_DIR=$HOME_DIR"
+
+  check config "$([[ -f "$CONFIG_DIR/database_config.json" && "$CONFIG_DIR" == "$HOME_DIR"* ]] && echo 1 || echo 0)" "$CONFIG_DIR/database_config.json"
+
+  local list_out
+  list_out="$(run_saber db list 2>&1 || true)"
+  check default_db "$([[ "$list_out" == *verify-sqlite* ]] && echo 1 || echo 0)" "db list contains verify-sqlite"
+
+  local test_out test_code=0
+  test_out="$(run_saber db test verify-sqlite 2>&1)" || test_code=$?
+  check db_test "$([[ $test_code -eq 0 && "$test_out" == *"Connection to 'verify-sqlite' successful"* ]] && echo 1 || echo 0)" "exit $test_code"
+
+  check keyring "$([[ "$KEYRING_BACKEND" == "keyring.backends.null.Keyring" ]] && echo 1 || echo 0)" "$KEYRING_BACKEND"
+
+  local tui_state="stopped"
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    tui_state="running"
+  fi
+  check tui 1 "$tui_state"
+
+  local auth_hint="absent"
+  if [[ -n "${ANTHROPIC_API_KEY:-}" || -n "${OPENAI_API_KEY:-}" || -n "${GEMINI_API_KEY:-}" || -n "${GOOGLE_API_KEY:-}" ]]; then
+    auth_hint="env-key-present"
+  fi
+  check auth 1 "$auth_hint (query and TUI chat need a provider key)"
+
+  if [[ "$failed" -ne 0 ]]; then
+    die "doctor found a problem. Do not drive this instance."
+  fi
+}
+
+cmd_cli() {
+  load_state
+  local out=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --out)
+        [[ $# -ge 2 ]] || die "--out requires a path"
+        out="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  [[ $# -gt 0 ]] || die "usage: control-sqlsaber cli [--out PATH] -- <saber-args...>"
+
+  local stdout_file stderr_file code_file
+  stdout_file="$(mktemp "$WORKDIR/cli-stdout.XXXXXX")"
+  stderr_file="$(mktemp "$WORKDIR/cli-stderr.XXXXXX")"
+  local code=0
+  set +e
+  run_saber "$@" >"$stdout_file" 2>"$stderr_file"
+  code=$?
+  set -e
+
+  cat "$stdout_file"
+  if [[ -s "$stderr_file" ]]; then
+    cat "$stderr_file" >&2
+  fi
+
+  if [[ -n "$out" ]]; then
+    local dest err_dest code_dest
+    dest="$(resolve_path "$out")"
+    mkdir -p "$(dirname "$dest")"
+    err_dest="$dest.err"
+    code_dest="$dest.exit"
+    cp "$stdout_file" "$dest"
+    cp "$stderr_file" "$err_dest"
+    printf '%s\n' "$code" >"$code_dest"
+    printf 'wrote %s (exit %s)\n' "$dest" "$code" >&2
+  fi
+
+  rm -f "$stdout_file" "$stderr_file"
+  return "$code"
+}
+
+emit_assignment() {
+  printf '%s=%q\n' "$1" "$2"
+}
+
+cmd_path() {
+  load_state
+  local key="${1:-}"
+  local knowledge_db threads_db
+  knowledge_db="$(find "$HOME_DIR" -name knowledge.db -print -quit 2>/dev/null || true)"
+  threads_db="$(find "$HOME_DIR" -name threads.db -print -quit 2>/dev/null || true)"
+  case "$key" in
+    RUN_ID) printf '%s\n' "$RUN_ID" ;;
+    WORKDIR) printf '%s\n' "$WORKDIR" ;;
+    HOME_DIR) printf '%s\n' "$HOME_DIR" ;;
+    CONFIG_DIR) printf '%s\n' "$CONFIG_DIR" ;;
+    CONFIG_FILE) printf '%s\n' "$CONFIG_DIR/database_config.json" ;;
+    KNOWLEDGE_DB) printf '%s\n' "${knowledge_db:-$CONFIG_DIR/knowledge.db}" ;;
+    THREADS_DB) printf '%s\n' "${threads_db:-$CONFIG_DIR/threads.db}" ;;
+    SEEDED_DB) printf '%s\n' "$SEEDED_DB" ;;
+    LOG_FILE) printf '%s\n' "$WORKDIR/sqlsaber.log" ;;
+    ARTIFACTS) printf '%s\n' "$ARTIFACTS_DIR" ;;
+    TMUX_SESSION) printf '%s\n' "$TMUX_SESSION" ;;
+    *) die "unknown path key '$key'. Try: control-sqlsaber paths" ;;
+  esac
+}
+
+cmd_paths() {
+  load_state
+  local knowledge_db threads_db
+  knowledge_db="$(find "$HOME_DIR" -name knowledge.db -print -quit 2>/dev/null || true)"
+  threads_db="$(find "$HOME_DIR" -name threads.db -print -quit 2>/dev/null || true)"
+  emit_assignment RUN_ID "$RUN_ID"
+  emit_assignment WORKDIR "$WORKDIR"
+  emit_assignment HOME_DIR "$HOME_DIR"
+  emit_assignment CONFIG_DIR "$CONFIG_DIR"
+  emit_assignment CONFIG_FILE "$CONFIG_DIR/database_config.json"
+  emit_assignment KNOWLEDGE_DB "${knowledge_db:-$CONFIG_DIR/knowledge.db}"
+  emit_assignment THREADS_DB "${threads_db:-$CONFIG_DIR/threads.db}"
+  emit_assignment SEEDED_DB "$SEEDED_DB"
+  emit_assignment LOG_FILE "$WORKDIR/sqlsaber.log"
+  emit_assignment ARTIFACTS "$ARTIFACTS_DIR"
+  emit_assignment TMUX_SESSION "$TMUX_SESSION"
+}
+
+tui_running() {
+  command -v tmux >/dev/null 2>&1 || return 1
+  tmux has-session -t "$TMUX_SESSION" 2>/dev/null
+}
+
+cmd_tui() {
+  load_state
+  local action="${1:-}"
+  shift || true
+  case "$action" in
+    start)
+      command -v tmux >/dev/null 2>&1 || die "tmux is required for interactive verification"
+      if tui_running; then
+        die "tmux session $TMUX_SESSION is already running. Capture or stop it; do not start a second TUI against this HOME."
+      fi
+      local wrapper="$WORKDIR/tui-start.sh"
+      cat >"$wrapper" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$(isolated_env)
+cd $(printf '%q' "$REPO_ROOT")
+exec uv run saber -d verify-sqlite
+EOF
+      chmod +x "$wrapper"
+      tmux new-session -d -s "$TMUX_SESSION" -x 120 -y 40 "$wrapper"
+      local i
+      for i in $(seq 1 50); do
+        local pane
+        pane="$(tmux capture-pane -pt "$TMUX_SESSION" 2>/dev/null || true)"
+        if [[ "$pane" == *"Use \`/\` for slash commands"* || "$pane" == *"slash commands"* ]]; then
+          printf 'tui ready\n'
+          return 0
+        fi
+        sleep 0.2
+      done
+      printf '%s\n' "$(tmux capture-pane -pt "$TMUX_SESSION" 2>/dev/null || true)" >&2
+      die "interactive session did not show the slash-command instructions"
+      ;;
+    send)
+      tui_running || die "no TUI session. Start one with: control-sqlsaber tui start"
+      local literal=0
+      if [[ "${1:-}" == "--literal" ]]; then
+        literal=1
+        shift
+      fi
+      [[ $# -gt 0 ]] || die "usage: control-sqlsaber tui send [--literal] <text-or-keys>"
+      if [[ "$literal" -eq 1 ]]; then
+        tmux send-keys -t "$TMUX_SESSION" -l "$*"
+      else
+        tmux send-keys -t "$TMUX_SESSION" "$@"
+      fi
+      ;;
+    capture)
+      tui_running || die "no TUI session. Start one with: control-sqlsaber tui start"
+      local out=""
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --path)
+            out="$2"
+            shift 2
+            ;;
+          *)
+            die "usage: control-sqlsaber tui capture [--path PATH]"
+            ;;
+        esac
+      done
+      local pane
+      pane="$(tmux capture-pane -pt "$TMUX_SESSION" -S - -E -)"
+      printf '%s\n' "$pane"
+      if [[ -n "$out" ]]; then
+        local dest
+        dest="$(resolve_path "$out")"
+        mkdir -p "$(dirname "$dest")"
+        printf '%s\n' "$pane" >"$dest"
+        printf 'wrote %s\n' "$dest" >&2
+      fi
+      ;;
+    stop)
+      if tui_running; then
+        tmux send-keys -t "$TMUX_SESSION" C-d || true
+        sleep 0.3
+        if tui_running; then
+          tmux kill-session -t "$TMUX_SESSION"
+        fi
+        printf 'tui stopped\n'
+      else
+        printf 'tui already stopped\n'
+      fi
+      ;;
+    *)
+      die "usage: control-sqlsaber tui start|send|capture|stop"
+      ;;
+  esac
+}
+
+cmd_cleanup() {
+  if have_state; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+    if command -v tmux >/dev/null 2>&1 && tmux has-session -t "${TMUX_SESSION:-sqlsaber-verify}" 2>/dev/null; then
+      tmux kill-session -t "$TMUX_SESSION"
+    fi
+    if [[ -n "${WORKDIR:-}" && -d "${WORKDIR:-}" && "$WORKDIR" == *sqlsaber-verify-* ]]; then
+      rm -rf "$WORKDIR"
+    fi
+    rm -f "$STATE_FILE"
+  fi
+  printf 'cleaned isolated run. artifacts remain in %s\n' "$ARTIFACTS_DIR"
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    launch) cmd_launch "$@" ;;
+    doctor) cmd_doctor "$@" ;;
+    cli) cmd_cli "$@" ;;
+    tui) cmd_tui "$@" ;;
+    path) cmd_path "$@" ;;
+    paths) cmd_paths "$@" ;;
+    cleanup) cmd_cleanup "$@" ;;
+    *)
+      die "usage: control-sqlsaber launch|doctor|cli|tui|path|paths|cleanup"
+      ;;
+  esac
+}
+
+main "$@"

--- a/.cursor/skills/verify-sqlsaber/features/README.md
+++ b/.cursor/skills/verify-sqlsaber/features/README.md
@@ -1,0 +1,52 @@
+# SQLsaber verification map
+
+This directory is the maintained source for verifying user-facing SQLsaber behavior. Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Run `.cursor/skills/verify-sqlsaber/control-sqlsaber launch` then `doctor`.
+- Isolated HOME is `$WORKDIR/home` from `control-sqlsaber paths`. Never use the operator's SQLsaber config dir.
+- Seed sqlite is `control-sqlsaber path SEEDED_DB` with tables `customers` and `orders`.
+- Saved connection `verify-sqlite` is the default.
+- `PYTHON_KEYRING_BACKEND` is `keyring.backends.null.Keyring`.
+- Provider API keys are optional. Features that talk to a model say so in their preconditions.
+- Put the helper on your command path for the run, or invoke it by repo-relative path.
+- Never drive a `saber` process or tmux session this run did not start.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Run non-interactive commands as `control-sqlsaber cli -- <args>`.
+- Run interactive chat as `control-sqlsaber tui start` / `send` / `capture` / `stop`.
+- Treat every command as literal. Keep connection name `verify-sqlite` and quoted knowledge names unchanged unless the recipe introduces another name.
+- Restore baseline after a mutation that would break later recipes (`verify-sqlite` remains the default; extra connections and knowledge entries created by a recipe are removed in that recipe).
+- Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the last command.
+- CLI proof includes the command, stdout, stderr, and exit code.
+- Mutation proof includes a read-only second view (`db list`, `knowledge show`, config JSON, or sqlite).
+- TUI proof includes a pane capture with `DB: verify-sqlite` visible.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition (especially missing provider keys).
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with control-sqlsaber` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [Database connections](./database-connections.md) covers adding, listing, testing, defaulting, and removing saved connections.
+- [Knowledge base](./knowledge-base.md) covers adding, listing, showing, searching, and removing per-database knowledge.
+- [One-shot query](./one-shot-query.md) covers non-interactive natural-language questions against a saved connection or an ad-hoc file.
+- [Interactive session](./interactive-session.md) covers the TUI chat, slash commands, command palette, and exit.
+- [Conversation threads](./conversation-threads.md) covers listing, showing, resuming, non-interactive follow-up, and dry-run prune.

--- a/.cursor/skills/verify-sqlsaber/features/conversation-threads.md
+++ b/.cursor/skills/verify-sqlsaber/features/conversation-threads.md
@@ -1,0 +1,44 @@
+# Conversation threads
+
+Conversation threads let a user list saved chats, read a transcript, continue a thread in the TUI or with one non-interactive follow-up, and preview prune without deleting.
+
+## Sub-features
+
+- `threads-list-empty` reports no threads on a fresh launch.
+- `threads-list` shows IDs after a query has been saved.
+- `threads-show` prints metadata and the transcript for one ID.
+- `threads-followup` continues a thread with `saber --thread ID "question"`.
+- `threads-prune-dry-run` reports what would be deleted without removing threads.
+
+## How to get to it (user POV)
+
+- Run `saber threads list`.
+- Run `saber threads show THREAD_ID`.
+- Run `saber threads resume THREAD_ID` for an interactive continuation.
+- Run `saber --thread THREAD_ID "follow-up question"` for one non-interactive continuation.
+- Run `saber threads prune --days 30 --dry-run`.
+
+## Driving it with control-sqlsaber
+
+Preconditions:
+
+- `control-sqlsaber doctor` is clean.
+- For `threads-list-empty` only: no query has been run in this isolated HOME yet (true immediately after launch).
+- For list/show/follow-up: a thread exists. Create one only via the user path in [one-shot query](./one-shot-query.md) (`cli -- -d verify-sqlite "How many customers are in CA?"`). That requires a provider key. If the key is absent, skip the populated-thread entry points and still run the empty list plus dry-run on empty.
+
+- **Empty list.** Right after launch, run `control-sqlsaber cli --out artifacts/conversation-threads/list-empty.txt -- threads list`. Exit code `0`. Stdout is `No threads found.`
+- **Populate (optional).** Drive one-shot query against `verify-sqlite`. Note the printed `saber threads resume` / `--thread` ID if present.
+- **List populated.** Run `control-sqlsaber cli --out artifacts/conversation-threads/list.txt -- threads list`. Stdout contains table title `Threads` and the thread ID. Database column includes `verify-sqlite`.
+- **Show transcript.** Run `control-sqlsaber cli --out artifacts/conversation-threads/show.txt -- threads show THREAD_ID`. Stdout contains `Thread: THREAD_ID`, `Database: verify-sqlite`, and the original user question.
+- **Non-interactive follow-up.** Run `control-sqlsaber cli --out artifacts/conversation-threads/followup.txt -- --thread THREAD_ID "How many orders are pending?"`. Exit code `0`. Stdout contains `Connected to:` and an answer about the pending `Globex` order. A second `threads show THREAD_ID` includes both questions.
+- **Dry-run prune.** Run `control-sqlsaber cli --out artifacts/conversation-threads/prune-dry-run.txt -- threads prune --days 0 --dry-run`. Then run `threads list` again to `artifacts/conversation-threads/list-after-dry-run.txt`. Thread IDs from before the dry-run are still present. If the dry-run said it would delete N threads, N must match the listed count, and the files on disk must still contain those IDs.
+- **Proof.** Empty-list plus either (populated list, show, unchanged IDs after dry-run) or an explicit skip of populated paths for missing provider keys.
+
+## Gotchas
+
+- Threads are stored under the isolated HOME (`threads.db` from `control-sqlsaber paths`). Listing from the operator's real config is a failed isolation check.
+- `saber threads resume ID` starts the TUI. For non-interactive proof use `saber --thread ID "question"`.
+- `--thread` requires a query. `saber --thread ID` with no question exits `2`.
+- Ad-hoc file queries may not auto-resume from saved connection names. This recipe uses `verify-sqlite`.
+- `threads prune` without `--dry-run` deletes. Always pass `--dry-run` in verification unless a recipe is specifically testing deletion, and then only inside this isolated HOME.
+- `--days 0` is aggressive; that is why the post-dry-run list is mandatory. Trusting the word `dry-run` without a second list is not proof.

--- a/.cursor/skills/verify-sqlsaber/features/database-connections.md
+++ b/.cursor/skills/verify-sqlsaber/features/database-connections.md
@@ -1,0 +1,49 @@
+# Database connections
+
+Database connections let a user save a named SQLite, DuckDB, PostgreSQL, or MySQL target, see it in the connection list, test that it answers, choose a default, and remove it without touching other connections.
+
+## Sub-features
+
+- `db-add-sqlite` saves a named SQLite connection from flags, without prompts.
+- `db-list` shows saved names, types, and the default marker.
+- `db-test` runs a live `SELECT 1` against the named connection.
+- `db-set-default` changes which connection is used when `-d` is omitted.
+- `db-remove` deletes a named connection after `--yes`.
+
+## How to get to it (user POV)
+
+- Run `saber db add <name> --type sqlite --database <abs-path> --no-interactive`.
+- Run `saber db list`.
+- Run `saber db test <name>` or `saber db test` for the default.
+- Run `saber db set-default <name>`.
+- Run `saber db remove <name> --yes`.
+
+## Driving it with control-sqlsaber
+
+Preconditions:
+
+- `control-sqlsaber doctor` is clean.
+- Baseline connection `verify-sqlite` exists and is the default.
+- No connection is named `verify-alt`.
+- Seed sqlite path is `control-sqlsaber path SEEDED_DB`.
+
+- **Add second connection.** Save another SQLite name against the seed file. Run `control-sqlsaber cli --out artifacts/database-connections/add.txt -- db add verify-alt --type sqlite --database "$(control-sqlsaber path SEEDED_DB)" --no-interactive --description "verification alternate"`. Exit code `0`. Stdout contains `Successfully added database connection 'verify-alt'` and does not contain `Set 'verify-alt' as default database`.
+- **List both.** Run `control-sqlsaber cli --out artifacts/database-connections/list-both.txt -- db list`. Exit code `0`. Stdout contains `Database Connections`, `verify-sqlite`, `verify-alt`, and `sqlite`.
+- **Test new connection.** Run `control-sqlsaber cli --out artifacts/database-connections/test-alt.txt -- db test verify-alt`. Exit code `0`. Stdout contains `Testing connection to 'verify-alt'...` and `Connection to 'verify-alt' successful`.
+- **Change default.** Run `control-sqlsaber cli --out artifacts/database-connections/set-default-alt.txt -- db set-default verify-alt`. Exit code `0`. Stdout contains `Successfully set 'verify-alt' as default database`.
+- **Confirm default.** Run `control-sqlsaber cli --out artifacts/database-connections/list-default-alt.txt -- db list`. The `verify-alt` row is marked default (`✓` in the Default column).
+- **Restore default.** Run `control-sqlsaber cli -- db set-default verify-sqlite`. Stdout contains `Successfully set 'verify-sqlite' as default database`.
+- **Remove extra connection.** Run `control-sqlsaber cli --out artifacts/database-connections/remove.txt -- db remove verify-alt --yes`. Exit code `0`. Stdout contains `Successfully removed database connection 'verify-alt'`.
+- **Confirm removal.** Run `control-sqlsaber cli --out artifacts/database-connections/list-final.txt -- db list`. Stdout contains `verify-sqlite` and does not contain `verify-alt`.
+- **Confirm persistence.** Copy `$(control-sqlsaber path CONFIG_FILE)` to `artifacts/database-connections/database_config.json`. The JSON `connections` object has `verify-sqlite` and does not have `verify-alt`.
+- **Proof.** Keep the add, list-both, test, remove, list-final, and config JSON artifacts together. They show the extra connection appearing, answering, and disappearing while `verify-sqlite` remains.
+
+## Gotchas
+
+- `saber db add` without `--no-interactive` opens questionary prompts. That path is not this recipe.
+- SQLite `--database` must be an absolute path. A relative path is stored as given and later `db test` depends on cwd.
+- The first saved connection is auto-defaulted. `verify-sqlite` already is, so `verify-alt` must not print the default line.
+- Rich table cells truncate when `COLUMNS` is narrow. Assert on the connection name strings, not on every wrapped cell. The helper exports `COLUMNS=200`.
+- `db remove` without `--yes` exits non-zero when stdin is not a TTY. Use `--yes`.
+- Do not `db remove verify-sqlite` in this recipe. Later features need the baseline connection.
+- Passwords for PostgreSQL/MySQL go to the OS keyring. This run uses a null keyring; do not treat a skipped server-password save as a SQLite bug.

--- a/.cursor/skills/verify-sqlsaber/features/interactive-session.md
+++ b/.cursor/skills/verify-sqlsaber/features/interactive-session.md
@@ -1,0 +1,44 @@
+# Interactive session
+
+Interactive session is the full-screen chat TUI started by `saber` with no query. A user sees the SQLsaber banner, types questions or slash commands, and exits back to the shell.
+
+## Sub-features
+
+- `tui-open` shows the banner, slash-command instructions, and a `DB: verify-sqlite (SQLite)` footer.
+- `tui-slash-clear` runs `/clear` and reports that history was cleared.
+- `tui-palette` opens the command palette from `/` on an empty editor.
+- `tui-exit` leaves the session via `/exit` or empty-editor Ctrl+D.
+
+## How to get to it (user POV)
+
+- Run `saber` or `saber -d verify-sqlite` with no question.
+- Type `/` on an empty prompt to open the command palette.
+- Type `/clear`, `/thinking`, `/exit`, or `/quit`.
+- Press Ctrl+D on an empty editor to exit.
+
+## Driving it with control-sqlsaber
+
+Preconditions:
+
+- `control-sqlsaber doctor` is clean.
+- `tmux` is on `PATH`.
+- No tmux session named `sqlsaber-verify` exists (`doctor` reports `tui  stopped`).
+- Opening the TUI does not require a provider key. Submitting a natural-language question does. This recipe does not submit a question.
+
+- **Start session.** Run `control-sqlsaber tui start`. It returns `tui ready` when the pane contains `slash commands`.
+- **Capture identity.** Run `control-sqlsaber tui capture --path artifacts/interactive-session/ready.txt`. The pane contains `slash commands`, `table name completions`, and `DB: verify-sqlite`.
+- **Open palette.** Run `control-sqlsaber tui send --literal /` then `control-sqlsaber tui capture --path artifacts/interactive-session/palette.txt`. The pane contains `Thinking mode` and `Clear conversation`.
+- **Dismiss palette.** Run `control-sqlsaber tui send Escape`. Capture if needed; the editor is focused again and the palette labels are gone.
+- **Clear via slash command.** Run `control-sqlsaber tui send --literal '/clear'` then `control-sqlsaber tui send Enter` then capture `--path artifacts/interactive-session/clear.txt`. The pane contains `Conversation history cleared.`
+- **Exit.** Run `control-sqlsaber tui send --literal '/exit'` then `control-sqlsaber tui send Enter`. If the session is still present after a second, run `control-sqlsaber tui stop`. The helper reports `tui stopped`.
+- **Shell goodbye.** If `/exit` returned to the wrapper, the tmux pane or helper output contains `Goodbye!` before the session ends.
+- **Proof.** Keep `ready.txt`, `palette.txt`, and `clear.txt`. Ready must identify SQLsaber and `verify-sqlite`. Clear must show the slash-command result. Do not claim chat-query verification from this recipe.
+
+## Gotchas
+
+- `tui start` already passes `-d verify-sqlite`. Starting a second session against the same HOME is refused.
+- `/` only opens the palette when the editor is empty. If text is present, `/` is a character.
+- `control-sqlsaber tui send` without `--literal` lets tmux interpret key names (`Enter`, `Escape`, `C-d`). Use `--literal` for the slash-command text.
+- Submitting a question without a provider key hangs on auth. Stop the session and skip; do not keep sending keys.
+- `control-sqlsaber cleanup` kills session `sqlsaber-verify` if you forget `tui stop`.
+- The ASCII banner uses box-drawing characters. Assert on `slash commands` and `DB: verify-sqlite`, which survive `tmux capture-pane`.

--- a/.cursor/skills/verify-sqlsaber/features/knowledge-base.md
+++ b/.cursor/skills/verify-sqlsaber/features/knowledge-base.md
@@ -1,0 +1,45 @@
+# Knowledge base
+
+Knowledge base lets a user save named business context for the current database, list and show those entries, search them by keyword, and remove them.
+
+## Sub-features
+
+- `knowledge-add` stores a name, description, optional SQL, and optional source on `verify-sqlite`.
+- `knowledge-list` shows IDs and names for that database.
+- `knowledge-show` prints the full entry by ID.
+- `knowledge-search` ranks entries by full-text match.
+- `knowledge-search-empty` reports a complete miss.
+- `knowledge-remove` deletes one entry after `--yes`.
+
+## How to get to it (user POV)
+
+- Run `saber knowledge add "Name" "Description"` with optional `--sql`, `--source`, and `-d`.
+- Run `saber knowledge list`.
+- Run `saber knowledge show ENTRY_ID`.
+- Run `saber knowledge search "query"`.
+- Run `saber knowledge remove ENTRY_ID --yes`.
+
+## Driving it with control-sqlsaber
+
+Preconditions:
+
+- `control-sqlsaber doctor` is clean.
+- Default database is `verify-sqlite`.
+- No knowledge entry is named `Revenue KPI`.
+
+- **Add entry.** Run `control-sqlsaber cli --out artifacts/knowledge-base/add.txt -- knowledge add "Revenue KPI" "Recognized revenue from shipped orders only" --sql "SELECT SUM(amount_cents) FROM orders WHERE status = 'shipped'" --source "finance-wiki"`. Exit code `0`. Stdout contains `Knowledge entry added for database 'verify-sqlite'`, `Name: Revenue KPI`, and an `ID:` UUID. Record that UUID as `ENTRY_ID`.
+- **List.** Run `control-sqlsaber cli --out artifacts/knowledge-base/list.txt -- knowledge list`. Exit code `0`. Stdout contains `Knowledge Entries for Database: verify-sqlite`, `Revenue KPI`, and `Total entries: 1`.
+- **Show.** Run `control-sqlsaber cli --out artifacts/knowledge-base/show.txt -- knowledge show ENTRY_ID`. Exit code `0`. Stdout contains `Name: Revenue KPI`, `Recognized revenue from shipped orders only`, `SELECT SUM(amount_cents) FROM orders WHERE status = 'shipped'`, and `Source: finance-wiki`.
+- **Search hit.** Run `control-sqlsaber cli --out artifacts/knowledge-base/search-hit.txt -- knowledge search "shipped revenue"`. Exit code `0`. Stdout contains `Knowledge Search Results` and `Revenue KPI`.
+- **Search miss.** Run `control-sqlsaber cli --out artifacts/knowledge-base/search-miss.txt -- knowledge search "volcano"`. Exit code `0`. Stdout contains `No knowledge entries matched 'volcano' for database 'verify-sqlite'`.
+- **Remove.** Run `control-sqlsaber cli --out artifacts/knowledge-base/remove.txt -- knowledge remove ENTRY_ID --yes`. Exit code `0`. Stdout contains `Knowledge entry removed from database 'verify-sqlite'`.
+- **Confirm removal.** Run `control-sqlsaber cli --out artifacts/knowledge-base/list-empty.txt -- knowledge list`. Stdout contains `No knowledge entries found for database 'verify-sqlite'`.
+- **Proof.** Keep add, show, search-hit, search-miss, and list-empty. The ID from add must be the ID shown and removed.
+
+## Gotchas
+
+- Knowledge is scoped to a saved connection name. Adding with `-d` of an unknown name exits `1` with `database connection 'NAME' not found`.
+- Without any saved connection, `knowledge list` exits `1` with `no database connections configured`. This recipe assumes launch already added `verify-sqlite`.
+- `knowledge remove` and `knowledge clear` require `--yes` when stdin is not a TTY.
+- Search ranking is full-text, not substring-on-list. Assert on the printed name, not on result order beyond the expected hit being present.
+- Do not leave `Revenue KPI` behind. Other recipes assume the empty knowledge list unless they add their own entries.

--- a/.cursor/skills/verify-sqlsaber/features/one-shot-query.md
+++ b/.cursor/skills/verify-sqlsaber/features/one-shot-query.md
@@ -1,0 +1,38 @@
+# One-shot query
+
+One-shot query lets a user ask a natural-language question from the shell, get a streamed answer against the connected database, and exit without opening the TUI.
+
+## Sub-features
+
+- `query-saved` runs a question with `-d verify-sqlite`.
+- `query-adhoc-file` runs a question with `-d` pointing at the seed sqlite path.
+- `query-connected-banner` prints the connected database and model before the answer.
+- `query-thread-hint` prints continue hints when a thread was saved.
+
+## How to get to it (user POV)
+
+- Run `saber -d verify-sqlite "How many customers are in CA?"`.
+- Run `saber -d /abs/path/verify.sqlite "How many customers are in CA?"`.
+- Pipe the question: `echo "How many customers are in CA?" | saber -d verify-sqlite`.
+
+## Driving it with control-sqlsaber
+
+Preconditions:
+
+- `control-sqlsaber doctor` is clean.
+- A provider API key is present in the environment (`ANTHROPIC_API_KEY` for the default model `anthropic:claude-opus-4-5`, or another configured provider). If doctor reports `auth  absent`, skip this feature and record that unmet precondition. Do not mark it verified from unit tests.
+- Default database is `verify-sqlite`.
+
+- **Saved connection.** Run `control-sqlsaber cli --out artifacts/one-shot-query/saved.txt -- -d verify-sqlite "How many customers are in CA?"`. Exit code `0`. Stdout contains `Connected to: verify-sqlite (sqlite)` and an answer that reports one California customer (`Acme`).
+- **Ad-hoc file.** Run `control-sqlsaber cli --out artifacts/one-shot-query/adhoc.txt -- -d "$(control-sqlsaber path SEEDED_DB)" "How many customers live in New York?"`. Exit code `0`. Stdout contains `Connected to:` and an answer that reports one New York customer (`Globex`).
+- **Unknown saved name.** Run `control-sqlsaber cli --out artifacts/one-shot-query/missing.txt -- -d nonexistent "show tables"`. Exit code `1`. Stderr contains `Database connection 'nonexistent' not found`.
+- **Proof.** Keep saved and adhoc transcripts. Both must show the connected banner and a user-visible answer, not only tool-call traces. If a thread ID is printed, `saber threads list` in a follow-up `cli` call contains that ID.
+
+## Gotchas
+
+- This path calls a real model and executes read-only SQL against the seed sqlite. It is not dry-run.
+- Without a provider key the process may prompt or fail on auth. That is an unmet precondition, not a query-engine bug.
+- `-d NAME` looks up a saved connection. `-d /path/file.sqlite` (or `.csv`, `.duckdb`) is an ad-hoc file and does not need `db add`.
+- Stdin with a TTY and no query starts the TUI instead. Always pass the question as an argument in this recipe.
+- `--allow-dangerous` is out of scope here. Default is read-only.
+- Do not assert on exact model wording. Assert on the banner, exit code, and the countable fact from `customers`.

--- a/.cursor/skills/verify-sqlsaber/seed.sql
+++ b/.cursor/skills/verify-sqlsaber/seed.sql
@@ -1,0 +1,24 @@
+-- Verification scaffolding: disposable SQLite used by control-sqlsaber launch.
+-- Not part of the product. Cleanup deletes the file with the isolated workdir.
+
+CREATE TABLE customers (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    state TEXT NOT NULL
+);
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    customer_id INTEGER NOT NULL REFERENCES customers (id),
+    amount_cents INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    shipped_at TEXT
+);
+
+INSERT INTO customers (id, name, state) VALUES
+    (1, 'Acme', 'CA'),
+    (2, 'Globex', 'NY');
+
+INSERT INTO orders (id, customer_id, amount_cents, status, shipped_at) VALUES
+    (1, 1, 1999, 'shipped', '2024-01-15'),
+    (2, 2, 5000, 'pending', NULL);


### PR DESCRIPTION
Give agents a HOME-isolated way to drive saber the way a user does, with a feature map and a helper that never touches the operator config or keychain.

## Summary
- Add a project-local `verify-sqlsaber` skill so agents can drive the real `saber` CLI in a disposable HOME, with a null keyring so operator config and credentials are never touched.
- Include `control-sqlsaber` (launch, doctor, cli, tui, cleanup), a seed SQLite schema, and a feature map for database connections, knowledge, one-shot query, interactive TUI, and threads.
- Proof artifacts and run state stay gitignored; database-connections was exercised end to end before this PR.