### PR TITLE
chore: add pstack model mapping as a project rule

### DIFF
--- a/.cursor/rules/pstack-models.mdc
+++ b/.cursor/rules/pstack-models.mdc
@@ -1,0 +1,24 @@
+---
+description: pstack per-role model choices (overrides skill defaults)
+alwaysApply: true
+---
+# pstack model configuration. One line per role. Delete a line to fall back to the skill default.
+# `inherit-parent` or `auto` as a value: the role runs on the parent chat model (omit Task `model`). Alias entries in a panel list still count toward its fan-out.
+feature, refactoring: cursor-grok-4.6-xhigh
+bug-fix: gpt-5.6-sol-max
+perf-issue: gpt-5.6-sol-max
+hillclimb: gpt-5.6-sol-max
+judgment and prose: claude-fable-5-thinking-max
+hardest tasks: claude-fable-5-thinking-max
+how explorer: cursor-grok-4.6-xhigh
+how explainer: claude-fable-5-thinking-max
+how critics: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh, claude-opus-5-thinking-xhigh
+why investigators: cursor-grok-4.6-xhigh
+why synthesizer: claude-fable-5-thinking-max
+reflect tooling: gpt-5.6-sol-max
+reflect judgment, divergent, synthesizer: claude-fable-5-thinking-max
+arena runners: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh, claude-opus-5-thinking-xhigh
+arena cross-judge pool: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh, claude-opus-5-thinking-xhigh
+swarm workers: cursor-grok-4.6-xhigh
+architect runners: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh, claude-opus-5-thinking-xhigh
+interrogate reviewers: claude-fable-5-thinking-max, gpt-5.6-sol-max, cursor-grok-4.6-xhigh, claude-opus-5-thinking-xhigh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `.cursor/rules/pstack-models.mdc` so Cloud Agents load the pstack per-role model mapping from the repo.

`/setup-pstack` writes this file to `~/.cursor/rules` on the current machine. That path does not persist across Cloud Agent VMs and is not injected as a Cursor rule. A committed project rule with `alwaysApply: true` is, so later Cloud sessions on this repo get the same mapping.

## Mapping
- Feature / refactor / how explorer / why investigators / swarm: `cursor-grok-4.6-xhigh`
- Bug-fix / perf / hillclimb / reflect tooling: `gpt-5.6-sol-max`
- Judgment, hardest tasks, how explainer, why synthesizer, reflect judgment: `claude-fable-5-thinking-max`
- Panels (how critics, arena, architect, interrogate): fable-max, sol-max, grok-xhigh, opus-xhigh

## Test plan
- [x] File is committed at `.cursor/rules/pstack-models.mdc` with `alwaysApply: true`
- [x] Role lines match the confirmed `/setup-pstack` defaults
- After merge, a new Cloud Agent should see this rule in workspace context

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c21eac-da8f-4f85-86e0-24be3a664172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c21eac-da8f-4f85-86e0-24be3a664172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

