### PR TITLE
chore: refresh SQLsaber verification skill

### DIFF
--- a/.pi/skills/verify-sqlsaber/SKILL.md
+++ b/.pi/skills/verify-sqlsaber/SKILL.md
@@ -13,7 +13,7 @@ Read [`features/README.md`](features/README.md) before choosing a recipe.
 
 ## Launch
 
-There is no server to leave running. Launch installs the locked checkout once, creates an isolated run, seeds a three-employee SQLite database, and checks that the CLI version matches `pyproject.toml`.
+There is no server to leave running. Launch installs the locked checkout once, creates an isolated run, seeds a three-employee SQLite database, checks that the CLI version matches `pyproject.toml`, and selects keyring's null backend. The app cannot read or write the operator's keychain.
 
 From the repository root:
 
@@ -41,7 +41,7 @@ Run this read-only check whenever a command behaves unexpectedly:
 "$VERIFY_SQLSABER" doctor "$RUN_ID"
 ```
 
-Require `HEALTHY`. Doctor checks the checkout revision, CLI version, seeded fixture, config/data/log paths, and whether another process is driving this run. It reports which model credential environment variables are present without printing their values. SQLsaber has no port or long-lived process to inspect.
+Require `HEALTHY`. Doctor checks the checkout revision, CLI version, seeded fixture, config/data/log paths, and whether another process is driving this run. It reports the null keyring backend and which model credential environment variables are present without printing their values. SQLsaber has no port or long-lived process to inspect.
 
 `doctor.txt` is written to `.pi/verification/sqlsaber/$RUN_ID/`. A present credential is not proof that the remote provider accepts it. The first real query establishes that.
 
@@ -73,11 +73,28 @@ The transcript records the command, terminal output, and exit code. Use `--timeo
 ```bash
 "$VERIFY_SQLSABER" drive "$RUN_ID" \
   --evidence interactive/exit.txt \
-  --timeout 30 --input $'/exit\r' --input-delay 2 \
+  --timeout 30 --input $'\004' --input-delay 2 \
   -- uv run saber -d "$FIXTURE"
 ```
 
-Do not use fixed input delays for a model response. Use single-shot mode for model-backed proof. The helper's fixed input option is only for deterministic prompt or exit actions.
+For several deterministic TUI actions in one process, pass JSON delay and text pairs. Delays are seconds from process start:
+
+```bash
+"$VERIFY_SQLSABER" drive "$RUN_ID" \
+  --evidence interactive/palette-clear-exit.txt --timeout 30 \
+  --input-sequence '[[2, "/"], [4, "\u001b[B\u001b[B\r"], [6, "\u0004"]]' \
+  -- uv run saber -d "$FIXTURE"
+```
+
+Do not use fixed input delays for a model response. Use single-shot mode for model-backed proof. Fixed input is only for deterministic prompts, controls, and exits.
+
+Redirected output has a separate non-PTY path. It records stdout, stderr, and exit code in one transcript:
+
+```bash
+"$VERIFY_SQLSABER" run "$RUN_ID" \
+  --evidence terminal-output/root-help.txt \
+  -- uv run saber --help
+```
 
 Use the exact commands and expected text in the selected feature file. Stable handles here are command names, flags, printed headings such as `Database Connections`, full IDs, and prompt strings. Do not assert terminal coordinates or color codes.
 
@@ -87,7 +104,7 @@ Proof belongs under `.pi/verification/sqlsaber/$RUN_ID/`. The helper creates tha
 
 A valid proof:
 
-- drives `uv run saber` through the PTY helper, not a Python function or test fixture;
+- drives `uv run saber` through `drive` for a terminal or `run` for redirected output, not a Python function or test fixture;
 - captures the user command and its immediate output in one transcript;
 - captures a second user-facing read after a mutation, such as `saber db list`, `saber knowledge show`, or `saber threads show`;
 - copies or queries the isolated persisted file when the feature has a side effect;
@@ -118,19 +135,20 @@ test -f ".pi/verification/sqlsaber/$RUN_ID/launch.txt"
 test -f ".pi/verification/sqlsaber/$RUN_ID/cleanup.txt"
 ```
 
-The helper records the exact active PID while a PTY is running. Cleanup will only signal that PID when its environment carries this run's marker. It never kills by process name. It removes the isolated home, fixture, app logs, and PID record. It preserves all proof artifacts.
+The helper records the exact active process leader. Cleanup verifies that leader's environment carries this run's marker, then signals its process group so descendants stop too. It never kills by process name. It removes the isolated home, fixture, app logs, and PID record. It preserves all proof artifacts.
 
 Do not remove `.pi/verification/sqlsaber/$RUN_ID/` during cleanup. If you created exports as part of a feature, write them inside that evidence directory before teardown.
 
 ## Helpers
 
-`.pi/skills/verify-sqlsaber/bin/verify-sqlsaber` is executable and has five commands:
+`.pi/skills/verify-sqlsaber/bin/verify-sqlsaber` is executable and has six commands:
 
 ```text
 verify-sqlsaber launch RUN_ID
 verify-sqlsaber doctor RUN_ID
-verify-sqlsaber drive RUN_ID --evidence RELATIVE_PATH [--timeout SECONDS] [--input TEXT] -- COMMAND...
-verify-sqlsaber path RUN_ID {state,evidence,fixture,database-config,knowledge-db,threads-db,log}
+verify-sqlsaber drive RUN_ID --evidence RELATIVE_PATH [--timeout SECONDS] [--input TEXT [--input-delay SECONDS] | --input-sequence JSON] -- COMMAND...
+verify-sqlsaber run RUN_ID --evidence RELATIVE_PATH [--timeout SECONDS] -- COMMAND...
+verify-sqlsaber path RUN_ID {state,evidence,fixture,database-config,auth-config,model-config,theme-config,knowledge-db,threads-db,log}
 verify-sqlsaber cleanup RUN_ID
 ```
 

--- a/.pi/skills/verify-sqlsaber/bin/verify-sqlsaber
+++ b/.pi/skills/verify-sqlsaber/bin/verify-sqlsaber
@@ -7,6 +7,7 @@ import argparse
 import datetime as dt
 import fcntl
 import json
+import math
 import os
 import pty
 import re
@@ -20,7 +21,9 @@ import sys
 import termios
 import time
 import tomllib
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 ROOT = Path(__file__).resolve().parents[4]
 BASE = ROOT / ".pi" / "verification" / "sqlsaber"
@@ -76,7 +79,11 @@ def git_revision() -> str:
 def run_env(run_id: str) -> dict[str, str]:
     state = state_dir(run_id)
     home = state / "home"
-    env = os.environ.copy()
+    env = {
+        name: value
+        for name, value in os.environ.items()
+        if not name.startswith("SQLSABER_")
+    }
     env.update(
         {
             "HOME": str(home),
@@ -87,6 +94,7 @@ def run_env(run_id: str) -> dict[str, str]:
             "SQLSABER_LOG_FILE": str(state / "sqlsaber.log"),
             "SQLSABER_SKIP_VERSION_CHECK": "1",
             "SQLSABER_VERIFY_RUN_ID": run_id,
+            "PYTHON_KEYRING_BACKEND": "keyring.backends.null.Keyring",
             "NO_COLOR": "1",
             "TERM": "xterm-256color",
             "UV_NO_PROGRESS": "1",
@@ -151,15 +159,14 @@ def launch(run_id: str) -> None:
             f"Run {run_id!r} already exists. Use a new RUN_ID so proof cannot mix."
         )
 
-    state.mkdir(parents=True)
-    evidence.mkdir(parents=True)
-    for name in ("config", "data", "cache", "state"):
-        (state / "home" / name).mkdir(parents=True)
-
-    fixture = state / "fixtures" / "verification.db"
-    seed_fixture(fixture)
-
     try:
+        state.mkdir(parents=True)
+        evidence.mkdir(parents=True)
+        for name in ("config", "data", "cache", "state"):
+            (state / "home" / name).mkdir(parents=True)
+
+        fixture = state / "fixtures" / "verification.db"
+        seed_fixture(fixture)
         subprocess.run(["uv", "sync", "--locked"], cwd=ROOT, check=True)
         expected = project_version()
         actual = command_output(["uv", "run", "saber", "--version"], run_id)
@@ -194,6 +201,7 @@ def launch(run_id: str) -> None:
         print(f"evidence: {evidence}")
     except BaseException:
         shutil.rmtree(state, ignore_errors=True)
+        shutil.rmtree(evidence, ignore_errors=True)
         raise
 
 
@@ -240,15 +248,20 @@ def doctor(run_id: str) -> None:
             errors.append(f"{kind} path escapes run state: {path}")
 
     active_path = state / "active.json"
-    if active_path.exists():
-        active = json.loads(active_path.read_text(encoding="utf-8"))
-        pid = int(active["pid"])
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            active_path.unlink(missing_ok=True)
-        else:
-            errors.append(f"run is already being driven by PID {pid}")
+    with run_lock(state):
+        if active_lock_path(active_path).exists():
+            try:
+                active = json.loads(active_path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                release_active(active_path)
+            else:
+                pid = int(active["pid"])
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    release_active(active_path)
+                else:
+                    errors.append(f"run is already being driven by PID {pid}")
 
     credential_names = [
         name
@@ -258,8 +271,8 @@ def doctor(run_id: str) -> None:
             "GOOGLE_API_KEY",
             "GROQ_API_KEY",
             "MISTRAL_API_KEY",
-            "CO_API_KEY",
-            "HF_TOKEN",
+            "COHERE_API_KEY",
+            "HUGGINGFACE_API_KEY",
         )
         if os.getenv(name)
     ]
@@ -272,6 +285,7 @@ def doctor(run_id: str) -> None:
         f"data root: {paths['data']}",
         f"log root: {paths['log']}",
         "server: not applicable; each SQLsaber command is a short-lived process",
+        "keyring backend: keyring.backends.null.Keyring",
         "model credentials present: "
         + (", ".join(credential_names) if credential_names else "none"),
     ]
@@ -313,13 +327,95 @@ def terminate_process_group(pid: int) -> None:
         pass
 
 
+def command_text(command: list[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in command)
+
+
+@contextmanager
+def run_lock(state: Path) -> Iterator[None]:
+    lock_path = state / "run.lock"
+    with lock_path.open("a", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def atomic_write(path: Path, text: str) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as file:
+            file.write(text)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_new(path: Path, text: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8") as file:
+            file.write(text)
+    except FileExistsError:
+        raise SystemExit(
+            f"Evidence path already exists: {path}. Use a new evidence name."
+        ) from None
+
+
+def active_lock_path(active_path: Path) -> Path:
+    return active_path.with_name("active.lock")
+
+
+def reserve_active(active_path: Path, command: list[str]) -> None:
+    lock_path = active_lock_path(active_path)
+    try:
+        fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        raise SystemExit(
+            "This RUN_ID already has an active command. Run doctor or cleanup."
+        ) from None
+    os.close(fd)
+    try:
+        write_active(active_path, os.getpid(), command, starting=True)
+    except BaseException:
+        lock_path.unlink(missing_ok=True)
+        raise
+
+
+def write_active(
+    active_path: Path, pid: int, command: list[str], *, starting: bool = False
+) -> None:
+    payload = {"pid": pid, "command": command}
+    if starting:
+        payload["starting"] = True
+    atomic_write(active_path, json.dumps(payload) + "\n")
+
+
+def release_active(active_path: Path) -> None:
+    active_path.unlink(missing_ok=True)
+    active_lock_path(active_path).unlink(missing_ok=True)
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a finite number greater than zero")
+    return parsed
+
+
+def nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("must be a finite non-negative number")
+    return parsed
+
+
 def drive(
     run_id: str,
     evidence_name: str,
     command: list[str],
     timeout: float,
-    input_text: str | None,
-    input_delay: float,
+    input_events: list[tuple[float, str]],
 ) -> None:
     load_metadata(run_id)
     if command and command[0] == "--":
@@ -332,40 +428,58 @@ def drive(
         raise SystemExit("--evidence must be a relative path without '..'")
     output_path = evidence_dir(run_id) / relative
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        raise SystemExit(
+            f"Evidence path already exists: {output_path}. Use a new evidence name."
+        )
 
     state = state_dir(run_id)
     active_path = state / "active.json"
-    if active_path.exists():
-        raise SystemExit(
-            "This RUN_ID already has an active drive. Run doctor or cleanup."
-        )
+    with run_lock(state):
+        reserve_active(active_path, command)
+        try:
+            pid, master_fd = pty.fork()
+        except BaseException:
+            release_active(active_path)
+            raise
+        if pid == 0:
+            try:
+                os.chdir(ROOT)
+                os.execvpe(command[0], command, run_env(run_id))
+            except BaseException as exc:
+                os.write(
+                    sys.stderr.fileno(), f"failed to start command: {exc}\n".encode()
+                )
+                os._exit(127)
 
-    pid, master_fd = pty.fork()
-    if pid == 0:
-        os.chdir(ROOT)
-        os.execvpe(command[0], command, run_env(run_id))
-
-    winsize = struct.pack("HHHH", 40, 120, 0, 0)
-    fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
-    active_path.write_text(
-        json.dumps({"pid": pid, "command": command}) + "\n", encoding="utf-8"
-    )
+        try:
+            winsize = struct.pack("HHHH", 40, 120, 0, 0)
+            fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
+            write_active(active_path, pid, command)
+        except BaseException:
+            terminate_process_group(pid)
+            release_active(active_path)
+            os.close(master_fd)
+            raise
 
     started = dt.datetime.now(dt.UTC).isoformat()
     chunks: list[bytes] = []
-    deadline = time.monotonic() + timeout
-    send_at = time.monotonic() + input_delay if input_text is not None else None
-    sent = input_text is None
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    pending_events = list(input_events)
     status: int | None = None
+    timed_out = False
+    interrupted: BaseException | None = None
     try:
         while True:
             now = time.monotonic()
-            if not sent and send_at is not None and now >= send_at:
-                os.write(master_fd, input_text.encode())
-                sent = True
+            while pending_events and now - started_at >= pending_events[0][0]:
+                _, text = pending_events.pop(0)
+                os.write(master_fd, text.encode())
             if now >= deadline:
+                timed_out = True
                 terminate_process_group(pid)
-                raise TimeoutError(f"command exceeded {timeout:g} seconds")
+                break
 
             readable, _, _ = select.select([master_fd], [], [], 0.1)
             if readable:
@@ -393,30 +507,160 @@ def drive(
                     chunks.append(data)
                     os.write(sys.stdout.fileno(), data)
                 break
-    except BaseException:
+    except BaseException as exc:
+        interrupted = exc
         terminate_process_group(pid)
-        raise
     finally:
-        active_path.unlink(missing_ok=True)
+        release_active(active_path)
         os.close(master_fd)
 
-    assert status is not None
-    exit_code = os.waitstatus_to_exitcode(status)
-    command_text = " ".join(subprocess.list2cmdline([part]) for part in command)
+    if timed_out:
+        exit_code = 124
+    elif interrupted is not None:
+        exit_code = 130 if isinstance(interrupted, KeyboardInterrupt) else 1
+    else:
+        assert status is not None
+        exit_code = os.waitstatus_to_exitcode(status)
     body = b"".join(chunks).decode("utf-8", errors="replace")
     transcript = (
         f"run_id: {run_id}\n"
         f"started_at: {started}\n"
-        f"command: {command_text}\n"
+        f"command: {command_text(command)}\n"
         "--- terminal output ---\n"
         f"{clean_terminal(body)}"
         "--- result ---\n"
         f"exit_code: {exit_code}\n"
+        f"timed_out: {str(timed_out).lower()}\n"
+        f"interrupted: {str(interrupted is not None).lower()}\n"
     )
-    output_path.write_text(transcript, encoding="utf-8")
+    write_new(output_path, transcript)
+    if interrupted is not None:
+        raise interrupted
     print(f"\nproof: {output_path}")
+    if timed_out:
+        raise TimeoutError(f"command exceeded {timeout:g} seconds")
     if exit_code != 0:
         raise SystemExit(exit_code)
+
+
+def stop_popen(process: subprocess.Popen[bytes]) -> tuple[bytes, bytes]:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        return process.communicate(timeout=3)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        return process.communicate()
+
+
+def with_trailing_newline(text: str) -> str:
+    return text if not text or text.endswith("\n") else text + "\n"
+
+
+def run_non_tty(
+    run_id: str,
+    evidence_name: str,
+    command: list[str],
+    timeout: float,
+) -> None:
+    load_metadata(run_id)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        raise SystemExit("run requires a command after --")
+
+    relative = Path(evidence_name)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise SystemExit("--evidence must be a relative path without '..'")
+    output_path = evidence_dir(run_id) / relative
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        raise SystemExit(
+            f"Evidence path already exists: {output_path}. Use a new evidence name."
+        )
+
+    state = state_dir(run_id)
+    active_path = state / "active.json"
+    with run_lock(state):
+        reserve_active(active_path, command)
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=ROOT,
+                env=run_env(run_id),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+            write_active(active_path, process.pid, command)
+        except BaseException:
+            release_active(active_path)
+            raise
+    started = dt.datetime.now(dt.UTC).isoformat()
+    timed_out = False
+    interrupted: BaseException | None = None
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        stdout, stderr = stop_popen(process)
+    except BaseException as exc:
+        interrupted = exc
+        stdout, stderr = stop_popen(process)
+    finally:
+        release_active(active_path)
+
+    stdout_text = stdout.decode("utf-8", errors="replace")
+    stderr_text = stderr.decode("utf-8", errors="replace")
+    transcript = (
+        f"run_id: {run_id}\n"
+        f"started_at: {started}\n"
+        f"command: {command_text(command)}\n"
+        "--- stdout ---\n"
+        f"{with_trailing_newline(stdout_text)}"
+        "--- stderr ---\n"
+        f"{with_trailing_newline(stderr_text)}"
+        "--- result ---\n"
+        f"exit_code: {process.returncode}\n"
+        f"timed_out: {str(timed_out).lower()}\n"
+        f"interrupted: {str(interrupted is not None).lower()}\n"
+    )
+    write_new(output_path, transcript)
+    if stdout:
+        os.write(sys.stdout.fileno(), stdout)
+    if stderr:
+        os.write(sys.stderr.fileno(), stderr)
+    print(f"\nproof: {output_path}")
+    if timed_out:
+        raise TimeoutError(f"command exceeded {timeout:g} seconds")
+    if interrupted is not None:
+        raise interrupted
+    if process.returncode != 0:
+        raise SystemExit(process.returncode)
+
+
+def parse_input_events(args: argparse.Namespace) -> list[tuple[float, str]]:
+    if args.input is not None and args.input_sequence is not None:
+        raise SystemExit("use only one of --input or --input-sequence")
+    if args.input_sequence is None:
+        return [] if args.input is None else [(args.input_delay, args.input)]
+    try:
+        raw_events = json.loads(args.input_sequence)
+        events = [(float(delay), str(text)) for delay, text in raw_events]
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            "--input-sequence must be JSON pairs such as "
+            '\'[[2, "/clear\\r"], [4, "/exit\\r"]]\''
+        ) from exc
+    if any(not math.isfinite(delay) or delay < 0 for delay, _ in events):
+        raise SystemExit("--input-sequence delays must be finite and non-negative")
+    return sorted(events, key=lambda event: event[0])
 
 
 def path_value(run_id: str, name: str) -> None:
@@ -430,6 +674,21 @@ def path_value(run_id: str, name: str) -> None:
         / "config"
         / "sqlsaber"
         / "database_config.json",
+        "auth-config": state_dir(run_id)
+        / "home"
+        / "config"
+        / "sqlsaber"
+        / "auth_config.json",
+        "model-config": state_dir(run_id)
+        / "home"
+        / "config"
+        / "sqlsaber"
+        / "model_config.json",
+        "theme-config": state_dir(run_id)
+        / "home"
+        / "config"
+        / "sqlsaber"
+        / "theme.json",
         "knowledge-db": state_dir(run_id)
         / "home"
         / "data"
@@ -445,35 +704,45 @@ def cleanup(run_id: str) -> None:
     validate_run_id(run_id)
     state = state_dir(run_id)
     evidence = evidence_dir(run_id)
-    evidence.mkdir(parents=True, exist_ok=True)
-    active_path = state / "active.json"
-    if active_path.exists():
-        active = json.loads(active_path.read_text(encoding="utf-8"))
-        pid = int(active["pid"])
-        try:
-            process = subprocess.run(
-                ["ps", "eww", "-p", str(pid), "-o", "command="],
-                check=False,
-                capture_output=True,
-                text=True,
-            ).stdout
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            active_path.unlink(missing_ok=True)
-        else:
-            marker = f"SQLSABER_VERIFY_RUN_ID={run_id}"
-            if marker not in process:
-                raise SystemExit(
-                    f"Refusing to kill PID {pid}: it does not carry this run marker"
-                )
-            os.killpg(pid, signal.SIGTERM)
-            time.sleep(0.5)
-            try:
-                os.killpg(pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+    if not state.exists() and not evidence.exists():
+        raise SystemExit(f"Run {run_id!r} does not exist; refusing cleanup.")
 
-    shutil.rmtree(state, ignore_errors=True)
+    if state.exists():
+        with run_lock(state):
+            active_path = state / "active.json"
+            if active_lock_path(active_path).exists():
+                try:
+                    active = json.loads(active_path.read_text(encoding="utf-8"))
+                except FileNotFoundError:
+                    release_active(active_path)
+                else:
+                    pid = int(active["pid"])
+                    try:
+                        process = subprocess.run(
+                            ["ps", "eww", "-p", str(pid), "-o", "command="],
+                            check=False,
+                            capture_output=True,
+                            text=True,
+                        ).stdout
+                        os.kill(pid, 0)
+                    except ProcessLookupError:
+                        release_active(active_path)
+                    else:
+                        marker = f"SQLSABER_VERIFY_RUN_ID={run_id}"
+                        if marker not in process:
+                            raise SystemExit(
+                                f"Refusing to kill PID {pid}: it does not carry this run marker"
+                            )
+                        os.killpg(pid, signal.SIGTERM)
+                        time.sleep(0.5)
+                        try:
+                            os.killpg(pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                        release_active(active_path)
+            shutil.rmtree(state, ignore_errors=True)
+
+    evidence.mkdir(parents=True, exist_ok=True)
     record = (
         f"cleaned_at={dt.datetime.now(dt.UTC).isoformat()}\n"
         f"removed_state={state}\n"
@@ -501,6 +770,9 @@ def build_parser() -> argparse.ArgumentParser:
             "evidence",
             "fixture",
             "database-config",
+            "auth-config",
+            "model-config",
+            "theme-config",
             "knowledge-db",
             "threads-db",
             "log",
@@ -510,10 +782,17 @@ def build_parser() -> argparse.ArgumentParser:
     drive_parser = subparsers.add_parser("drive")
     drive_parser.add_argument("run_id")
     drive_parser.add_argument("--evidence", required=True)
-    drive_parser.add_argument("--timeout", type=float, default=60)
+    drive_parser.add_argument("--timeout", type=positive_float, default=60)
     drive_parser.add_argument("--input")
-    drive_parser.add_argument("--input-delay", type=float, default=1.5)
+    drive_parser.add_argument("--input-delay", type=nonnegative_float, default=1.5)
+    drive_parser.add_argument("--input-sequence")
     drive_parser.add_argument("command", nargs="+")
+
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("run_id")
+    run_parser.add_argument("--evidence", required=True)
+    run_parser.add_argument("--timeout", type=positive_float, default=60)
+    run_parser.add_argument("command", nargs="+")
     return parser
 
 
@@ -529,9 +808,10 @@ def main() -> None:
             args.evidence,
             args.command,
             args.timeout,
-            args.input,
-            args.input_delay,
+            parse_input_events(args),
         )
+    elif args.action == "run":
+        run_non_tty(args.run_id, args.evidence, args.command, args.timeout)
     elif args.action == "path":
         path_value(args.run_id, args.name)
     elif args.action == "cleanup":

--- a/.pi/skills/verify-sqlsaber/features/README.md
+++ b/.pi/skills/verify-sqlsaber/features/README.md
@@ -10,11 +10,12 @@ This directory tracks SQLsaber behavior that a user can reach from the terminal.
 - Use the fixture returned by `verify-sqlsaber path "$RUN_ID" fixture`.
 - Keep app state under `.pi/verification/sqlsaber/.state/$RUN_ID/` and proof under `.pi/verification/sqlsaber/$RUN_ID/`.
 - Use a different `RUN_ID` for every concurrent agent. Never point the helper at the user's normal config or data directories.
-- A model-backed query also requires a provider credential in the environment and a matching model selected inside the isolated run.
+- The helper uses `keyring.backends.null.Keyring`, so verification cannot read or write the operator's OS keyring. Driven commands still inherit provider credentials from the coordinator environment.
+- A model-backed query requires one of those environment credentials and a matching model selected inside the isolated run.
 
 ## Driving conventions
 
-- Run every `saber` command through `verify-sqlsaber drive` so it gets an isolated PTY and transcript.
+- Run terminal commands through `verify-sqlsaber drive`. Use `verify-sqlsaber run` only when the recipe calls for redirected, non-TTY output.
 - Start a stateful recipe from a new run unless the recipe says otherwise.
 - Treat command names, option names, full IDs, headings, and prompt text as stable handles. Ignore colors and terminal coordinates.
 - Use `--yes` only after the recipe has identified the exact isolated object to delete.
@@ -38,7 +39,13 @@ Each feature file has an H1 title and one user-focused summary. It then uses fou
 ## Features
 
 - [Command discovery](./command-discovery.md) covers version output, root help, and command-specific help.
-- [Query databases](./query-databases.md) covers single-shot questions, stdin, file selectors, multiple databases, and the terminal UI.
+- [First-run onboarding](./first-run-onboarding.md) covers the guided setup route when no database is configured.
 - [Database connections](./database-connections.md) covers adding, listing, testing, editing, selecting, and removing saved connections.
-- [Knowledge base](./knowledge-base.md) covers database-scoped add, list, show, search, remove, and clear behavior.
-- [Conversation threads](./conversation-threads.md) covers thread listing, transcript display, artifacts, resume, export, and pruning.
+- [Authentication](./authentication.md) covers provider setup, status, and stored-key reset.
+- [Model configuration](./model-configuration.md) covers model selection, thinking levels, per-agent overrides, current state, and reset.
+- [Themes](./themes.md) covers named and interactive theme selection, persistence, and reset.
+- [Query databases](./query-databases.md) covers single-shot questions, stdin, file selectors, multiple databases, and write safety.
+- [Interactive session](./interactive-session.md) covers the terminal UI, palette, slash commands, and exits.
+- [Knowledge base](./knowledge-base.md) covers database-scoped add, list, show, search, remove, clear, and agent retrieval.
+- [Conversation threads](./conversation-threads.md) covers empty and populated listing, transcript display, artifacts, resume, export, and pruning.
+- [Terminal output](./terminal-output.md) covers redirected Markdown, stream separation, and ANSI-free output.

--- a/.pi/skills/verify-sqlsaber/features/authentication.md
+++ b/.pi/skills/verify-sqlsaber/features/authentication.md
@@ -1,0 +1,35 @@
+# Authentication
+
+Authentication commands let a user configure provider API keys, inspect which providers are available through environment variables or stored credentials, and remove a stored key.
+
+## Sub-features
+
+- `auth-setup` selects a provider and stores an entered API key in the operating-system keyring.
+- `auth-status` reports whether API-key authentication is configured and where each available provider key comes from.
+- `auth-reset` removes one stored provider key after confirmation and leaves environment variables unchanged.
+
+## How to get to it (user POV)
+
+- Run `saber auth setup` in a terminal.
+- Run `saber auth status`.
+- Run `saber auth reset [PROVIDER]`, with `--yes` for deliberate automation.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY` and `keyring backend: keyring.backends.null.Keyring`.
+- Never type a real API key into a transcript.
+
+- **Fresh status.** Capture `saber auth status`. A fresh run prints `Authentication Status`, says no method is configured, and points to `saber auth setup`.
+- **Environment status.** If a provider credential is already present in the coordinator environment, create only the isolated non-secret auth method marker through the normal setup path, then capture status. It names the corresponding environment variable without printing its value.
+- **Reset without stored credentials.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence authentication/reset-empty.txt -- uv run saber auth reset openai --yes`. With the null keyring it exits `0` and says no stored credentials were found. This proves the no-op route, not credential deletion.
+- **Setup route.** Start `saber auth setup` through `drive`, cancel at the provider or key prompt, and retain the transcript. Key storage and the corresponding destructive reset are `verified-unreachable` in this harness because the null backend deliberately blocks any persistent keyring. Their concrete prerequisite is a disposable credential store with a seeded test key; never use the operator's OS keyring.
+
+## Gotchas
+
+- Environment variables take precedence over keyring values.
+- Status reports provider availability only after an authentication method has been configured.
+- `auth reset` never changes environment variables.
+- Without an explicit provider, reset opens an interactive selector and fails usage when stdin is not a terminal.
+- The verification harness uses a null keyring to protect the operator's credentials. Do not weaken that isolation to make setup pass.

--- a/.pi/skills/verify-sqlsaber/features/conversation-threads.md
+++ b/.pi/skills/verify-sqlsaber/features/conversation-threads.md
@@ -1,45 +1,49 @@
 # Conversation threads
 
-Conversation threads let a user find saved query sessions, read complete transcripts, inspect durable artifacts, resume context, export HTML, and prune old history.
+Conversation threads let a user find saved query sessions, read complete transcripts, inspect durable artifacts, resume context, export HTML, and preview or perform retention cleanup.
 
 ## Sub-features
 
+- `threads-list-empty` reports an empty store before any query runs.
 - `threads-list-show` lists retained sessions and renders one transcript by full ID.
 - `threads-artifacts` lists durable outputs referenced by a thread.
 - `threads-resume` reopens a thread in the terminal UI or continues it with root `--thread`.
-- `threads-export` writes a standalone HTML transcript.
-- `threads-prune` previews or deletes threads older than a chosen age.
+- `threads-export` writes an HTML transcript whose core text is embedded in the file.
+- `threads-prune-preview` reports eligible old threads without deleting them.
+- `threads-prune-delete` deletes eligible old threads after confirmation; completed sessions also remove threads older than 30 days.
 
 ## How to get to it (user POV)
 
-- Finish a single-shot query, then run `saber threads list` and `saber threads show ID`.
+- Run `saber threads list` before or after a single-shot query, then `saber threads show ID`.
 - Run `saber threads artifacts ID` to inspect retained output references.
-- Run `saber threads resume ID` for the terminal UI or `saber --thread ID "FOLLOW-UP"` for one automated follow-up.
-- Run `saber threads export ID --output FILE` to create HTML.
+- Run `saber threads resume ID` or `saber --thread ID "FOLLOW-UP"`.
+- Run `saber threads export ID --output FILE`.
 - Run `saber threads prune --days N --dry-run` before deliberate deletion with `--yes`.
 
 ## Driving it with verify-sqlsaber
 
 Preconditions:
 
-- Doctor reports `HEALTHY` and a real model-backed query has completed in this run.
-- The query transcript contains a full continuation thread ID for database `verification`.
-- `THREAD_ID` holds that full ID, and the saved database remains configured.
+- Doctor reports `HEALTHY`.
+- Populated-thread entries require a completed real model query against a saved connection named `verification`.
+- `THREAD_ID` holds the full UUID from that query.
 
-- **List entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/list.txt -- uv run saber threads list --database verification --limit 10`. The `Threads` table contains `THREAD_ID`, database `verification`, a title, activity time, and model.
-- **Show entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/show.txt -- uv run saber threads show "$THREAD_ID"`. The output includes thread metadata, the original user question, assistant answer, and SQL/tool details.
-- **Artifacts entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/artifacts.txt -- uv run saber threads artifacts "$THREAD_ID"`. A thread without publications prints `No artifacts found.`. If the query published an artifact, require publication ID, kind, name, size, URI, and no unexpected `unavailable` marker.
-- **Interactive resume.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input $'/exit\r' --input-delay 2 --evidence threads/resume-exit.txt -- uv run saber threads resume "$THREAD_ID"`. It renders prior context, enters the terminal UI, accepts `/exit`, and prints `Goodbye!`.
-- **Non-interactive follow-up.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence threads/follow-up.txt -- uv run saber --thread "$THREAD_ID" "Repeat the prior answer as an integer only."`. The command uses saved history, returns a database-backed answer, and keeps the same retained context.
-- **HTML export.** Set `EXPORT=$("$VERIFY_SQLSABER" path "$RUN_ID" evidence)/threads/thread.html`, then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/export.txt -- uv run saber threads export "$THREAD_ID" --output "$EXPORT"`. The HTML remains under evidence, contains `THREAD_ID` and visible transcript text, and opens without external app assets.
-- **Prune preview.** Copy the thread database, count `threads` rows, run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/prune-dry-run.txt -- uv run saber threads prune --days 1 --dry-run`, then copy and count again. Counts and thread IDs must match. This proves the preview did not delete state.
-- **Persisted proof.** Run `THREADS_DB=$("$VERIFY_SQLSABER" path "$RUN_ID" threads-db)`, copy it into the feature evidence directory, and query the copied `threads` table in read-only mode. Its full IDs, database names, and message presence must match `list` and `show`.
+- **Empty list.** Immediately after launch, capture `saber threads list`. It exits `0` and prints `No threads found.`. This remains valid when model credentials are absent.
+- **List and show.** After the query, list with `--database verification --limit 10`, then show the full ID. Require database, title, model, original question, answer, and SQL or tool details.
+- **Artifacts.** Run `threads artifacts "$THREAD_ID"`. A thread without publications prints `No artifacts found.`. Published output includes publication ID and kind, artifact kind, name, size, URI, and availability.
+- **Resume.** Start `threads resume "$THREAD_ID"` through `drive`, send Ctrl+D on the empty editor, and require prior context plus `Goodbye!`. Continue once with root `--thread "$THREAD_ID" "Repeat the prior answer as an integer only."`; then show the thread again and require both turns. Root `--thread` without a question is an expected usage error.
+- **HTML export.** Export to `$("$VERIFY_SQLSABER" path "$RUN_ID" evidence)/threads/thread.html`. Require the thread ID and visible transcript text in the saved file.
+- **Prune preview.** This needs at least one thread older than the selected age. Copy the thread database and record full IDs plus the eligible count, then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence threads/prune-dry-run.txt -- uv run saber threads prune --days 1 --dry-run`. Require its count to match the eligible rows. Capture another list and database copy; every ID and count remains unchanged. A store with no eligible row proves only that the command starts, not dry-run safety.
+- **Prune deletion.** In a separate isolated run with a genuinely old thread, preview first, then run the same command with `--yes`. Require the eligible ID to disappear from both `threads list` and a copied database while newer IDs remain. Do not edit timestamps to manufacture eligibility. If no old thread exists, record the age prerequisite as unreachable.
+- **Automatic retention.** With a thread older than 30 days, complete any query session and require that old ID to disappear while recent IDs remain. This entry needs both an old thread and a working provider credential.
+- **Persisted proof.** Copy `THREADS_DB=$("$VERIFY_SQLSABER" path "$RUN_ID" threads-db)` into evidence before cleanup, then run `uv run python - "$EVIDENCE/threads/threads.db"` with `sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)`. Record full IDs, database names, creation times, and message presence; they must match list and show.
 
 ## Gotchas
 
-- Thread IDs must be complete UUIDs. Terminal width should not be used as a reason to copy a truncated value.
-- Automatic resume requires saved database selectors. Threads created from an ad hoc path need an explicit repeated `-d` override.
-- `threads show` may mark expired query results or artifacts unavailable. Record that state instead of silently omitting it.
-- `--dry-run` is proven only when the copied thread database has identical rows before and after.
-- `threads prune --yes` also runs durable result and artifact cleanup. Never test deletion against the user's thread store.
-- Export output defaults to the current directory. Always pass an evidence path so cleanup cannot remove it.
+- Thread IDs must be complete UUIDs.
+- Automatic resume trusts saved database selectors. Ad hoc paths need an explicit repeated `-d` override.
+- `threads show` can mark expired query results or artifacts unavailable. Record that state.
+- `--days` must be at least 1.
+- `threads prune --yes` also cleans durable results and artifacts. Never test deletion against the user's store.
+- Export defaults to the current directory. Always pass an evidence path.
+- The HTML embeds transcript data and layout, but fonts, Markdown rendering, and syntax highlighting load from external CDNs. Do not claim the enhanced rendering is fully offline.

--- a/.pi/skills/verify-sqlsaber/features/database-connections.md
+++ b/.pi/skills/verify-sqlsaber/features/database-connections.md
@@ -4,18 +4,19 @@ Database connection commands let a user save named databases, inspect and test t
 
 ## Sub-features
 
-- `db-add-interactive` collects connection details in a terminal prompt.
-- `db-add-noninteractive` saves a fully specified SQLite, DuckDB, PostgreSQL, or MySQL connection.
-- `db-list-test` lists saved details and opens the selected database for a health query.
-- `db-exclude` reads or changes excluded schemas.
+- `db-add-interactive` collects connection details in terminal prompts.
+- `db-add-noninteractive` saves a fully specified SQLite, DuckDB, PostgreSQL, or MySQL connection, including an optional description.
+- `db-list-test` lists saved details and tests either a named connection or the default with a health query.
+- `db-exclude` replaces, adds, removes, clears, or interactively edits excluded schemas.
 - `db-default` chooses the connection used when `-d` is omitted.
 - `db-remove` confirms deletion or accepts deliberate `--yes` automation.
 
 ## How to get to it (user POV)
 
 - Run `saber db add NAME` for prompted setup.
-- Run `saber db add NAME --type sqlite --database FILE --no-interactive` for scripted local setup.
-- Run `saber db list`, `saber db test NAME`, or `saber db exclude NAME` to inspect a connection.
+- Run `saber db add NAME --type sqlite --database FILE --description TEXT --no-interactive` for scripted local setup.
+- Run `saber db list` or `saber db test [NAME]` to inspect and test connections.
+- Run `saber db exclude NAME --set LIST`, `--add LIST`, `--remove LIST`, or `--clear`. With no action flag, SQLsaber opens an editor and saves the response.
 - Run `saber db set-default NAME` or `saber db remove NAME` to change saved state.
 
 ## Driving it with verify-sqlsaber
@@ -26,19 +27,18 @@ Preconditions:
 - `FIXTURE=$("$VERIFY_SQLSABER" path "$RUN_ID" fixture)` points to the seeded SQLite file.
 - The isolated run has no saved connection named `verification` or `secondary`.
 
-- **Non-interactive add.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/add.txt -- uv run saber db add verification --type sqlite --database "$FIXTURE" --no-interactive`. Output confirms the add and says `verification` became the default.
-- **List read-back.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/list.txt -- uv run saber db list`. The `Database Connections` table contains `verification`, `sqlite`, the fixture path, and a default check mark.
-- **Connection test.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/test.txt -- uv run saber db test verification`. Output says `Connection to 'verification' successful` and exits `0`.
-- **Exclusions.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/exclude.txt -- uv run saber db exclude verification --set temp,audit`. A second `saber db list` transcript shows `temp, audit`. Run `saber db exclude verification --clear` and confirm the list is blank.
-- **Default selection.** Add `secondary` against the same disposable fixture, then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/default.txt -- uv run saber db set-default secondary`. A new list transcript marks `secondary` as default and no longer marks `verification`.
-- **Removal.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/remove.txt -- uv run saber db remove secondary --yes`. Output confirms removal. A final list contains `verification`, omits `secondary`, and marks `verification` as default.
-- **Interactive add.** Start a fresh run. Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input $'\033[B\033[B\r'"$FIXTURE"$'\r' --input-delay 1.5 --evidence database-connections/interactive-add.txt -- uv run saber db add verification`. The two down-arrow keys choose `sqlite`, Enter confirms it, and the next line supplies the fixture path. Require the same add confirmation and list read-back. If questionary does not consume the buffered path, retain the transcript and report `db-add-interactive` as unreachable with this helper. Do not substitute the non-interactive path.
-- **Persisted proof.** Run `DB_CONFIG=$("$VERIFY_SQLSABER" path "$RUN_ID" database-config)`, copy it to the feature evidence directory, and parse it read-only. Its `default` and `connections` values must match the final `saber db list` transcript.
+- **Non-interactive add.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence database-connections/add.txt -- uv run saber db add verification --type sqlite --database "$FIXTURE" --description "verification fixture" --no-interactive`. Output confirms the add and says `verification` became the default.
+- **List and default test.** Capture `saber db list`, then `saber db test` without a name. The table contains `verification`, `sqlite`, the fixture path, and a default marker. The test says `Connection to 'verification' successful`.
+- **Exclusions.** Set `temp,audit`, add `archive`, remove `temp`, and capture `saber db list`; it shows `audit, archive`. Clear exclusions and confirm the list is blank. This covers `--set`, `--add`, `--remove`, and `--clear` without an interactive editor.
+- **Default selection.** Add `secondary` against the same fixture, set it as default, and capture a list where only `secondary` is marked. Remove `secondary --yes`; a final list contains `verification` and marks it as default.
+- **Interactive add.** Start a fresh run. Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input-sequence '[[2, "\u001b[B\u001b[B\r"], [4, "FIXTURE_PATH\r"]]' --evidence database-connections/interactive-add.txt -- uv run saber db add verification`, replacing `FIXTURE_PATH` before passing the JSON. The two down-arrow keys choose SQLite. Require the add confirmation and a list read-back. If the prompt does not consume the path, retain the transcript and report this entry as unreachable with the attempted input.
+- **Persisted proof.** Copy the file from `path database-config` after the final list. Its default, connection names, paths, and exclusions match the list. The saved description matches the original add argument; `db list` does not display descriptions.
 
 ## Gotchas
 
-- A SQLite add saves the path as supplied, while DuckDB normalizes it to an absolute path. Compare against the displayed value for that database type.
-- Database passwords go to the operating-system keyring. Never test server passwords in a shared keyring; use SQLite or an isolated verification keyring backend.
+- Non-interactive SQLite adds save the path as supplied. Interactive SQLite and DuckDB setup resolves it to an absolute path.
+- Database passwords use the operating-system keyring in normal use. Verification selects a null backend, so never use it to prove server-password persistence.
 - The first connection becomes default automatically. Removing the default promotes the first remaining connection.
-- `db test` opens the real database. Keep remote connection checks read-only and record the endpoint used.
-- `db remove --yes` skips only confirmation. It still deletes the saved config and any stored password for that connection.
+- `db test` opens the real database. Keep remote checks read-only.
+- `db exclude NAME` with no action flag is a mutation, not an inspection command.
+- `db remove --yes` skips confirmation but still deletes saved configuration and any stored password.

--- a/.pi/skills/verify-sqlsaber/features/first-run-onboarding.md
+++ b/.pi/skills/verify-sqlsaber/features/first-run-onboarding.md
@@ -1,0 +1,37 @@
+# First-run onboarding
+
+When a user starts `saber` without `-d` and has no saved database, SQLsaber opens a guided terminal setup for a database, authentication, and model choice before entering chat.
+
+## Sub-features
+
+- `onboarding-trigger` appears only when no saved database and no command-line selector exist.
+- `onboarding-database` collects, tests, and saves a named connection.
+- `onboarding-auth-model` offers provider authentication and model selection after the database succeeds.
+- `onboarding-cancel` exits without pretending setup completed and prints manual setup guidance.
+
+## How to get to it (user POV)
+
+- Run `saber` in a fresh home.
+- Complete the database prompts, then the authentication and model prompts.
+- Press Ctrl+C to cancel.
+- Pass `-d FILE` or configure a saved database to skip onboarding.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Launch has completed and doctor reports `HEALTHY`.
+- No database command has run in this isolated home.
+
+- **Trigger and cancel.** Run `saber` through `drive` with Ctrl+C as deterministic input after the welcome form appears. Require `Welcome to SQLsaber`, the first database prompt, `Database setup is required to continue`, the `-d` guidance, a setup-incomplete exit, and no saved database config.
+- **Bypass with a file.** In a fresh run, start `saber -d "$FIXTURE"` with a harmless placeholder credential and send Ctrl+D on the empty editor. It reaches the interactive session without the onboarding welcome because a selector was supplied.
+- **Completed database step.** Build JSON input events with `uv run python -c 'import json,sys; print(json.dumps([[2,"onboarded\\r"],[4,"\\x1b[B\\x1b[B\\r"],[6,sys.argv[1]+"\\r"]]))' "$FIXTURE"`, then pass that value to `drive --input-sequence` for `uv run saber`. The events name the connection, choose SQLite, and enter only the disposable fixture path. Require a successful connection and a `db list` read-back. If prompt timing differs, retain the transcript and report the harness gap rather than sending more input blindly.
+- **Authentication and model step.** This needs an environment credential matching the selected provider and network access to the model catalog. After the guided database succeeds, select that provider. Require `Step 2 of 2: Authentication`, credential detection through the named environment variable, model fetch or documented fallback, `Model set to:`, the all-set summary, and the interactive-session start. `auth_config.json` must record `api_key`; derive the provider from the environment notice and selected model in the transcript. `model_config.json` must match the selected model. Only a real query proves provider acceptance. If either prerequisite is absent, retain the attempted route and mark only `onboarding-auth-model` unreachable.
+- **Keyring boundary.** Full credential storage is unreachable by design because the harness uses a null keyring. Do not enter a real key to bypass this boundary; use an inherited environment credential for the completed step.
+
+## Gotchas
+
+- `launch` seeds a fixture but does not register it, so the first run remains a real onboarding state.
+- Onboarding is bypassed by any explicit `-d` selector.
+- At least a database must succeed for onboarding to return success.
+- Prompt timing is deterministic only for setup controls. Never schedule input around a network-backed model response.

--- a/.pi/skills/verify-sqlsaber/features/interactive-session.md
+++ b/.pi/skills/verify-sqlsaber/features/interactive-session.md
@@ -1,0 +1,40 @@
+# Interactive session
+
+The interactive session is the full-screen chat started by `saber` with no question. It shows database and model identity, accepts questions and local slash commands, and exits back to the shell.
+
+## Sub-features
+
+- `interactive-open` shows the chat editor, slash-command hint, and database footer.
+- `interactive-palette` opens settings with `/` on an empty editor.
+- `interactive-clear-thinking` clears history and changes session-only thinking state.
+- `interactive-handoff` drafts a goal that can start a new thread with current context.
+- `interactive-exit` accepts `/exit`, `/quit`, bare `exit` or `quit`, and Ctrl+D on an empty editor.
+- `interactive-interrupt` uses Ctrl+C to cancel a running query.
+
+## How to get to it (user POV)
+
+- Run `saber -d FILE` or `saber -d SAVED_NAME` with no question.
+- Type `/` on an empty prompt to open the palette.
+- Type `/clear`, `/thinking`, `/handoff GOAL`, `/exit`, or `/quit`.
+- Press Ctrl+C during a query or Ctrl+D on an empty editor.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY`.
+- `FIXTURE=$("$VERIFY_SQLSABER" path "$RUN_ID" fixture)` is available.
+- TUI startup needs a key matching the configured model. A harmless placeholder environment value is sufficient only for local controls that never call the provider.
+
+- **Open, palette, clear, and exit.** Start `env ANTHROPIC_API_KEY=verification-placeholder uv run saber -d "$FIXTURE"` through `drive`. Use `--input-sequence` to send `/`, two down arrows plus Enter to activate `Clear conversation`, then Ctrl+D. Require the slash-command hint, database footer, palette labels, `Conversation history cleared.`, and clean exit.
+- **Thinking.** In a fresh drive, open the palette and change `Thinking mode`, or submit `/thinking off` as one pasted line. Require the visible status before exit.
+- **Exit aliases.** In separate fresh drives where needed, submit bare `exit` or `quit`, or send Ctrl+D on an empty editor. Require clean exit.
+- **Handoff and interruption.** These paths call or interrupt a real model. Exercise them only with a working provider credential. Capture the original thread ID, handoff goal, new thread ID, and the visible cancellation state.
+
+## Gotchas
+
+- A credential for the wrong provider does not satisfy TUI startup. Match the current model.
+- `/` opens the palette only when the editor is empty. Bytewise automated typing that starts with `/` also opens it; use palette keys for deterministic harness proof.
+- Fixed input delays are safe for local controls, not for model responses.
+- `/handoff` invokes the model. `/clear`, thinking changes, palette open, and exit do not.
+- The helper strips ANSI. Assert visible labels and messages, not screen coordinates or colors.

--- a/.pi/skills/verify-sqlsaber/features/knowledge-base.md
+++ b/.pi/skills/verify-sqlsaber/features/knowledge-base.md
@@ -1,6 +1,6 @@
 # Knowledge base
 
-The knowledge base lets a user store database-scoped definitions and SQL patterns, find them later, inspect full entries, and remove stale context.
+The knowledge base lets a user store database-scoped definitions and SQL patterns, find and inspect them later, and make that context available to natural-language queries.
 
 ## Sub-features
 
@@ -9,12 +9,14 @@ The knowledge base lets a user store database-scoped definitions and SQL pattern
 - `knowledge-search` returns full-text matches ranked within one database.
 - `knowledge-remove` deletes one confirmed entry.
 - `knowledge-clear` deletes all entries for the selected database.
+- `knowledge-query-use` lets the query agent search knowledge for its current database.
 
 ## How to get to it (user POV)
 
 - Run `saber knowledge add NAME DESCRIPTION` with optional `--sql`, `--source`, and `--database`.
 - Run `saber knowledge list`, `show ID`, or `search QUERY` to read entries.
 - Run `saber knowledge remove ID` or `clear` to delete entries, with `--yes` for deliberate automation.
+- Ask a natural-language question whose answer depends on a saved definition or SQL pattern.
 
 ## Driving it with verify-sqlsaber
 
@@ -24,18 +26,18 @@ Preconditions:
 - A saved SQLite connection named `verification` exists and is the default.
 - No knowledge entry is named `Paid order definition` in this isolated run.
 
-- **Add entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/add.txt -- uv run saber knowledge add "Paid order definition" "Orders count as paid when status equals paid" --sql "SELECT COUNT(*) FROM orders WHERE status = 'paid'" --source "verification-fixture"`. Output prints a full entry ID, the exact name, and exit code `0`.
-- **List read-back.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/list.txt -- uv run saber knowledge list`. The table title names database `verification`, contains the new ID and name, and reports `Total entries: 1`.
-- **Show entry.** Run `EVIDENCE=$("$VERIFY_SQLSABER" path "$RUN_ID" evidence)` and `ENTRY_ID=$(awk '/^ID:/{print $2; exit}' "$EVIDENCE/knowledge/add.txt")`. Require a 36-character ID, then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/show.txt -- uv run saber knowledge show "$ENTRY_ID"`. The output includes the full description, SQL, source, and database.
-- **Search match.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/search-match.txt -- uv run saber knowledge search "paid orders" --limit 5`. Results contain `Paid order definition`. Run a second search for `volcano`; output says no entries matched and still exits `0`.
-- **Remove one.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/remove.txt -- uv run saber knowledge remove "$ENTRY_ID" --yes`. A list read-back reports no knowledge entries.
-- **Clear all.** Add two new entries, run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence knowledge/clear.txt -- uv run saber knowledge clear --database verification --yes`, then list again. Output reports two cleared entries and the final list is empty.
-- **Persisted proof.** Run `KNOWLEDGE_DB=$("$VERIFY_SQLSABER" path "$RUN_ID" knowledge-db)`, copy it into the feature evidence directory, and query the copy with Python's `sqlite3` in read-only mode. The `knowledge` rows for `verification` must match the final CLI list. Record row IDs, names, and database names, not only a count.
+- **Add and identify.** Add `Paid order definition` with description `Orders count as paid when status equals paid`, SQL `SELECT COUNT(*) FROM orders WHERE status = 'paid'`, and source `verification-fixture`. Output prints the exact name and a full UUID. Extract the UUID with `grep -Eo '[0-9a-f]{8}-[0-9a-f-]{27}'`, not an anchored `ID:` line.
+- **Read paths.** Capture `knowledge list`, `show "$ENTRY_ID"`, a search for `paid orders`, and a search for `volcano`. The list and show match the added record. The first search finds it; the second reports no match and exits `0`.
+- **Persisted row proof.** Before deletion, copy the file from `path knowledge-db` to `knowledge/before-delete.db`. Query the copy read-only and require the UUID, name, database `verification`, SQL, and source.
+- **Remove and clear.** Remove the entry with `--yes` and confirm an empty list. Add two entries, clear database `verification --yes`, and confirm the final list is empty.
+- **Persisted empty proof.** Copy the final knowledge database to `knowledge/after-clear.db` and query it read-only. It has no rows for `verification`.
+- **Agent retrieval.** When a matching provider credential works, add a deliberately unique rule, ask a saved-selector query that needs it, and require the visible answer plus a `search_knowledge` tool result naming the entry. If no credential works, record that prerequisite and keep the CRUD proof.
 
 ## Gotchas
 
 - Knowledge commands require a saved database name. Passing an ad hoc file to a query does not create a knowledge scope.
-- Search uses FTS5 token matching. Use plain terms such as `paid orders`, not punctuation-heavy SQL fragments.
-- IDs are UUIDs. Capture the full value from `add` or `list`; do not use a shortened prefix.
-- `remove` and `clear` require confirmation in a terminal. Use `--yes` only against this run's isolated database.
-- A successful delete message is not enough. Confirm through `list` and the copied `knowledge.db`.
+- Search uses FTS5 token matching with OR semantics for plain terms. Assert the expected name is present, not a fixed result order.
+- Search indexes name, description, and SQL, not source.
+- IDs are UUIDs. Capture the full value from add or list.
+- `remove` and `clear` require confirmation in a terminal. Use `--yes` only against the isolated database.
+- Copy row-level proof before clear. The final database can prove emptiness, not the deleted row's fields.

--- a/.pi/skills/verify-sqlsaber/features/model-configuration.md
+++ b/.pi/skills/verify-sqlsaber/features/model-configuration.md
@@ -1,0 +1,40 @@
+# Model configuration
+
+Model commands let a user inspect and select the main model, control its thinking level, set per-agent overrides, list models from the remote catalog, and reset saved choices.
+
+## Sub-features
+
+- `models-current` shows the effective main model, thinking state, and subagent overrides.
+- `models-set-main` saves a provider-prefixed main model and optional thinking level.
+- `models-set-agent` saves an override for `handoff`, `viz`, or `notebook`.
+- `models-list` fetches the current supported catalog from models.dev.
+- `models-reset` writes the command's built-in main-model reset target or clears one subagent override.
+
+## How to get to it (user POV)
+
+- Run `saber models current [--agent AGENT]`.
+- Run `saber models set PROVIDER:MODEL [--thinking-level LEVEL] [--agent AGENT]`.
+- Run `saber models list`.
+- Run `saber models reset [--agent AGENT]`, with `--yes` for automation.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY`.
+- Model configuration does not require a provider key. A later query does.
+
+- **Initial state.** Capture `saber models current`. It prints the current model, thinking state, and rows for `handoff`, `viz`, and `notebook`.
+- **Main selection.** Set `openai:gpt-5 --thinking-level off`, capture `models current --agent main`, and require the model plus `Thinking: disabled`.
+- **Subagent override.** Set `openai:gpt-5-mini --agent handoff`, then capture `models current --agent handoff`. It shows the override and main model. Reset the override with `--yes` and confirm it uses main again.
+- **Main reset.** Run `models reset --yes`, then capture current state. It shows `anthropic:claude-sonnet-4-5-20250929`, the reset target printed by the command.
+- **Persisted proof.** Copy the file from `path model-config` before reset and after reset. The JSON matches each `models current` read-back.
+- **Remote catalog.** When network access is available, run `models list` with a short explicit timeout. Require `Available Models` and provider-prefixed IDs. Require a current marker only when the configured model appears in the returned catalog. A network failure makes only this entry unreachable.
+
+## Gotchas
+
+- `--thinking-level` applies only to the main model.
+- Model IDs must use a supported `PROVIDER:MODEL` prefix, but saving one does not prove the provider accepts it.
+- `models list` calls `https://models.dev/api.json`; current and set are local.
+- `main`, `handoff`, `viz`, and `notebook` are the accepted agent names.
+- A fresh config currently starts at `anthropic:claude-opus-4-5`, while `models reset` writes `anthropic:claude-sonnet-4-5-20250929`. Record both values rather than calling them the same default.

--- a/.pi/skills/verify-sqlsaber/features/query-databases.md
+++ b/.pi/skills/verify-sqlsaber/features/query-databases.md
@@ -1,45 +1,46 @@
 # Query databases
 
-Querying lets a user ask a natural-language question against a file or saved connection, inspect generated SQL and results, continue in the terminal UI, and retain the conversation as a thread.
+Querying lets a user ask one natural-language question against a file or saved connection, inspect generated SQL and results, select several databases, and retain the conversation as a thread.
 
 ## Sub-features
 
 - `query-single` answers one command-line question and exits.
 - `query-stdin` reads a question from piped standard input.
 - `query-file` resolves an ad hoc SQLite, DuckDB, or CSV path without saving it first.
+- `query-saved` resolves a configured name and saves that selector for automatic continuation.
 - `query-multiple` connects repeated `-d` selectors in one session.
-- `query-interactive` opens the terminal UI, accepts follow-up questions, and exits through `/exit` or `/quit`.
+- `query-missing-selector` reports an actionable error for an unknown saved name.
 - `query-dangerous` keeps writes blocked unless the user passes `--allow-dangerous`.
 
 ## How to get to it (user POV)
 
-- Run `saber -d FILE "QUESTION"` for a single answer.
+- Run `saber -d FILE "QUESTION"` or `saber -d SAVED_NAME "QUESTION"`.
 - Pipe a question with `printf '%s\n' "QUESTION" | saber -d FILE`.
 - Repeat `-d` to query multiple saved connections or files.
-- Run `saber -d FILE` in a terminal to open the interactive UI.
-- Add `--thinking` or `--allow-dangerous` when that behavior is deliberate.
+- Add `--thinking` or `--allow-dangerous` only when that behavior is deliberate.
+- Run `saber` with no question for the separate [interactive session](./interactive-session.md).
 
 ## Driving it with verify-sqlsaber
 
 Preconditions:
 
 - Doctor reports `HEALTHY` and names a provider credential present in the environment.
-- The run has a model that matches that credential. For `ANTHROPIC_API_KEY`, run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence query/model.txt -- uv run saber models set anthropic:claude-sonnet-4-5-20250929 --thinking-level off`.
-- `FIXTURE=$("$VERIFY_SQLSABER" path "$RUN_ID" fixture)` points to the seeded database with three employees and two paid orders.
+- The run has a model matching that credential. Set one with `saber models set PROVIDER:MODEL --thinking-level off`.
+- `FIXTURE=$("$VERIFY_SQLSABER" path "$RUN_ID" fixture)` has three employees and two paid orders; `EVIDENCE=$("$VERIFY_SQLSABER" path "$RUN_ID" evidence)` names the proof directory.
 
-- **Single-shot entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence query/single.txt -- uv run saber -d "$FIXTURE" "Count all employees. Use the database and report the integer only."`. The transcript shows the fixture connection, SQL execution or tool result, the value `3`, exit code `0`, and a continuation thread ID.
-- **Stdin entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence query/stdin.txt -- bash -c 'printf "%s\n" "Count paid orders. Use the database and report the integer only." | uv run saber -d "$1"' _ "$FIXTURE"`. The answer is `2` and exit code is `0`.
-- **Saved selector entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence query/register-verification.txt -- uv run saber db add verification --type sqlite --database "$FIXTURE" --no-interactive`, then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence query/saved-selector.txt -- uv run saber -d verification "List active employee names in alphabetical order."`. The answer contains `Ada` before `Grace` and omits `Linus`.
-- **Multiple database entry.** Register the same disposable fixture with `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence query/register-staff.txt -- uv run saber db add staff --type sqlite --database "$FIXTURE" --no-interactive` and `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence query/register-orders.txt -- uv run saber db add orders --type sqlite --database "$FIXTURE" --no-interactive`. Then run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence query/multiple.txt -- uv run saber -d staff -d orders "Report the configured database names available in this session."`. The visible answer names both selectors. This proves connection selection, not a cross-database join.
-- **Interactive entry.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input $'/exit\r' --input-delay 2 --evidence query/interactive-exit.txt -- uv run saber -d "$FIXTURE"`. The terminal UI starts, handles `/exit`, prints `Goodbye!`, and exits `0`.
-- **Thread read-back.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence query/threads.txt -- uv run saber threads list`. The table contains the thread IDs printed by the completed questions. Set `THREAD_ID` to each full ID and run `saber threads show "$THREAD_ID"` through the helper for each claimed query and capture its question, SQL/tool result, and answer.
-- **Safety entry.** Snapshot the fixture row counts, ask for a write without `--allow-dangerous`, and snapshot them again. The command must refuse or avoid the write, and the before/after counts must match. Test `--allow-dangerous` only in a separate run because it can mutate the fixture.
+- **Saved single shot.** Register the fixture as `verification`, then run `saber -d verification "Count all employees. Use the database and report the integer only."` with a 180-second timeout. Require the connection and model heading, SQL execution or tool result, answer `3`, exit `0`, and a full continuation thread ID.
+- **Thread read-back.** Capture `threads list` and `threads show "$THREAD_ID"`. They contain the saved selector, question, tool result, and answer. The printed continuation commands are directly usable because this recipe used a saved name.
+- **Ad hoc file.** Ask the same count with `-d "$FIXTURE"`. Thread retention and `threads show` work, but automatic resume needs an explicit repeated `-d` because SQLsaber does not persist ad hoc paths.
+- **Stdin.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 180 --evidence query/stdin.txt -- bash -c 'printf "%s\n" "Count paid orders. Use the database and report the integer only." | uv run saber -d "$1"' _ "$FIXTURE"`. Require answer `2` and exit `0`.
+- **Multiple databases.** Register the fixture as `staff` and `orders`, then ask with `-d staff -d orders` which configured database names are available. Require both names. This proves connection selection, not a cross-database join.
+- **Unknown selector.** In a fresh or healthy run, execute `saber -d nonexistent "show tables"`. Retain the expected nonzero transcript and require `Database connection 'nonexistent' not found` with guidance to list or add connections.
+- **Safety.** Before the query, run `uv run python -c 'import sqlite3,sys; db=sqlite3.connect(f"file:{sys.argv[1]}?mode=ro",uri=True); print(db.execute("SELECT id,name FROM employees ORDER BY id").fetchall())' "$FIXTURE" > "$EVIDENCE/query/employees-before.txt"`. Ask without `--allow-dangerous`: `Attempt to insert an employee named SafetyProbe. Invoke the SQL execution tool so its safety refusal is visible; do not only explain the policy.` Require a blocked `execute_sql` result. Repeat the same read-only snapshot into `employees-after.txt` and run `cmp` on the two files. A model that merely avoids the tool does not prove the guard. Test allowed writes only in a separate run and compare that disposable fixture before and after.
 
 ## Gotchas
 
 - Model output varies. Assert database-backed values and tool results, not prose or token counts.
-- A present environment variable may contain an expired credential. Record the provider error and mark model-backed entries unreachable if the first query fails authentication.
-- The stdin recipe needs `bash -c` inside the PTY so `saber` sees a non-terminal stdin stream.
-- Interactive TUI input uses carriage return. A newline may render in the editor instead of submitting.
-- `--allow-dangerous` is real write access, not a preview mode. SQLsaber still blocks `DROP`, `TRUNCATE`, admin operations, and `UPDATE` or `DELETE` without `WHERE`.
-- Repeated ad hoc CSV selectors merge views differently from repeated saved database selectors. Report which path the proof used.
+- A present environment variable may hold an expired credential. Record the provider error and mark model-backed entries unreachable if authentication fails.
+- The stdin recipe needs `bash -c` inside the PTY so `saber` sees non-terminal stdin.
+- Ad hoc thread hints omit the `-d` override required for continuation. Record the limitation instead of claiming automatic resume.
+- `--allow-dangerous` is real write access. SQLsaber still blocks `DROP`, `TRUNCATE`, administrative operations, and unfiltered `UPDATE` or `DELETE`.
+- Repeated CSV selectors merge views differently from repeated saved databases. Record which path the proof used.

--- a/.pi/skills/verify-sqlsaber/features/terminal-output.md
+++ b/.pi/skills/verify-sqlsaber/features/terminal-output.md
@@ -1,0 +1,37 @@
+# Terminal output
+
+SQLsaber renders styled saber-tui blocks to a terminal and plain Markdown when stdout is redirected, while keeping diagnostics on stderr and avoiding ANSI in redirected output.
+
+## Sub-features
+
+- `output-tty` renders readable interactive terminal blocks through `drive`.
+- `output-redirected-table` serializes tables as GitHub pipe tables.
+- `output-redirected-values` serializes key-value blocks with Markdown labels.
+- `output-streams` keeps normal output on stdout, diagnostics on stderr, and records the exit code.
+- `output-no-ansi` emits no terminal escape sequences when redirected.
+
+## How to get to it (user POV)
+
+- Run any command in a terminal for styled output.
+- Redirect or pipe stdout, for example `saber db list > databases.md`.
+- Redirect stderr separately for errors.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY`.
+- Register the fixture as `verification` so table and key-value commands have content.
+
+- **Redirected table.** Use `verify-sqlsaber run`, not `drive`, for `uv run saber db list`. In the transcript's stdout section require a Markdown header row, separator row, and `verification`. Stderr is empty and exit code is `0`.
+- **Redirected values.** Use `run` for `uv run saber models current --agent main`. Stdout contains Markdown labels such as `**Current model**` and `**Thinking**`.
+- **Error stream.** Use `run` for an expected usage error such as `uv run saber theme set not-a-real-theme`. Retain the nonzero transcript. The actionable error is in stderr, stdout does not contain it, and the exit code is recorded.
+- **No ANSI.** Search all three transcripts for byte `0x1b`; none is present in the command output sections.
+- **TTY comparison.** Capture the same `db list` through `drive`. It has the same data, but do not require the Markdown pipe layout.
+
+## Gotchas
+
+- `drive` always allocates a PTY, even when its own output is redirected by the coordinator. Use `run` to test SQLsaber's non-TTY branch.
+- Query streaming buffers differently without a TTY. Prove a model-backed redirected query only when a provider credential works.
+- The evidence wrapper adds section headings. ANSI and stream assertions apply to command output inside those sections.
+- Usage errors can exit nonzero. A retained transcript is valid proof even when the helper returns that code.

--- a/.pi/skills/verify-sqlsaber/features/themes.md
+++ b/.pi/skills/verify-sqlsaber/features/themes.md
@@ -1,0 +1,34 @@
+# Themes
+
+Theme commands let a user choose a Pygments style for terminal syntax highlighting, browse choices interactively, and reset the saved theme.
+
+## Sub-features
+
+- `theme-set-named` validates and saves a named Pygments theme.
+- `theme-set-interactive` opens a searchable theme selector when no name is supplied.
+- `theme-reset` removes the saved theme after confirmation.
+
+## How to get to it (user POV)
+
+- Run `saber theme set THEME`.
+- Run `saber theme set` in a terminal to browse choices.
+- Run `saber theme reset`, with `--yes` for automation.
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY`.
+- No `theme.json` exists in the isolated config directory.
+
+- **Named selection.** Capture `saber theme set dracula`. It exits `0` and prints `Theme set to: dracula`.
+- **Persisted proof.** Copy the file from `path theme-config`. It records `dracula` as both the selected name and Pygments style.
+- **Reset.** Capture `saber theme reset --yes`. It prints the default theme name. Confirm `theme.json` no longer exists, then run a help command to show the CLI still starts.
+- **Interactive route.** In a fresh run, start `saber theme set` through `drive`, select or cancel one visible choice, and retain the transcript. Do not substitute the named path when claiming selector behavior.
+
+## Gotchas
+
+- A non-TTY call without `THEME` is a usage error.
+- `SQLSABER_THEME` wins over the saved file in normal use, but this skill does not claim that precedence from ANSI-stripped evidence.
+- Available names come from installed Pygments styles and can change with that dependency.
+- ANSI colors are not stable proof. Use the success text and persisted JSON.


### PR DESCRIPTION
## Summary

- expand the terminal feature map for onboarding, authentication, models, themes, interactive controls, and redirected output
- correct drift in database, knowledge, query, and thread recipes
- harden the verifier with isolated keyring settings, non-TTY capture, scripted PTY input, atomic run coordination, evidence protection, and cleanup-safe interruption handling

## Verification

- exercised all 11 feature files against an isolated SQLsaber run
- preserved evidence at `.pi/verification/sqlsaber/maintain-20260829T195556Z-33364/`
- re-proved harness interruption, locking, cleanup, environment isolation, and evidence retention in separate isolated runs
- `uv run ruff check .pi/skills/verify-sqlsaber/bin/verify-sqlsaber`
- `uv run ruff format --check .pi/skills/verify-sqlsaber/bin/verify-sqlsaber`
- `uvx ty check .pi/skills/verify-sqlsaber/bin/verify-sqlsaber`

Model-backed query, populated-thread, knowledge-agent, handoff, and query-interruption paths were unreachable because no provider credential was present. The attempted query and provider error are retained in `query/no-provider.txt` under the main evidence run.
