### PR TITLE
fix(cli): route the PyPI notice through ChatSurface

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -20,7 +20,7 @@ from sqlsaber.cli.onboarding import needs_onboarding, run_onboarding
 from sqlsaber.cli.output import fail, fail_usage, out
 from sqlsaber.cli.theme import create_theme_app
 from sqlsaber.cli.threads import create_threads_app
-from sqlsaber.cli.update_check import schedule_update_check
+from sqlsaber.cli.update_check import bind_update_notice, schedule_update_check
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 
@@ -199,6 +199,9 @@ def query(
             actual_query = sys.stdin.read().strip()
             if not actual_query:
                 actual_query = None
+
+        if actual_query:
+            bind_update_notice(out)
 
         storage = ThreadStorage()
         if thread is not None and actual_query is None:

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -17,6 +17,7 @@ from sqlsaber.cli.tui_chat import (
     build_chat_app,
 )
 from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
+from sqlsaber.cli.update_check import bind_update_notice
 from sqlsaber.cli.usage import SessionUsage, format_cost_usd, format_tokens
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
@@ -413,11 +414,13 @@ class InteractiveSession:
             query_result_store=self.saber.query_result_store,
         )
         self.show_welcome_message(app)
+        bind_update_notice(surface.emit)
 
         app.tui.start()
         try:
             await exit_event.wait()
         finally:
+            bind_update_notice(None)
             if not app.tui.stopped:
                 app.stop()
             await self._finalize_exit()

--- a/src/sqlsaber/cli/update_check.py
+++ b/src/sqlsaber/cli/update_check.py
@@ -5,6 +5,7 @@ This is best-effort and must never fail the CLI.
 
 import asyncio
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import metadata
 
@@ -13,6 +14,7 @@ import httpx
 from sqlsaber.cli.output import out
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
+from sqlsaber.render.blocks import Block
 
 PACKAGE_NAME = "sqlsaber"
 ENV_SKIP_VERSION_CHECK = "SQLSABER_SKIP_VERSION_CHECK"
@@ -20,6 +22,8 @@ PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 
 _LOG = get_logger(__name__)
 _SCHEDULED = False
+_notice_emit: Callable[..., None] | None = None
+_pending_blocks: tuple[Block, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -101,11 +105,39 @@ def _is_newer(latest: str, current: str) -> bool:
         return _parse_version(latest) > _parse_version(current)
 
 
-def _print_update_notice() -> None:
-    out(
-        b.md("A new version is now available!"),
-        b.md(f"Run: `uv tool update {PACKAGE_NAME}`"),
+def _notice_blocks() -> tuple[Block, ...]:
+    return (
+        b.md("A new version is now available!", role="muted"),
+        b.md(f"Run: `uv tool update {PACKAGE_NAME}`", role="muted"),
     )
+
+
+def bind_update_notice(emit: Callable[..., None] | None) -> None:
+    """Route the PyPI notice through ``emit``.
+
+    ``None`` holds a later notice until another bind. Interactive chat
+    binds ``ChatSurface.emit`` so the notice cannot write to stdout after
+    saber-tui owns the terminal.
+
+    Args:
+        emit: Block sink, or None to unbind.
+    """
+
+    global _notice_emit
+    _notice_emit = emit
+
+
+def reset_update_check() -> None:
+    """Clear process-global schedule, sink, and pending notice."""
+
+    global _SCHEDULED, _notice_emit, _pending_blocks
+    _SCHEDULED = False
+    _notice_emit = None
+    _pending_blocks = None
+
+
+def _print_update_notice() -> None:
+    out(*_notice_blocks())
 
 
 async def _check_and_notify() -> None:

--- a/src/sqlsaber/cli/update_check.py
+++ b/src/sqlsaber/cli/update_check.py
@@ -112,14 +112,10 @@ def _notice_blocks() -> tuple[Block, ...]:
 
 
 def bind_update_notice(emit: Callable[..., None] | None) -> None:
-    """Route the PyPI notice through ``emit``.
-
-    ``None`` holds a later notice until another bind. Interactive chat
-    binds ``ChatSurface.emit`` so the notice cannot write to stdout after
-    saber-tui owns the terminal.
+    """Set where an available-update notice goes.
 
     Args:
-        emit: Block sink, or None to unbind.
+        emit: Block sink. ``None`` unbinds and holds a later notice.
     """
 
     global _notice_emit, _pending_blocks
@@ -131,15 +127,13 @@ def bind_update_notice(emit: Callable[..., None] | None) -> None:
 
 
 def reset_update_check() -> None:
-    """Clear process-global schedule, sink, and pending notice."""
-
     global _SCHEDULED, _notice_emit, _pending_blocks
     _SCHEDULED = False
     _notice_emit = None
     _pending_blocks = None
 
 
-def _print_update_notice() -> None:
+def _emit_update_notice() -> None:
     global _pending_blocks
     blocks = _notice_blocks()
     if _notice_emit is not None:
@@ -159,7 +153,7 @@ async def _check_and_notify() -> None:
 
     if _is_newer(latest, current):
         _LOG.info("update_check.available", current=current, latest=latest)
-        _print_update_notice()
+        _emit_update_notice()
 
 
 async def _run_safely() -> None:

--- a/src/sqlsaber/cli/update_check.py
+++ b/src/sqlsaber/cli/update_check.py
@@ -11,7 +11,6 @@ from importlib import metadata
 
 import httpx
 
-from sqlsaber.cli.output import out
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 from sqlsaber.render.blocks import Block
@@ -123,8 +122,12 @@ def bind_update_notice(emit: Callable[..., None] | None) -> None:
         emit: Block sink, or None to unbind.
     """
 
-    global _notice_emit
+    global _notice_emit, _pending_blocks
     _notice_emit = emit
+    if emit is not None and _pending_blocks is not None:
+        blocks = _pending_blocks
+        _pending_blocks = None
+        emit(*blocks)
 
 
 def reset_update_check() -> None:
@@ -137,7 +140,12 @@ def reset_update_check() -> None:
 
 
 def _print_update_notice() -> None:
-    out(*_notice_blocks())
+    global _pending_blocks
+    blocks = _notice_blocks()
+    if _notice_emit is not None:
+        _notice_emit(*blocks)
+        return
+    _pending_blocks = blocks
 
 
 async def _check_and_notify() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,13 @@ from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
 def reset_render_io(capsys):
     """Rebind stdout/stderr surfaces after capsys so CLI emit is captured."""
     del capsys
+    from sqlsaber.cli.update_check import reset_update_check
     from sqlsaber.render import reset_io
 
     reset_io()
+    reset_update_check()
     yield
+    reset_update_check()
 
 
 @pytest.fixture

--- a/tests/test_cli/test_update_check.py
+++ b/tests/test_cli/test_update_check.py
@@ -8,7 +8,7 @@ from sqlsaber.cli.chat_surface import ChatSurface
 from sqlsaber.cli.interactive import InteractiveSession
 from sqlsaber.cli.tui_chat import build_chat_app
 from sqlsaber.cli.update_check import (
-    _print_update_notice,
+    _emit_update_notice,
     bind_update_notice,
 )
 from sqlsaber.render import reset_io
@@ -45,7 +45,7 @@ def test_bound_update_notice_joins_chat_above_editor_and_leaves_footer() -> None
     reset_io(stdout=buf, tty=False)
     bind_update_notice(ChatSurface(app).emit)
 
-    _print_update_notice()
+    _emit_update_notice()
     app.tui.flush_render()
 
     viewport = _viewport(app)
@@ -70,7 +70,7 @@ def test_notice_before_bind_flushes_into_chat_not_stdout() -> None:
     app, buf = _started_chat_app()
     reset_io(stdout=buf, tty=False)
 
-    _print_update_notice()
+    _emit_update_notice()
     assert "A new version is now available!" not in buf.getvalue()
     assert "A new version is now available!" not in _viewport(app)
 
@@ -90,7 +90,7 @@ def test_one_shot_bind_still_prints_to_stdout() -> None:
     buf = StringIO()
     reset_io(stdout=buf, tty=False)
     bind_update_notice(out)
-    _print_update_notice()
+    _emit_update_notice()
     text = buf.getvalue()
     assert "A new version is now available!" in text
     assert "uv tool update sqlsaber" in text

--- a/tests/test_cli/test_update_check.py
+++ b/tests/test_cli/test_update_check.py
@@ -1,0 +1,132 @@
+import asyncio
+from io import StringIO
+
+import pytest
+
+from sqlsaber.cli import interactive as interactive_mod
+from sqlsaber.cli.chat_surface import ChatSurface
+from sqlsaber.cli.interactive import InteractiveSession
+from sqlsaber.cli.tui_chat import build_chat_app
+from sqlsaber.cli.update_check import (
+    _print_update_notice,
+    bind_update_notice,
+)
+from sqlsaber.render import reset_io
+
+from tests.test_cli.test_tui_chat import FakeTerminal, _fake_saber
+
+
+def _started_chat_app() -> tuple:
+    terminal = FakeTerminal(columns=100, rows=24)
+    session = InteractiveSession(_fake_saber())
+    app = build_chat_app(
+        terminal=terminal,
+        on_submit=lambda text: None,
+        footer_text=session._footer_text(),
+    )
+    session.show_welcome_message(app)
+    app.tui.start()
+    app.tui.flush_render()
+    return app, StringIO()
+
+
+def _viewport(app) -> str:
+    return "\n".join(app.render_plain_viewport())
+
+
+def _footer_line(app) -> str:
+    lines = [line for line in app.render_plain_viewport() if "DB:" in line]
+    assert lines
+    return lines[-1]
+
+
+def test_bound_update_notice_joins_chat_above_editor_and_leaves_footer() -> None:
+    app, buf = _started_chat_app()
+    reset_io(stdout=buf, tty=False)
+    bind_update_notice(ChatSurface(app).emit)
+
+    _print_update_notice()
+    app.tui.flush_render()
+
+    viewport = _viewport(app)
+    assert "A new version is now available!" in viewport
+    assert "uv tool update sqlsaber" in viewport
+    assert "A new version is now available!" not in buf.getvalue()
+    assert "uv tool update" not in _footer_line(app)
+    assert "Model: gpt-test" in _footer_line(app)
+
+    lines = app.render_plain_viewport()
+    notice_at = next(
+        i for i, line in enumerate(lines) if "A new version is now available!" in line
+    )
+    editor_rules = [
+        i for i, line in enumerate(lines) if line.strip() and set(line.strip()) <= {"─"}
+    ]
+    assert editor_rules
+    assert notice_at < editor_rules[0]
+
+
+def test_notice_before_bind_flushes_into_chat_not_stdout() -> None:
+    app, buf = _started_chat_app()
+    reset_io(stdout=buf, tty=False)
+
+    _print_update_notice()
+    assert "A new version is now available!" not in buf.getvalue()
+    assert "A new version is now available!" not in _viewport(app)
+
+    bind_update_notice(ChatSurface(app).emit)
+    app.tui.flush_render()
+
+    viewport = _viewport(app)
+    assert "A new version is now available!" in viewport
+    assert "uv tool update sqlsaber" in viewport
+    assert "A new version is now available!" not in buf.getvalue()
+    assert "Model: gpt-test" in _footer_line(app)
+
+
+def test_one_shot_bind_still_prints_to_stdout() -> None:
+    from sqlsaber.cli.output import out
+
+    buf = StringIO()
+    reset_io(stdout=buf, tty=False)
+    bind_update_notice(out)
+    _print_update_notice()
+    text = buf.getvalue()
+    assert "A new version is now available!" in text
+    assert "uv tool update sqlsaber" in text
+
+
+@pytest.mark.asyncio
+async def test_interactive_session_binds_update_notice_before_tui_start(
+    monkeypatch,
+) -> None:
+    bound: list[object] = []
+
+    def fake_bind(emit: object) -> None:
+        bound.append(emit)
+
+    monkeypatch.setattr(interactive_mod, "bind_update_notice", fake_bind, raising=False)
+
+    terminal = FakeTerminal(columns=80, rows=12)
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.log = type("FakeLog", (), {"info": lambda *a, **k: None})()
+    session.saber = _fake_saber(database_names=("test",))
+    session.autocomplete_provider = None
+    session._handoff_mode = False
+    session.current_task = None
+    session._submit_pending = False
+    session._exit_finalized = False
+    session.session_usage = interactive_mod.SessionUsage()
+    session.before_prompt_loop = lambda: asyncio.sleep(0)
+    session._load_history = lambda: []
+    session.show_welcome_message = lambda app: None
+    session._finalize_exit = lambda: asyncio.sleep(0)
+
+    def fake_build_chat_app(**kwargs):
+        app = build_chat_app(terminal=terminal, **kwargs)
+        asyncio.get_running_loop().call_soon(app.stop)
+        return app
+
+    monkeypatch.setattr(interactive_mod, "build_chat_app", fake_build_chat_app)
+    await session.run()
+    assert bound, "InteractiveSession.run must bind the chat surface before tui.start"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Interactive `saber` takes over the terminal with saber-tui. The PyPI update check still called `out()` / `cli_out().emit()` when a newer version was found. That write landed between the editor borders, so the first paint showed `A new version is now available!` in the input slot and `Run: uv tool update sqlsaber` under or inside the footer. A later submit redrew the footer, but leftover lines stayed in the transcript.

This was in 0.72.0 and is still on `main` after #228. That PR made saber-tui the only renderer for CLI output, but the update check kept using the stdout surface.

## Scope

- `bind_update_notice` in `src/sqlsaber/cli/update_check.py` holds the notice until a sink is bound, then emits the muted markdown blocks.
- `InteractiveSession.run` binds `ChatSurface.emit` after the welcome banner and before `tui.start()`, and unbinds on exit.
- One-shot queries bind `out` once `actual_query` is known.
- Tests in `tests/test_cli/test_update_check.py` require the notice above the editor, an intact footer, a pending flush, and the interactive bind.
- `_print_update_notice` is now `_emit_update_notice`. Sermon comments on bind/reset are gone. The pending process-global sink stays; it matches `schedule_update_check`.

## Tradeoffs

The HTTP check still starts at session start so it overlaps agent setup. Interactive mode no longer prints the notice to stdout if the user never reaches ChatApp (failed onboarding). That is better than painting into a TUI.

A typed sink class was rejected. The module already latches with `_SCHEDULED`. Passing `emit` at `schedule_update_check` time cannot work because `ChatSurface` does not exist yet.

## Blast Radius

Interactive first paint when an update is available, and one-shot stdout when an update is available. Other CLI prints are unchanged. `SQLSABER_SKIP_VERSION_CHECK` still skips the fetch.

## Verification

Same delayed `_emit_update_notice` (2.5s after ChatApp start) on the isolated `control-sqlsaber` HOME, tmux 100x32.

Before the fix, the notice sat between the editor rules and `Run: uv tool update sqlsaber` printed under the footer.

After the fix, the notice sits in the chat transcript above the editor. The footer stays `DB: verify-sqlite (SQLite) | Model: gpt-5 | Usage: ↑0 ↓0`. Typing `how many customers` goes into the editor, not into the notice.

- `env -u FORCE_COLOR uv run python -m pytest tests/test_cli/test_update_check.py`: 4 passed after the rename as well.
- `env -u FORCE_COLOR uv run python -m pytest`: 1343 passed, 6 skipped.
- `uvx ty check src/sqlsaber/cli/update_check.py`: clean.
- `time uv run saber --help`: about 0.67s. No new eager import.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b53567-d020-4780-b3bd-7ade547daee4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b53567-d020-4780-b3bd-7ade547daee4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

