### PR TITLE
fix: restore static type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras --dev
 
+      - name: Run type check
+        if: runner.os == 'Linux'
+        run: uvx ty check src/
+
       - name: Run tests
         run: uv run python -m pytest

--- a/src/sqlsaber/capabilities/_wrapping.py
+++ b/src/sqlsaber/capabilities/_wrapping.py
@@ -27,7 +27,7 @@ def wrap_strip_db_name(tool: Tool) -> Callable[..., Awaitable[str]]:
         async def wrapper(*args, **kwargs) -> str:
             return await raw(*args, **kwargs)
 
-    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    setattr(wrapper, "__signature__", new_sig)
     wrapper.__name__ = getattr(raw, "__name__", tool.name)
     wrapper.__doc__ = raw.__doc__
     wrapper.__annotations__ = {
@@ -44,7 +44,7 @@ def wrap_add_db_name(
     """Wrap a tool so its public schema requires ``db_name: Literal[...]``."""
     raw = tool.execute
     raw_sig = inspect.signature(raw)
-    db_literal = Literal[names]  # type: ignore[valid-type]
+    db_literal = Literal.__getitem__(names)
 
     new_params = []
     for name, parameter in raw_sig.parameters.items():
@@ -78,7 +78,7 @@ def wrap_add_db_name(
         async def wrapper(*args, db_name, **kwargs) -> str:
             return await raw(*args, db_name=db_name, **kwargs)
 
-    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    setattr(wrapper, "__signature__", new_sig)
     wrapper.__name__ = getattr(raw, "__name__", tool.name)
     wrapper.__doc__ = docstring_with_db_name(raw.__doc__)
     wrapper.__annotations__ = {

--- a/src/sqlsaber/capabilities/knowledge.py
+++ b/src/sqlsaber/capabilities/knowledge.py
@@ -77,7 +77,7 @@ class Knowledge(SqlSaberCapability):
                 function = wrap_add_db_name(tool, tuple(registry.names()))
             else:
                 function = wrap_strip_db_name(tool)
-        self._toolset.add_function(function, name=tool.name, takes_ctx=False)
+        self._toolset.tool_plain(name=tool.name)(function)
 
     @property
     def display_specs(self) -> Mapping[str, Tool]:

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -24,6 +24,7 @@ from sqlsaber.render import blocks as b
 
 if TYPE_CHECKING:
     from sqlsaber import SQLSaber, SQLSaberResult
+    from sqlsaber.config.settings import ThinkingLevel
 
 QUERY_CANCEL_GRACE_SECONDS = 0.1
 
@@ -374,14 +375,15 @@ class InteractiveSession:
             loop.call_soon_threadsafe(lambda: asyncio.create_task(submit_query()))
             return True
 
+        def on_thinking_change(enabled: bool, level: ThinkingLevel | None) -> None:
+            self.saber.set_thinking(enabled=enabled, level=level)
+
         def open_command_palette(app: ChatApp) -> None:
             info = self.saber.info
             app.show_command_palette(
                 thinking_enabled=info.thinking.enabled,
                 thinking_level=info.thinking.level,
-                on_thinking_change=lambda enabled, level: self.saber.set_thinking(
-                    enabled=enabled, level=level
-                ),
+                on_thinking_change=on_thinking_change,
                 model_name=info.model_name,
                 database_name=info.primary_database_name,
             )


### PR DESCRIPTION
## Summary

- replace invalid static forms around runtime tool signatures
- register the knowledge function through Pydantic AI's typed plain-function API
- adapt the thinking callback to its `None`-returning UI contract
- run `uvx ty check src/` in Linux CI

## Verification

- `env -u FORCE_COLOR uv run python -m pytest` (1345 passed, 6 skipped)
- `uvx ty check src/`
- `uv run ruff check .`