### PR TITLE
feat(cli): add management slash command parity

### DIFF
--- a/src/sqlsaber/cli/chat_surface.py
+++ b/src/sqlsaber/cli/chat_surface.py
@@ -125,9 +125,9 @@ class ChatSurface:
         """
         if isinstance(prompt, AskConfirm) and prompt.assume_yes:
             return cast(T, True)
-        from sqlsaber.render.prompts import ask_in_transient_tui
+        from sqlsaber.render.prompts import ask_in_overlay
 
-        return await ask_in_transient_tui(prompt, get_styles())
+        return await ask_in_overlay(self.app.tui, prompt, get_styles())
 
     def _paint(self) -> None:
         self.app.tui.request_render()

--- a/src/sqlsaber/cli/command_catalog.py
+++ b/src/sqlsaber/cli/command_catalog.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class CommandKind(StrEnum):
+    SESSION = "session"
+    MANAGEMENT = "management"
+
+
+class PaletteMode(StrEnum):
+    SUBMIT = "submit"
+    FILL = "fill"
+    THINKING = "thinking"
+
+
+@dataclass(frozen=True, slots=True)
+class OptionSpec:
+    names: tuple[str, ...]
+    takes_value: bool = True
+    repeatable: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    path: tuple[str, ...]
+    summary: str
+    usage: str
+    kind: CommandKind
+    aliases: tuple[tuple[str, ...], ...] = ()
+    options: tuple[OptionSpec, ...] = ()
+    palette_mode: PaletteMode = PaletteMode.SUBMIT
+    palette_label: str | None = None
+
+    @property
+    def command(self) -> str:
+        return f"/{' '.join(self.path)}"
+
+
+@dataclass(frozen=True, slots=True)
+class PaletteCommand:
+    command: str
+    label: str
+    description: str
+    mode: PaletteMode
+
+
+def _option(
+    *names: str,
+    takes_value: bool = True,
+    repeatable: bool = False,
+) -> OptionSpec:
+    return OptionSpec(names, takes_value=takes_value, repeatable=repeatable)
+
+
+def _management(
+    path: tuple[str, str],
+    summary: str,
+    usage: str,
+    *,
+    group_alias: str | None = None,
+    options: tuple[OptionSpec, ...] = (),
+    takes_arguments: bool = False,
+) -> CommandSpec:
+    aliases = ((group_alias, path[1]),) if group_alias is not None else ()
+    return CommandSpec(
+        path=path,
+        aliases=aliases,
+        summary=summary,
+        usage=usage,
+        kind=CommandKind.MANAGEMENT,
+        options=options,
+        palette_mode=PaletteMode.FILL if takes_arguments else PaletteMode.SUBMIT,
+    )
+
+
+COMMAND_SPECS: tuple[CommandSpec, ...] = (
+    CommandSpec(
+        path=("thinking",),
+        summary="Show or change reasoning for this session.",
+        usage="/thinking [on|off|minimal|low|medium|high|maximum]",
+        kind=CommandKind.SESSION,
+        palette_mode=PaletteMode.THINKING,
+        palette_label="Thinking mode",
+    ),
+    CommandSpec(
+        path=("handoff",),
+        summary="Draft a prompt for a new thread with the current context.",
+        usage="/handoff GOAL",
+        kind=CommandKind.SESSION,
+        palette_mode=PaletteMode.FILL,
+        palette_label="Handoff thread",
+    ),
+    CommandSpec(
+        path=("clear",),
+        summary="Clear the current conversation history.",
+        usage="/clear",
+        kind=CommandKind.SESSION,
+        palette_label="Clear conversation",
+    ),
+    CommandSpec(
+        path=("exit",),
+        aliases=(("quit",),),
+        summary="End this interactive session.",
+        usage="/exit",
+        kind=CommandKind.SESSION,
+        palette_label="Exit",
+    ),
+    CommandSpec(
+        path=("help",),
+        aliases=(("?",),),
+        summary="Show slash-command help.",
+        usage="/help [GROUP [COMMAND]]",
+        kind=CommandKind.SESSION,
+        palette_mode=PaletteMode.FILL,
+        palette_label="Command help",
+    ),
+    _management(("auth", "setup"), "Configure API-key authentication.", "/auth setup"),
+    _management(("auth", "status"), "Show authentication status.", "/auth status"),
+    _management(
+        ("auth", "reset"),
+        "Reset stored credentials for a provider.",
+        "/auth reset [PROVIDER] [--yes]",
+        options=(_option("--yes", takes_value=False),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("db", "add"),
+        "Add a saved database connection.",
+        "/db add NAME [OPTIONS]",
+        group_alias="database",
+        options=(
+            _option("--type", "-t"),
+            _option("--host", "-h"),
+            _option("--port", "-p"),
+            _option("--database", "--db"),
+            _option("--username", "-u"),
+            _option("--ssl-mode"),
+            _option("--ssl-ca"),
+            _option("--ssl-cert"),
+            _option("--ssl-key"),
+            _option("--exclude-schemas"),
+            _option("--description"),
+            _option("--interactive", "--no-interactive", takes_value=False),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("db", "list"),
+        "List saved database connections.",
+        "/db list",
+        group_alias="database",
+    ),
+    _management(
+        ("db", "exclude"),
+        "Change excluded schemas for a connection.",
+        "/db exclude NAME [--set CSV|--add CSV|--remove CSV|--clear]",
+        group_alias="database",
+        options=(
+            _option("--set"),
+            _option("--add"),
+            _option("--remove"),
+            _option("--clear", takes_value=False),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("db", "remove"),
+        "Remove a saved database connection.",
+        "/db remove NAME [--yes]",
+        group_alias="database",
+        options=(_option("--yes", takes_value=False),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("db", "set-default"),
+        "Set the default database connection.",
+        "/db set-default NAME",
+        group_alias="database",
+        takes_arguments=True,
+    ),
+    _management(
+        ("db", "test"),
+        "Test a database connection.",
+        "/db test [NAME]",
+        group_alias="database",
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "add"),
+        "Add database-specific knowledge.",
+        "/knowledge add NAME DESCRIPTION [-d DATABASE] [--sql SQL] [--source SOURCE]",
+        group_alias="k",
+        options=(
+            _option("--database", "-d"),
+            _option("--sql"),
+            _option("--source"),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "list"),
+        "List database-specific knowledge.",
+        "/knowledge list [-d DATABASE]",
+        group_alias="k",
+        options=(_option("--database", "-d"),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "show"),
+        "Show one knowledge entry.",
+        "/knowledge show ID [-d DATABASE]",
+        group_alias="k",
+        options=(_option("--database", "-d"),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "search"),
+        "Search database-specific knowledge.",
+        "/knowledge search QUERY [-d DATABASE] [--limit N]",
+        group_alias="k",
+        options=(_option("--database", "-d"), _option("--limit")),
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "remove"),
+        "Remove one knowledge entry.",
+        "/knowledge remove ID [-d DATABASE] [--yes]",
+        group_alias="k",
+        options=(
+            _option("--database", "-d"),
+            _option("--yes", takes_value=False),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("knowledge", "clear"),
+        "Clear knowledge for a database.",
+        "/knowledge clear [-d DATABASE] [--yes]",
+        group_alias="k",
+        options=(
+            _option("--database", "-d"),
+            _option("--yes", takes_value=False),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("models", "list"),
+        "List available models.",
+        "/models list",
+        group_alias="model",
+    ),
+    _management(
+        ("models", "set"),
+        "Set a saved model configuration.",
+        "/models set [MODEL] [--agent AGENT] [--thinking-level LEVEL]",
+        group_alias="model",
+        options=(_option("--agent"), _option("--thinking-level")),
+        takes_arguments=True,
+    ),
+    _management(
+        ("models", "current"),
+        "Show saved model configuration.",
+        "/models current [--agent AGENT]",
+        group_alias="model",
+        options=(_option("--agent"),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("models", "reset"),
+        "Reset a saved model configuration.",
+        "/models reset [--agent AGENT] [--yes]",
+        group_alias="model",
+        options=(_option("--agent"), _option("--yes", takes_value=False)),
+        takes_arguments=True,
+    ),
+    _management(
+        ("theme", "set"),
+        "Set the theme for later sessions.",
+        "/theme set [THEME]",
+        takes_arguments=True,
+    ),
+    _management(
+        ("theme", "reset"),
+        "Reset the saved theme.",
+        "/theme reset [--yes]",
+        options=(_option("--yes", takes_value=False),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "list"),
+        "List retained threads.",
+        "/threads list [-d DATABASE] [--limit N]",
+        group_alias="thread",
+        options=(
+            _option("--database", "-d"),
+            _option("--limit", "-n"),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "show"),
+        "Show a retained thread and transcript.",
+        "/threads show ID",
+        group_alias="thread",
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "artifacts"),
+        "List durable artifacts for a thread.",
+        "/threads artifacts ID",
+        group_alias="thread",
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "resume"),
+        "Resume a retained thread in this session.",
+        "/threads resume ID [-d DATABASE ...]",
+        group_alias="thread",
+        options=(_option("--database", "-d", repeatable=True),),
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "prune"),
+        "Prune old retained threads.",
+        "/threads prune [--days N] [--dry-run] [--yes]",
+        group_alias="thread",
+        options=(
+            _option("--days", "-n"),
+            _option("--dry-run", takes_value=False),
+            _option("--yes", takes_value=False),
+        ),
+        takes_arguments=True,
+    ),
+    _management(
+        ("threads", "export"),
+        "Export a retained thread as HTML.",
+        "/threads export ID [-o PATH]",
+        group_alias="thread",
+        options=(_option("--output", "-o"),),
+        takes_arguments=True,
+    ),
+)
+
+
+def _validate_registry() -> None:
+    paths: set[tuple[str, ...]] = set()
+    aliases: set[tuple[str, ...]] = set()
+    for spec in COMMAND_SPECS:
+        if spec.path in paths or spec.path in aliases:
+            raise RuntimeError(f"duplicate slash-command path: {spec.path}")
+        paths.add(spec.path)
+        option_names = [name for option in spec.options for name in option.names]
+        if len(option_names) != len(set(option_names)):
+            raise RuntimeError(f"duplicate options for slash command: {spec.path}")
+        for alias in spec.aliases:
+            if alias in paths or alias in aliases:
+                raise RuntimeError(f"duplicate slash-command alias: {alias}")
+            aliases.add(alias)
+
+
+_validate_registry()
+
+
+def management_paths() -> frozenset[tuple[str, ...]]:
+    return frozenset(
+        spec.path for spec in COMMAND_SPECS if spec.kind is CommandKind.MANAGEMENT
+    )
+
+
+def palette_commands() -> tuple[PaletteCommand, ...]:
+    return tuple(
+        PaletteCommand(
+            command=spec.command,
+            label=spec.palette_label or spec.command,
+            description=spec.summary,
+            mode=spec.palette_mode,
+        )
+        for spec in COMMAND_SPECS
+    )

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -330,7 +330,10 @@ def query(
                 if allow_dangerous:
                     out(b.warn(DANGEROUS_MODE_WARNING, label="DANGEROUS MODE ENABLED"))
                 interactive_session = InteractiveSession(saber)
-                await interactive_session.run()
+                try:
+                    await interactive_session.run()
+                finally:
+                    saber = getattr(interactive_session, "saber", saber)
 
         finally:
             try:

--- a/src/sqlsaber/cli/completers.py
+++ b/src/sqlsaber/cli/completers.py
@@ -2,6 +2,8 @@
 
 from saber_tui import AutocompleteItem, AutocompleteSuggestions, CompletionResult
 
+from sqlsaber.cli.command_catalog import COMMAND_SPECS
+
 
 class SQLSaberAutocompleteProvider:
     """saber-tui autocomplete provider for table names."""
@@ -28,6 +30,10 @@ class SQLSaberAutocompleteProvider:
 
         current_line = lines[cursor_line] if 0 <= cursor_line < len(lines) else ""
         text_before_cursor = current_line[:cursor_col]
+
+        slash_suggestions = self._slash_suggestions(text_before_cursor)
+        if slash_suggestions is not None:
+            return slash_suggestions
 
         table_suggestions = self._table_suggestions(
             current_line, cursor_col, text_before_cursor
@@ -74,6 +80,100 @@ class SQLSaberAutocompleteProvider:
         text_before_cursor = current_line[:cursor_col]
         stripped = text_before_cursor.strip()
         return not (stripped.startswith("/") and " " not in stripped)
+
+    def _slash_suggestions(
+        self, text_before_cursor: str
+    ) -> AutocompleteSuggestions | None:
+        stripped = text_before_cursor.lstrip()
+        if not stripped.startswith("/"):
+            return None
+
+        command_candidates: dict[str, tuple[str, str]] = {}
+        for spec in COMMAND_SPECS:
+            canonical = spec.command
+            command_candidates[canonical] = (canonical, spec.summary)
+            for alias in spec.aliases:
+                value = f"/{' '.join(alias)}"
+                command_candidates[value] = (canonical, spec.summary)
+
+        folded = stripped.casefold()
+        if len(stripped.split()) <= 2 and not folded.endswith(" --"):
+            matches = [
+                (value, canonical, summary)
+                for value, (canonical, summary) in command_candidates.items()
+                if value.casefold().startswith(folded) and value.casefold() != folded
+            ]
+            if matches:
+                matches.sort(key=lambda item: (len(item[0]), item[0]))
+                return AutocompleteSuggestions(
+                    [
+                        AutocompleteItem(value, canonical, summary)
+                        for value, canonical, summary in matches
+                    ],
+                    stripped,
+                )
+
+        for spec in COMMAND_SPECS:
+            for path in (spec.path, *spec.aliases):
+                prefix = f"/{' '.join(path)}"
+                if folded != prefix.casefold() and not folded.startswith(
+                    f"{prefix.casefold()} "
+                ):
+                    continue
+                if not spec.options:
+                    return None
+                parts = stripped.split()
+                arguments = parts[len(path) :]
+                if not arguments and not stripped.endswith(" "):
+                    return None
+                current = "" if stripped.endswith(" ") else arguments[-1]
+                completed = arguments if not current else arguments[:-1]
+                used: set[int] = set()
+                pending_value = False
+                index = 0
+                while index < len(completed):
+                    token = completed[index]
+                    option_name, separator, _ = token.partition("=")
+                    match = next(
+                        (
+                            (option_index, option)
+                            for option_index, option in enumerate(spec.options)
+                            if option_name in option.names
+                        ),
+                        None,
+                    )
+                    if match is None:
+                        index += 1
+                        continue
+                    option_index, option = match
+                    used.add(option_index)
+                    if option.takes_value and not separator:
+                        if index + 1 >= len(completed):
+                            pending_value = True
+                            break
+                        index += 1
+                    index += 1
+                if pending_value or (current and not current.startswith("-")):
+                    return None
+                if any(current in option.names for option in spec.options):
+                    return None
+                options = [
+                    name
+                    for option_index, option in enumerate(spec.options)
+                    if option.repeatable or option_index not in used
+                    for name in option.names
+                    if name.startswith(current)
+                ]
+                if not options:
+                    return None
+                return AutocompleteSuggestions(
+                    [
+                        AutocompleteItem(option, option, spec.summary)
+                        for option in options
+                    ],
+                    current,
+                )
+        return None
 
     def _table_suggestions(
         self,

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING
 import platformdirs
 
 from sqlsaber.cli.completers import SQLSaberAutocompleteProvider
-from sqlsaber.cli.slash_commands import CommandContext, SlashCommandProcessor
+from sqlsaber.cli.slash_commands import (
+    CommandContext,
+    SlashCommandProcessor,
+    ThreadResumeRequest,
+)
 from sqlsaber.cli.tui_chat import (
     DANGEROUS_MODE_FOOTER_LABEL,
     ChatApp,
@@ -24,7 +28,6 @@ from sqlsaber.render import blocks as b
 
 if TYPE_CHECKING:
     from sqlsaber import SQLSaber, SQLSaberResult
-    from sqlsaber.config.settings import ThinkingLevel
 
 QUERY_CANCEL_GRACE_SECONDS = 0.1
 
@@ -156,6 +159,48 @@ class InteractiveSession:
     async def before_prompt_loop(self) -> None:
         """Hook to refresh context before prompt loop."""
         await self._update_table_cache()
+
+    async def _resume_thread(
+        self,
+        app: ChatApp,
+        surface,
+        request: ThreadResumeRequest,
+    ) -> None:
+        from sqlsaber.cli.threads import prepare_thread_resume, render_prepared_thread
+
+        if self.saber.info.thread_id == request.thread_id:
+            surface.emit(b.warn(f"Thread '{request.thread_id}' is already active."))
+            return
+
+        prepared = await prepare_thread_resume(
+            request.thread_id,
+            list(request.databases) or None,
+        )
+        prepared_saber = prepared.saber
+        previous = self.saber
+        try:
+            await previous.end_thread()
+        except BaseException:
+            await prepared_saber.close()
+            raise
+
+        self.saber = prepared_saber
+        try:
+            await previous.close()
+        except Exception as exc:
+            self.log.warning("interactive.resume.cleanup_failed", error=str(exc))
+            surface.emit(b.warn(f"Previous session cleanup failed: {exc}"))
+
+        self.streaming_handler = TUIStreamingQueryHandler(
+            app,
+            display_registry_provider=lambda: self.saber.display_registry,
+            query_result_store=self.saber.query_result_store,
+        )
+        self.session_usage = SessionUsage()
+        app.clear_chat()
+        render_prepared_thread(surface, prepared)
+        await self._update_table_cache()
+        self._refresh_footer()
 
     async def _start_handoff(self, app: ChatApp, goal: str) -> None:
         """Generate a handoff draft and put it in the focused editor."""
@@ -298,7 +343,8 @@ class InteractiveSession:
                 await self._submit_handoff(app, user_query)
                 return
 
-            self._append_history(user_query)
+            if not user_query.lstrip().startswith("/"):
+                self._append_history(user_query)
 
             context = CommandContext(
                 surface=surface,
@@ -314,6 +360,10 @@ class InteractiveSession:
 
             if cmd_result.handoff_goal:
                 await self._start_handoff(app, cmd_result.handoff_goal)
+                return
+
+            if cmd_result.resume_request is not None:
+                await self._resume_thread(app, surface, cmd_result.resume_request)
                 return
 
             if cmd_result.handled:
@@ -375,15 +425,12 @@ class InteractiveSession:
             loop.call_soon_threadsafe(lambda: asyncio.create_task(submit_query()))
             return True
 
-        def on_thinking_change(enabled: bool, level: ThinkingLevel | None) -> None:
-            self.saber.set_thinking(enabled=enabled, level=level)
-
         def open_command_palette(app: ChatApp) -> None:
             info = self.saber.info
             app.show_command_palette(
                 thinking_enabled=info.thinking.enabled,
                 thinking_level=info.thinking.level,
-                on_thinking_change=on_thinking_change,
+                commands=self.command_processor.palette_commands(),
                 model_name=info.model_name,
                 database_name=info.primary_database_name,
             )

--- a/src/sqlsaber/cli/slash_commands.py
+++ b/src/sqlsaber/cli/slash_commands.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
+import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from sqlsaber.cli.command_catalog import (
+    COMMAND_SPECS,
+    CommandKind,
+    CommandSpec,
+    PaletteCommand,
+    palette_commands,
+)
 from sqlsaber.config.settings import ThinkingLevel
-from sqlsaber.render import blocks as b
+from sqlsaber.render import bind_cli_surfaces, blocks as b
 from sqlsaber.render.surface import Surface
 
 if TYPE_CHECKING:
@@ -12,54 +22,281 @@ if TYPE_CHECKING:
 THINKING_LEVELS = {"minimal", "low", "medium", "high", "maximum"}
 
 
+@dataclass(frozen=True, slots=True)
+class ThreadResumeRequest:
+    thread_id: str
+    databases: tuple[str, ...] = ()
+
+
 @dataclass
 class CommandContext:
-    """Context passed to slash command handlers."""
-
     surface: Surface
-    saber: "SQLSaber"
-    session_usage: "SessionUsage | None" = None
+    saber: SQLSaber
+    session_usage: SessionUsage | None = None
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class CommandResult:
-    """Result of command processing."""
-
     handled: bool
     should_exit: bool = False
     handoff_goal: str | None = None
+    resume_request: ThreadResumeRequest | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _Invocation:
+    spec: CommandSpec
+    arguments: tuple[str, ...]
+
+
+class _TokenError(ValueError):
+    pass
+
+
+def _split_tokens(text: str) -> tuple[str, ...]:
+    tokens: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    started = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+            elif (
+                char == "\\"
+                and index + 1 < len(text)
+                and text[index + 1]
+                in {
+                    quote,
+                    "\\",
+                }
+            ):
+                index += 1
+                current.append(text[index])
+            else:
+                current.append(char)
+            started = True
+        elif char in {"'", '"'}:
+            quote = char
+            started = True
+        elif char.isspace():
+            if started:
+                tokens.append("".join(current))
+                current = []
+                started = False
+        else:
+            current.append(char)
+            started = True
+        index += 1
+    if quote is not None:
+        raise _TokenError("Unterminated quoted value.")
+    if started:
+        tokens.append("".join(current))
+    return tuple(tokens)
+
+
+def _path_variants(spec: CommandSpec) -> tuple[tuple[str, ...], ...]:
+    return (spec.path, *spec.aliases)
+
+
+def _resolve(tokens: tuple[str, ...]) -> _Invocation | None:
+    folded = tuple(token.casefold() for token in tokens)
+    matches: list[tuple[int, CommandSpec]] = []
+    for spec in COMMAND_SPECS:
+        for path in _path_variants(spec):
+            if folded[: len(path)] == path:
+                matches.append((len(path), spec))
+    if not matches:
+        return None
+    path_length, spec = max(matches, key=lambda item: item[0])
+    return _Invocation(spec, tokens[path_length:])
+
+
+def _group_specs(path: tuple[str, ...]) -> tuple[CommandSpec, ...]:
+    folded = tuple(part.casefold() for part in path)
+    matches: list[CommandSpec] = []
+    for spec in COMMAND_SPECS:
+        if len(spec.path) < len(folded):
+            continue
+        if any(variant[: len(folded)] == folded for variant in _path_variants(spec)):
+            matches.append(spec)
+    return tuple(matches)
+
+
+def _exact_spec(path: tuple[str, ...]) -> CommandSpec | None:
+    folded = tuple(part.casefold() for part in path)
+    for spec in COMMAND_SPECS:
+        if folded in _path_variants(spec):
+            return spec
+    return None
 
 
 class SlashCommandProcessor:
-    """Processes slash commands and special inputs."""
-
-    EXIT_COMMANDS = {"/exit", "/quit", "exit", "quit"}
-
     async def process(self, user_query: str, context: CommandContext) -> CommandResult:
-        """
-        Process a user query to see if it's a command.
-        Returns CommandResult indicating if it was handled and if we should exit.
-        """
-        query = user_query.strip().lower()
-
-        if query in self.EXIT_COMMANDS or any(
-            query.startswith(cmd) for cmd in self.EXIT_COMMANDS
-        ):
+        stripped = user_query.strip()
+        folded = stripped.casefold()
+        if folded in {"exit", "quit"}:
             return await self._handle_exit(context)
+        if not stripped.startswith("/"):
+            return CommandResult(handled=False)
 
-        if query == "/clear":
+        try:
+            tokens = _split_tokens(stripped[1:])
+        except _TokenError as exc:
+            context.surface.emit(
+                b.error(str(exc)), b.md("Use `/help` for command syntax.")
+            )
+            return CommandResult(handled=True)
+
+        if not tokens:
+            self._show_help(context, ())
+            return CommandResult(handled=True)
+
+        invocation = _resolve(tokens)
+        if invocation is None:
+            group_path = tokens[:1] if tokens[1:] == ("--help",) else tokens
+            groups = _group_specs(group_path)
+            if groups and (len(tokens) == 1 or tokens[1:] == ("--help",)):
+                self._show_help(context, group_path)
+            else:
+                context.surface.emit(
+                    b.error(f"Unknown slash command: /{' '.join(tokens)}"),
+                    b.md("Use `/help` to list available commands.", role="muted"),
+                )
+            return CommandResult(handled=True)
+
+        spec = invocation.spec
+        arguments = invocation.arguments
+        if spec.path == ("help",):
+            self._show_help(context, arguments)
+            return CommandResult(handled=True)
+        if "--help" in arguments:
+            self._show_help(context, spec.path)
+            return CommandResult(handled=True)
+        if spec.kind is CommandKind.MANAGEMENT:
+            return await self._handle_management(spec, arguments, context)
+        if spec.path == ("exit",):
+            if arguments:
+                return self._argument_error(spec, context)
+            return await self._handle_exit(context)
+        if spec.path == ("clear",):
+            if arguments:
+                return self._argument_error(spec, context)
             return await self._handle_clear(context)
+        if spec.path == ("thinking",):
+            return await self._handle_thinking(context, spec, arguments)
+        if spec.path == ("handoff",):
+            return self._handle_handoff(context, spec, arguments)
+        return CommandResult(handled=True)
 
-        if query.startswith("/thinking"):
-            return await self._handle_thinking_command(context, query)
+    def palette_commands(self) -> tuple[PaletteCommand, ...]:
+        return palette_commands()
 
-        if query.startswith("/handoff"):
-            return await self._handle_handoff(context, user_query)
+    def _show_help(self, context: CommandContext, path: tuple[str, ...]) -> None:
+        if not path:
+            session = [
+                spec for spec in COMMAND_SPECS if spec.kind is CommandKind.SESSION
+            ]
+            management = [
+                spec for spec in COMMAND_SPECS if spec.kind is CommandKind.MANAGEMENT
+            ]
+            lines = ["## Session commands", *self._help_lines(session)]
+            lines.extend(("", "## Management commands", *self._help_lines(management)))
+            context.surface.emit(b.md("\n".join(lines)))
+            return
 
-        return CommandResult(handled=False)
+        spec = _exact_spec(path)
+        if spec is not None:
+            aliases = [f"/{' '.join(alias)}" for alias in spec.aliases]
+            lines = [f"## `{spec.command}`", spec.summary, "", f"Usage: `{spec.usage}`"]
+            if aliases:
+                lines.extend(
+                    ("", f"Aliases: {', '.join(f'`{alias}`' for alias in aliases)}")
+                )
+            if spec.options:
+                labels = ["/".join(option.names) for option in spec.options]
+                lines.extend(
+                    ("", f"Options: {', '.join(f'`{name}`' for name in labels)}")
+                )
+            context.surface.emit(b.md("\n".join(lines)))
+            return
+
+        group = _group_specs(path)
+        if group:
+            canonical_group = group[0].path[0]
+            context.surface.emit(
+                b.md(
+                    "\n".join(
+                        [f"## `/{canonical_group}` commands", *self._help_lines(group)]
+                    )
+                )
+            )
+            return
+
+        context.surface.emit(
+            b.error(f"Unknown help topic: {' '.join(path)}"),
+            b.md("Use `/help` to list available commands.", role="muted"),
+        )
+
+    @staticmethod
+    def _help_lines(specs: list[CommandSpec] | tuple[CommandSpec, ...]) -> list[str]:
+        return [f"- `{spec.usage}`. {spec.summary}" for spec in specs]
+
+    async def _handle_management(
+        self,
+        spec: CommandSpec,
+        arguments: tuple[str, ...],
+        context: CommandContext,
+    ) -> CommandResult:
+        from cyclopts.exceptions import CycloptsError
+        from sqlsaber.cli.commands import app
+
+        try:
+            command, bound, _ = app.parse_args(
+                [*spec.path, *arguments],
+                exit_on_error=False,
+                print_error=False,
+            )
+        except CycloptsError as exc:
+            context.surface.emit(
+                b.error(str(exc)), b.md(f"Usage: `{spec.usage}`", role="muted")
+            )
+            return CommandResult(handled=True)
+        except SystemExit:
+            return CommandResult(handled=True)
+
+        if spec.path == ("threads", "resume"):
+            values = bound.arguments
+            database = values.get("database")
+            databases = tuple(database) if isinstance(database, list) else ()
+            return CommandResult(
+                handled=True,
+                resume_request=ThreadResumeRequest(
+                    thread_id=str(values["thread_id"]), databases=databases
+                ),
+            )
+
+        def invoke() -> None:
+            command(*bound.args, **bound.kwargs)
+
+        try:
+            with bind_cli_surfaces(context.surface):
+                await asyncio.to_thread(invoke)
+        except SystemExit:
+            pass
+        return CommandResult(handled=True)
+
+    @staticmethod
+    def _argument_error(spec: CommandSpec, context: CommandContext) -> CommandResult:
+        context.surface.emit(
+            b.error(f"Unexpected arguments for {spec.command}."),
+            b.md(f"Usage: `{spec.usage}`", role="muted"),
+        )
+        return CommandResult(handled=True)
 
     async def _handle_exit(self, context: CommandContext) -> CommandResult:
-        """Handle exit commands."""
         ended_thread_id = await context.saber.end_thread()
         if ended_thread_id:
             hint = f"saber threads resume {ended_thread_id}"
@@ -69,80 +306,59 @@ class SlashCommandProcessor:
         return CommandResult(handled=True, should_exit=True)
 
     async def _handle_clear(self, context: CommandContext) -> CommandResult:
-        """Handle /clear command."""
         await context.saber.new_thread()
         context.surface.emit(b.success("Conversation history cleared."))
         return CommandResult(handled=True)
 
-    async def _handle_thinking_command(
-        self, context: CommandContext, query: str
+    async def _handle_thinking(
+        self,
+        context: CommandContext,
+        spec: CommandSpec,
+        arguments: tuple[str, ...],
     ) -> CommandResult:
-        """Handle /thinking commands with various arguments.
-
-        Supported formats:
-            /thinking           - Show current status and level
-            /thinking on        - Enable thinking with current level
-            /thinking off       - Disable thinking
-            /thinking <level>   - Set level (implies enable)
-        """
-        parts = query.split(maxsplit=1)
-        arg = parts[1].strip() if len(parts) > 1 else ""
-
+        if len(arguments) > 1:
+            return self._argument_error(spec, context)
+        arg = arguments[0].casefold() if arguments else ""
         if not arg:
-            return await self._show_thinking_status(context)
-
+            thinking = context.saber.info.thinking
+            if thinking.enabled:
+                context.surface.emit(
+                    b.md(f"Thinking: enabled ({thinking.level.value})", role="info")
+                )
+            else:
+                context.surface.emit(b.md("Thinking: disabled", role="info"))
+            return CommandResult(handled=True)
         if arg == "on":
             state = context.saber.set_thinking(enabled=True)
             context.surface.emit(b.success(f"Thinking: enabled ({state.level.value})"))
             return CommandResult(handled=True)
-
         if arg == "off":
             context.saber.set_thinking(enabled=False)
             context.surface.emit(b.success("Thinking: disabled"))
             return CommandResult(handled=True)
-
         if arg in THINKING_LEVELS:
             level = ThinkingLevel(arg)
             context.saber.set_thinking(enabled=True, level=level)
             context.surface.emit(b.success(f"Thinking: enabled ({level.value})"))
             return CommandResult(handled=True)
-
         valid_args = ", ".join(sorted(THINKING_LEVELS | {"on", "off"}))
         context.surface.emit(b.warn(f"Invalid argument. Use: /thinking [{valid_args}]"))
         return CommandResult(handled=True)
 
-    async def _show_thinking_status(self, context: CommandContext) -> CommandResult:
-        """Show current thinking status and level."""
-        thinking = context.saber.info.thinking
-
-        if thinking.enabled:
-            context.surface.emit(
-                b.md(f"Thinking: enabled ({thinking.level.value})", role="info")
-            )
-        else:
-            context.surface.emit(b.md("Thinking: disabled", role="info"))
-
-        return CommandResult(handled=True)
-
-    async def _handle_handoff(
-        self, context: CommandContext, raw_query: str
+    @staticmethod
+    def _handle_handoff(
+        context: CommandContext,
+        spec: CommandSpec,
+        arguments: tuple[str, ...],
     ) -> CommandResult:
-        """Handle /handoff command.
-
-        Usage: /handoff <goal>
-        Returns a CommandResult with the handoff goal for InteractiveSession to process.
-        """
-        parts = raw_query.split(maxsplit=1)
-        goal = parts[1].strip() if len(parts) > 1 else ""
-
+        goal = " ".join(arguments).strip()
         if not goal:
             context.surface.emit(
-                b.warn("Usage: /handoff <goal>"),
+                b.warn(f"Usage: {spec.usage}"),
                 b.md(
                     "Example: `/handoff now optimize this query for performance`",
                     role="muted",
                 ),
             )
             return CommandResult(handled=True)
-
         return CommandResult(handled=True, handoff_goal=goal)

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -21,10 +22,32 @@ from sqlsaber.render.surface import Surface
 if TYPE_CHECKING:
     from pydantic_ai.messages import ModelMessage
 
+    from sqlsaber import SQLSaber
     from sqlsaber.artifact_resolution import ResolvedArtifactPublication
+    from sqlsaber.artifacts import ArtifactStore
+    from sqlsaber.query_results import QueryResultStore
+    from sqlsaber.threads import ThreadStorage
     from sqlsaber.tools.base import Tool
 
 logger = get_logger(__name__)
+
+
+class ThreadResumePreparationError(Exception):
+    pass
+
+
+@dataclass(slots=True)
+class PreparedThreadResume:
+    saber: SQLSaber
+    thread_id: str
+    history: list[ModelMessage]
+    hydrated_results: dict[str, str]
+    unavailable_results: set[str]
+    unavailable_artifacts: set[str]
+    resolved_artifacts: dict[str, ResolvedArtifactPublication]
+    storage: ThreadStorage
+    artifact_store: ArtifactStore
+    query_result_store: QueryResultStore
 
 
 threads_app = cyclopts.App(
@@ -404,6 +427,143 @@ def list_artifacts(
     asyncio.run(_run())
 
 
+async def prepare_thread_resume(
+    thread_id: str,
+    database: list[str] | None = None,
+    *,
+    storage: ThreadStorage | None = None,
+    artifact_store: ArtifactStore | None = None,
+    query_result_store: QueryResultStore | None = None,
+) -> PreparedThreadResume:
+    from sqlsaber import (
+        SQLSaber,
+        SQLSaberOptions,
+        ThreadDatabaseRequiredError,
+        ThreadDatabaseUnavailableError,
+        ThreadNotFoundError,
+        ThreadResumeHistoryError,
+        ThreadResumeMetadataError,
+    )
+    from sqlsaber.cli.artifacts import cli_artifact_store
+    from sqlsaber.cli.query_results import cli_query_result_store
+    from sqlsaber.database.resolver import DatabaseResolutionError
+    from sqlsaber.threads import ThreadStorage
+
+    store = storage if storage is not None else ThreadStorage()
+    artifacts = artifact_store if artifact_store is not None else cli_artifact_store()
+    query_results = (
+        query_result_store
+        if query_result_store is not None
+        else cli_query_result_store()
+    )
+    try:
+        saber = await SQLSaber.resume(
+            thread_id,
+            options=SQLSaberOptions(
+                database=database,
+                artifact_store=artifacts,
+                query_result_store=query_results,
+            ),
+            storage=store,
+        )
+    except ThreadNotFoundError:
+        raise ThreadResumePreparationError(
+            f"thread not found: {thread_id}\n  List threads with: saber threads list"
+        ) from None
+    except ThreadResumeHistoryError as exc:
+        raise ThreadResumePreparationError(
+            f"thread history cannot be resumed: {exc.reason}"
+        ) from None
+    except ThreadDatabaseUnavailableError:
+        raise ThreadResumePreparationError(
+            "the thread database is not configured for automatic resume.\n"
+            f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+        ) from None
+    except ThreadDatabaseRequiredError as exc:
+        if exc.reason == "No configured database selector is stored for this thread.":
+            message = (
+                "no database is specified or stored with this thread.\n"
+                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+            )
+        else:
+            message = (
+                f"invalid thread metadata: {exc.reason}\n"
+                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+            )
+        raise ThreadResumePreparationError(message) from None
+    except ThreadResumeMetadataError as exc:
+        raise ThreadResumePreparationError(
+            f"invalid thread metadata: {exc.reason}\n"
+            f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+        ) from None
+    except DatabaseResolutionError as exc:
+        raise ThreadResumePreparationError(
+            f"Error resolving database: {exc}\n"
+            f"  Retry with: saber threads resume {thread_id} --database DATABASE"
+        ) from None
+
+    try:
+        history = await store.get_thread_messages(thread_id)
+        from sqlsaber.cli.query_results import hydrate_query_result_contents
+        from sqlsaber.query_result_resolution import (
+            query_result_references_from_messages,
+        )
+
+        if any(
+            reference.descriptor is not None
+            for reference in query_result_references_from_messages(history)
+        ):
+            hydrated, unavailable = await hydrate_query_result_contents(
+                history, store=saber.query_result_store
+            )
+        else:
+            hydrated, unavailable = {}, set()
+        from sqlsaber.cli.artifacts import resolve_cli_artifact_publications
+
+        resolved = await resolve_cli_artifact_publications(history, store=artifacts)
+        unavailable_artifacts = {
+            artifact.id
+            for publication in resolved.values()
+            for artifact in publication.unavailable
+        }
+    except BaseException:
+        await saber.close()
+        raise
+
+    return PreparedThreadResume(
+        saber=saber,
+        thread_id=thread_id,
+        history=list(history),
+        hydrated_results=hydrated,
+        unavailable_results=unavailable,
+        unavailable_artifacts=unavailable_artifacts,
+        resolved_artifacts=dict(resolved),
+        storage=store,
+        artifact_store=artifacts,
+        query_result_store=query_results,
+    )
+
+
+def render_prepared_thread(surface: Surface, prepared: PreparedThreadResume) -> None:
+    from sqlsaber.render.terminal import TerminalSurface
+
+    if isinstance(surface, TerminalSurface):
+        surface.emit(b.panel((b.md(f"Thread: {prepared.thread_id}"),), role="primary"))
+    else:
+        surface.emit(b.md(f"# Thread: {prepared.thread_id}"))
+    saber = prepared.saber
+    _render_transcript(
+        surface,
+        prepared.history,
+        None,
+        hydrated_results=prepared.hydrated_results,
+        unavailable_results=prepared.unavailable_results,
+        unavailable_artifacts=prepared.unavailable_artifacts,
+        resolved_artifacts=prepared.resolved_artifacts,
+        display_registry=getattr(saber, "display_registry", None),
+    )
+
+
 @threads_app.command(
     help_epilogue=(
         "Examples:\n\n"
@@ -433,140 +593,32 @@ def resume(
     store = ThreadStorage()
 
     async def _run() -> None:
-        from sqlsaber import (
-            SQLSaber,
-            SQLSaberOptions,
-            ThreadDatabaseRequiredError,
-            ThreadDatabaseUnavailableError,
-            ThreadNotFoundError,
-            ThreadResumeHistoryError,
-            ThreadResumeMetadataError,
-        )
         from sqlsaber.cli.artifacts import cli_artifact_store
         from sqlsaber.cli.interactive import InteractiveSession
         from sqlsaber.cli.query_results import cli_query_result_store
         from sqlsaber.cli.retention import run_cli_retention
-        from sqlsaber.database.resolver import DatabaseResolutionError
 
         artifact_store = cli_artifact_store()
         query_result_store = cli_query_result_store()
         try:
-            saber = await SQLSaber.resume(
+            prepared = await prepare_thread_resume(
                 thread_id,
-                options=SQLSaberOptions(
-                    database=database,
-                    artifact_store=artifact_store,
-                    query_result_store=query_result_store,
-                ),
+                database,
                 storage=store,
+                artifact_store=artifact_store,
+                query_result_store=query_result_store,
             )
-        except ThreadNotFoundError:
-            logger.error("threads.cli.resume.not_found", thread_id=thread_id)
-            fail(
-                f"thread not found: {thread_id}\n  List threads with: saber threads list"
-            )
-        except ThreadResumeHistoryError as exc:
-            logger.error(
-                "threads.cli.resume.history_invalid",
-                thread_id=thread_id,
-                error=exc.reason,
-            )
-            fail(f"thread history cannot be resumed: {exc.reason}")
-        except ThreadDatabaseUnavailableError as exc:
-            logger.error(
-                "threads.cli.resume.database_not_configured",
-                thread_id=thread_id,
-                missing=exc.database_names,
-            )
-            fail(
-                "the thread database is not configured for automatic resume.\n"
-                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
-            )
-        except ThreadDatabaseRequiredError as exc:
-            if (
-                exc.reason
-                == "No configured database selector is stored for this thread."
-            ):
-                logger.error("threads.cli.resume.no_database", thread_id=thread_id)
-                fail(
-                    "no database is specified or stored with this thread.\n"
-                    f"  Retry with: saber threads resume {thread_id} --database DATABASE"
-                )
-            logger.error(
-                "threads.cli.resume.metadata_invalid",
-                thread_id=thread_id,
-                error=exc.reason,
-            )
-            fail(
-                f"invalid thread metadata: {exc.reason}\n"
-                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
-            )
-        except ThreadResumeMetadataError as exc:
-            logger.error(
-                "threads.cli.resume.metadata_invalid",
-                thread_id=thread_id,
-                error=exc.reason,
-            )
-            fail(
-                f"invalid thread metadata: {exc.reason}\n"
-                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
-            )
-        except DatabaseResolutionError as exc:
-            logger.error(
-                "threads.cli.resume.resolve_failed",
-                thread_id=thread_id,
-                error=str(exc),
-            )
-            fail(
-                f"Error resolving database: {exc}\n"
-                f"  Retry with: saber threads resume {thread_id} --database DATABASE"
-            )
+        except ThreadResumePreparationError as exc:
+            fail(str(exc))
 
+        saber = prepared.saber
         try:
-            history = await store.get_thread_messages(thread_id)
-            from sqlsaber.render.terminal import TerminalSurface
-
-            if isinstance(cli_out(), TerminalSurface):
-                out(b.panel((b.md(f"Thread: {thread_id}"),), role="primary"))
-            else:
-                out(b.md(f"# Thread: {thread_id}"))
-            from sqlsaber.cli.query_results import hydrate_query_result_contents
-
-            from sqlsaber.query_result_resolution import (
-                query_result_references_from_messages,
-            )
-
-            if any(
-                reference.descriptor is not None
-                for reference in query_result_references_from_messages(history)
-            ):
-                hydrated, unavailable = await hydrate_query_result_contents(
-                    history, store=saber.query_result_store
-                )
-            else:
-                hydrated, unavailable = {}, set()
-            from sqlsaber.cli.artifacts import resolve_cli_artifact_publications
-
-            resolved_artifacts = await resolve_cli_artifact_publications(
-                history,
-                store=artifact_store,
-            )
-            artifact_unavailable = {
-                artifact.id
-                for publication in resolved_artifacts.values()
-                for artifact in publication.unavailable
-            }
-            _render_transcript(
-                cli_out(),
-                history,
-                None,
-                hydrated_results=hydrated,
-                unavailable_results=unavailable,
-                unavailable_artifacts=artifact_unavailable,
-                resolved_artifacts=resolved_artifacts,
-            )
+            render_prepared_thread(cli_out(), prepared)
             interactive_session = InteractiveSession(saber)
-            await interactive_session.run()
+            try:
+                await interactive_session.run()
+            finally:
+                saber = getattr(interactive_session, "saber", saber)
         finally:
             try:
                 await saber.close()

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -38,10 +38,10 @@ from saber_tui.utils import (
     wrap_text_with_ansi,
 )
 
+from sqlsaber.cli.command_catalog import PaletteCommand, PaletteMode, palette_commands
 from sqlsaber.config.settings import ThinkingLevel
 
 type SubmitHandler = Callable[[str], bool | None]
-type ThinkingChangeHandler = Callable[[bool, ThinkingLevel | None], None]
 
 
 def _bold(text: str) -> str:
@@ -52,7 +52,7 @@ _RESPONSIVE_IMAGE_MAX_CELLS = 2**31 - 1
 MIN_TUI_WIDTH_CACHE_SIZE = 65_536
 SHIFT_ENTER_SEQUENCE = "\x1b[13;2u"
 SHIFT_ENTER_FALLBACK_SEQUENCES = {"\n", "\x1b\r"}
-THINKING_MODE_SETTING_ID = "thinking_mode"
+THINKING_MODE_SETTING_ID = "/thinking"
 THINKING_MODE_VALUES = ["off", *(level.value for level in ThinkingLevel)]
 ACTION_VALUE = ""
 COMMAND_PALETTE_MAX_WIDTH = 60
@@ -396,6 +396,7 @@ class ChatApp:
         self.should_submit_empty = should_submit_empty
         self.on_open_command_palette = on_open_command_palette
         self._command_palette_component: _CommandPaletteComponent | None = None
+        self._palette_fill_hint = False
 
     def submit(self, text: str) -> None:
         text = text.strip()
@@ -410,6 +411,9 @@ class ChatApp:
             self.tui.set_focus(self.editor)
             self.tui.request_render()
             return
+        if self._palette_fill_hint:
+            self._palette_fill_hint = False
+            self.clear_status()
         if text and not text.startswith("/"):
             self.append_user_message(text)
             self.editor.add_to_history(text)
@@ -552,6 +556,10 @@ class ChatApp:
             del children[0]
         self.tui.request_render()
 
+    def clear_chat(self) -> None:
+        self.chat_container.children.clear()
+        self.tui.request_render()
+
     def set_status(self, text: str | None) -> None:
         self.status.set_text(text)
         self.tui.request_render()
@@ -581,59 +589,43 @@ class ChatApp:
         *,
         thinking_enabled: bool,
         thinking_level: ThinkingLevel,
-        on_thinking_change: ThinkingChangeHandler,
+        commands: tuple[PaletteCommand, ...] | None = None,
         model_name: str | None = None,
         database_name: str | None = None,
     ) -> None:
         """Open the command palette."""
+        del model_name, database_name
         self.close_command_palette()
-
+        command_rows = commands or palette_commands()
+        rows_by_command = {row.command: row for row in command_rows}
         current_mode = thinking_level.value if thinking_enabled else "off"
 
         def on_change(setting_id: str, value: str) -> None:
-            if setting_id == THINKING_MODE_SETTING_ID:
-                if value == "off":
-                    on_thinking_change(False, None)
-                    self.set_status("Thinking disabled")
-                    return
-
-                level = ThinkingLevel(value)
-                on_thinking_change(True, level)
-                self.set_status(f"Thinking enabled ({level.value})")
+            row = rows_by_command[setting_id]
+            if row.mode is PaletteMode.THINKING:
+                self.close_command_palette()
+                self.submit(f"{row.command} {value}")
                 return
 
-            self._run_command_palette_action(setting_id)
+            self._run_command_palette_action(row)
 
-        settings_items = [
-            SettingItem(
-                THINKING_MODE_SETTING_ID,
-                "Thinking mode",
-                current_mode,
-                values=list(THINKING_MODE_VALUES),
-                description="Controls provider reasoning for this interactive session.",
-            ),
-            SettingItem(
-                "handoff",
-                "Handoff thread",
-                ACTION_VALUE,
-                values=[ACTION_VALUE],
-                description="Draft a prompt for a new thread with current context.",
-            ),
-            SettingItem(
-                "clear",
-                "Clear conversation",
-                ACTION_VALUE,
-                values=[ACTION_VALUE],
-                description="Clear visible conversation and current thread history.",
-            ),
-            SettingItem(
-                "exit",
-                "Exit",
-                ACTION_VALUE,
-                values=[ACTION_VALUE],
-                description="End this interactive session.",
-            ),
-        ]
+        settings_items = []
+        for row in command_rows:
+            values = (
+                list(THINKING_MODE_VALUES)
+                if row.mode is PaletteMode.THINKING
+                else [ACTION_VALUE]
+            )
+            value = current_mode if row.mode is PaletteMode.THINKING else ACTION_VALUE
+            settings_items.append(
+                SettingItem(
+                    row.command,
+                    row.label,
+                    value,
+                    values=values,
+                    description=row.description,
+                )
+            )
         settings = SettingsList(
             settings_items,
             max_visible=8,
@@ -651,24 +643,16 @@ class ChatApp:
         self.tui.set_focus(component)
         self.tui.request_render()
 
-    def _run_command_palette_action(self, action_id: str) -> None:
-        if action_id == "handoff":
-            self.close_command_palette()
-            self.editor.set_text("/handoff ")
-            self.set_status("Type the handoff goal and press Enter.")
-            self.tui.set_focus(self.editor)
-            self.tui.request_render()
+    def _run_command_palette_action(self, command: PaletteCommand) -> None:
+        self.close_command_palette()
+        if command.mode is PaletteMode.SUBMIT:
+            self.submit(command.command)
             return
-
-        if action_id == "clear":
-            self.close_command_palette()
-            self.submit("/clear")
-            return
-
-        if action_id == "exit":
-            self.close_command_palette()
-            self.submit("/exit")
-            return
+        self.editor.set_text(f"{command.command} ")
+        self._palette_fill_hint = True
+        self.set_status("Complete the command and press Enter.")
+        self.tui.set_focus(self.editor)
+        self.tui.request_render()
 
     def close_command_palette(self) -> None:
         component = self._command_palette_component
@@ -785,6 +769,10 @@ def build_chat_app(
             return {"consume": True}
         if data in SHIFT_ENTER_FALLBACK_SEQUENCES:
             return {"data": SHIFT_ENTER_SEQUENCE}
+        if app.tui.has_overlay() and matches_key(data, "ctrl+d"):
+            return {"data": "\x1b"}
+        if app.tui.has_overlay() and matches_key(data, "ctrl+c"):
+            return None
         if matches_key(data, "ctrl+d") and not editor.get_text().strip():
             if app.status.cancel_loading():
                 app.tui.set_focus(app.editor)

--- a/src/sqlsaber/cli/workflows/auth_setup.py
+++ b/src/sqlsaber/cli/workflows/auth_setup.py
@@ -27,7 +27,10 @@ async def select_provider(prompter: Prompter, default: str = "anthropic") -> str
 
 
 async def configure_api_key(
-    provider: str, api_key_manager: APIKeyManager, auth_manager: AuthConfigManager
+    provider: str,
+    prompter: Prompter,
+    api_key_manager: APIKeyManager,
+    auth_manager: AuthConfigManager,
 ) -> bool:
     """Configure API key for a provider.
 
@@ -39,13 +42,19 @@ async def configure_api_key(
     Returns:
         True if API key configured successfully, False otherwise
     """
-    api_key = api_key_manager.get_api_key(provider)
+    api_key = api_key_manager.get_configured_api_key(provider)
+    if not api_key:
+        api_key = await prompter.secret(
+            f"Enter your {provider.title()} API key (leave blank to skip):"
+        )
+        api_key = api_key.strip() if api_key else None
+        if api_key and not api_key_manager.store_api_key(provider, api_key):
+            return False
 
-    if api_key:
-        auth_manager.set_auth_method(AuthMethod.API_KEY)
-        return True
-
-    return False
+    if not api_key:
+        return False
+    auth_manager.set_auth_method(AuthMethod.API_KEY)
+    return True
 
 
 async def setup_auth(
@@ -113,7 +122,7 @@ async def setup_auth(
     )
 
     api_key_configured = await configure_api_key(
-        provider, api_key_manager, auth_manager
+        provider, prompter, api_key_manager, auth_manager
     )
 
     if api_key_configured:

--- a/src/sqlsaber/cli/workflows/db_setup.py
+++ b/src/sqlsaber/cli/workflows/db_setup.py
@@ -1,6 +1,5 @@
 """Shared database setup logic for onboarding and CLI."""
 
-import getpass
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -120,7 +119,9 @@ async def collect_db_input(
         if username is None:
             return None
 
-        password = getpass.getpass("Password (stored in your OS keychain): ")
+        password = await prompter.secret("Password (stored in your OS keychain):")
+        if password is None:
+            return None
 
         ssl_mode = None
         ssl_ca = None

--- a/src/sqlsaber/config/api_keys.py
+++ b/src/sqlsaber/config/api_keys.py
@@ -19,21 +19,34 @@ class APIKeyManager:
 
     def get_api_key(self, provider: str) -> str | None:
         """Get API key for the specified provider using cascading logic."""
-        env_var_name = self.get_env_var_name(provider)
-        service_name = self._get_service_name(provider)
-
-        api_key = os.getenv(env_var_name)
+        api_key = self.get_configured_api_key(provider)
         if api_key:
             return api_key
+        return self._prompt_and_store_key(
+            provider,
+            self.get_env_var_name(provider),
+            self._get_service_name(provider),
+        )
 
+    def get_configured_api_key(self, provider: str) -> str | None:
+        """Read an API key without prompting."""
+        api_key = os.getenv(self.get_env_var_name(provider))
+        if api_key:
+            return api_key
         try:
-            api_key = keyring.get_password(service_name, provider)
-            if api_key:
-                return api_key
+            return keyring.get_password(self._get_service_name(provider), provider)
         except Exception as e:
             cli_err().emit(b.warn(f"Keyring access failed: {e}"))
+            return None
 
-        return self._prompt_and_store_key(provider, env_var_name, service_name)
+    def store_api_key(self, provider: str, api_key: str) -> bool:
+        """Store an API key in the operating system credentials store."""
+        try:
+            keyring.set_password(self._get_service_name(provider), provider, api_key)
+            return True
+        except Exception as e:
+            cli_err().emit(b.warn(f"Could not store API key: {e}"))
+            return False
 
     def has_stored_api_key(self, provider: str) -> bool:
         """Check if an API key is stored for the provider."""

--- a/src/sqlsaber/render/__init__.py
+++ b/src/sqlsaber/render/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, TextIO
 
 from . import blocks
@@ -75,6 +76,7 @@ __all__ = [
     "TextBlock",
     "TextStream",
     "ansi",
+    "bind_cli_surfaces",
     "blocks",
     "cli_err",
     "cli_out",
@@ -96,6 +98,8 @@ __all__ = [
 
 _out: Surface | None = None
 _err: Surface | None = None
+_bound_out: ContextVar[Surface | None] = ContextVar("sqlsaber_cli_out", default=None)
+_bound_err: ContextVar[Surface | None] = ContextVar("sqlsaber_cli_err", default=None)
 
 
 def _stream_closed(surface: Surface | None) -> bool:
@@ -109,6 +113,8 @@ def cli_out() -> Surface:
     Returns:
         The stdout ``Surface``.
     """
+    if bound := _bound_out.get():
+        return bound
     global _out
     if _out is None or _stream_closed(_out):
         _out = _make_surface(sys.stdout, stderr=False)
@@ -121,10 +127,24 @@ def cli_err() -> Surface:
     Returns:
         The stderr ``Surface``.
     """
+    if bound := _bound_err.get():
+        return bound
     global _err
     if _err is None or _stream_closed(_err):
         _err = _make_surface(sys.stderr, stderr=True)
     return _err
+
+
+@contextmanager
+def bind_cli_surfaces(stdout: Surface, stderr: Surface | None = None) -> Iterator[None]:
+    """Bind CLI rendering to surfaces in the current async or thread context."""
+    out_token = _bound_out.set(stdout)
+    err_token = _bound_err.set(stderr or stdout)
+    try:
+        yield
+    finally:
+        _bound_err.reset(err_token)
+        _bound_out.reset(out_token)
 
 
 def reset_io(

--- a/src/sqlsaber/render/prompts.py
+++ b/src/sqlsaber/render/prompts.py
@@ -31,6 +31,18 @@ def _default_process_terminal() -> Any:
     return PosixProcessTerminal()
 
 
+class _MaskedInput(Input):
+    def render(self, width: int) -> list[str]:
+        value = self.value
+        cursor = self.cursor
+        self.value = "*" * len(value)
+        try:
+            return super().render(width)
+        finally:
+            self.value = value
+            self.cursor = cursor
+
+
 class PromptForm:
     """Message line plus Input or filtered SelectList plus a hint line.
 
@@ -113,10 +125,11 @@ class PromptForm:
 
     def _build(self) -> None:
         prompt = self._prompt
-        if isinstance(prompt, AskText | AskPath):
-            widget = Input()
+        if isinstance(prompt, AskText | AskPath | AskSecret):
+            widget = _MaskedInput() if isinstance(prompt, AskSecret) else Input()
             widget.focused = True
-            widget.set_value(prompt.default)
+            if isinstance(prompt, AskText | AskPath):
+                widget.set_value(prompt.default)
             widget.on_submit = self._submit_text
             widget.on_escape = self._on_cancel
             self._input = widget
@@ -205,8 +218,6 @@ async def ask_in_overlay[T](tui: TUI, prompt: Ask[T], styles: Styles) -> T | Non
     Returns:
         The typed value, or None when the user cancelled.
     """
-    if isinstance(prompt, AskSecret):
-        return cast(T | None, await asyncio.to_thread(_ask_secret, prompt))
     loop = asyncio.get_running_loop()
     future: asyncio.Future[T | None] = loop.create_future()
 

--- a/tests/test_cli/test_completers.py
+++ b/tests/test_cli/test_completers.py
@@ -8,12 +8,14 @@ def _sync_suggestions(result):
     return result
 
 
-def test_slash_command_prefix_does_not_use_editor_autocomplete() -> None:
+def test_slash_command_prefix_uses_static_command_completion() -> None:
     provider = SQLSaberAutocompleteProvider()
 
     suggestions = _sync_suggestions(provider.get_suggestions(["/thi"], 0, 4))
 
-    assert suggestions is None
+    assert suggestions is not None
+    assert suggestions.prefix == "/thi"
+    assert suggestions.items[0].value == "/thinking"
 
 
 def test_table_suggestions_use_cached_tables_and_at_prefix() -> None:
@@ -45,6 +47,37 @@ def test_table_suggestions_are_ignored_inside_quotes() -> None:
     )
 
     assert suggestions is None
+
+
+def test_slash_options_use_static_completion() -> None:
+    provider = SQLSaberAutocompleteProvider()
+
+    suggestions = _sync_suggestions(
+        provider.get_suggestions(["/db remove analytics --"], 0, 23)
+    )
+
+    assert suggestions is not None
+    assert suggestions.prefix == "--"
+    assert [item.value for item in suggestions.items] == ["--yes"]
+
+
+def test_slash_completion_waits_for_option_value() -> None:
+    provider = SQLSaberAutocompleteProvider()
+    line = "/threads list --limit "
+
+    suggestions = _sync_suggestions(provider.get_suggestions([line], 0, len(line)))
+
+    assert suggestions is None
+
+
+def test_slash_completion_treats_option_aliases_as_one_value() -> None:
+    provider = SQLSaberAutocompleteProvider()
+    line = "/knowledge search shipped -d Analytics --"
+
+    suggestions = _sync_suggestions(provider.get_suggestions([line], 0, len(line)))
+
+    assert suggestions is not None
+    assert [item.value for item in suggestions.items] == ["--limit"]
 
 
 def test_apply_table_completion_replaces_at_token() -> None:

--- a/tests/test_cli/test_slash_commands.py
+++ b/tests/test_cli/test_slash_commands.py
@@ -67,10 +67,11 @@ async def test_process_clear_command(processor, mock_context):
 
 
 @pytest.mark.asyncio
-async def test_process_settings_is_not_a_slash_command(processor, mock_context):
+async def test_process_unknown_slash_is_handled(processor, mock_context):
     result = await processor.process("/settings", mock_context)
 
-    assert result.handled is False
+    assert result.handled is True
+    assert "Unknown slash command" in _emitted_markdown(mock_context.surface)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli/test_slash_management.py
+++ b/tests/test_cli/test_slash_management.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sqlsaber.cli.command_catalog import (
+    PaletteMode,
+    management_paths,
+    palette_commands,
+)
+from sqlsaber.cli.interactive import InteractiveSession
+from sqlsaber.cli.output import out
+from sqlsaber.cli.slash_commands import (
+    CommandContext,
+    CommandResult,
+    SlashCommandProcessor,
+    ThreadResumeRequest,
+)
+from sqlsaber.cli.threads import (
+    PreparedThreadResume,
+    ThreadResumePreparationError,
+)
+from sqlsaber.cli.tui_chat import ChatApp
+from sqlsaber.cli.usage import SessionUsage
+from sqlsaber.config.settings import ThinkingLevel
+from sqlsaber.render import bind_cli_surfaces, blocks as b
+from sqlsaber.render.markdown_text import md_of
+
+EXPECTED_MANAGEMENT_PATHS = {
+    ("auth", "setup"),
+    ("auth", "status"),
+    ("auth", "reset"),
+    ("db", "add"),
+    ("db", "list"),
+    ("db", "exclude"),
+    ("db", "remove"),
+    ("db", "set-default"),
+    ("db", "test"),
+    ("knowledge", "add"),
+    ("knowledge", "list"),
+    ("knowledge", "show"),
+    ("knowledge", "search"),
+    ("knowledge", "remove"),
+    ("knowledge", "clear"),
+    ("models", "list"),
+    ("models", "set"),
+    ("models", "current"),
+    ("models", "reset"),
+    ("theme", "set"),
+    ("theme", "reset"),
+    ("threads", "list"),
+    ("threads", "show"),
+    ("threads", "artifacts"),
+    ("threads", "resume"),
+    ("threads", "prune"),
+    ("threads", "export"),
+}
+
+
+def _context() -> CommandContext:
+    saber = MagicMock()
+    saber.end_thread = AsyncMock(return_value=None)
+    saber.new_thread = AsyncMock(return_value=None)
+    saber.info = SimpleNamespace(
+        thinking=SimpleNamespace(enabled=False, level=ThinkingLevel.MEDIUM)
+    )
+    return CommandContext(surface=MagicMock(), saber=saber)
+
+
+def _output(context: CommandContext) -> str:
+    return "\n\n".join(md_of(call.args) for call in context.surface.emit.call_args_list)
+
+
+def test_registry_has_exact_management_parity() -> None:
+    assert management_paths() == EXPECTED_MANAGEMENT_PATHS
+    assert len(management_paths()) == 27
+
+
+def test_palette_projects_every_management_command_from_registry() -> None:
+    rows = {row.command: row for row in palette_commands()}
+
+    assert {f"/{' '.join(path)}" for path in EXPECTED_MANAGEMENT_PATHS} <= rows.keys()
+    assert rows["/db list"].mode is PaletteMode.SUBMIT
+    assert rows["/db remove"].mode is PaletteMode.FILL
+    assert rows["/thinking"].mode is PaletteMode.THINKING
+
+
+def test_palette_submits_zero_arg_commands_and_fills_argument_commands() -> None:
+    rows = {row.command: row for row in palette_commands()}
+    app = MagicMock()
+
+    ChatApp._run_command_palette_action(app, rows["/db list"])
+    app.submit.assert_called_once_with("/db list")
+
+    app.reset_mock()
+    ChatApp._run_command_palette_action(app, rows["/db remove"])
+    app.editor.set_text.assert_called_once_with("/db remove ")
+    app.submit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_only_management_dispatch_invokes_existing_handler() -> None:
+    context = _context()
+    database = SimpleNamespace(
+        name="CaseDB",
+        type="sqlite",
+        host="localhost",
+        port=0,
+        database="Case.DB",
+        username="sqlite",
+        exclude_schemas=[],
+        ssl_mode=None,
+        ssl_ca=None,
+        ssl_cert=None,
+    )
+    manager = MagicMock()
+    manager.list_databases.return_value = [database]
+    manager.get_default_name.return_value = "CaseDB"
+
+    with patch("sqlsaber.cli.database.config_manager", manager):
+        result = await SlashCommandProcessor().process("/db list", context)
+
+    assert result.handled is True
+    manager.list_databases.assert_called_once_with()
+    assert "CaseDB" in _output(context)
+
+
+@pytest.mark.asyncio
+async def test_cyclopts_validation_is_rendered_in_chat() -> None:
+    context = _context()
+
+    result = await SlashCommandProcessor().process("/db remove", context)
+
+    assert result.handled is True
+    assert "requires an argument" in _output(context)
+    assert "Usage: `/db remove NAME [--yes]`" in _output(context)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_preserves_quoted_values_and_case() -> None:
+    context = _context()
+    config = MagicMock()
+    config.get_database.return_value = SimpleNamespace(name="Analytics")
+    manager = MagicMock()
+    manager.add_knowledge = AsyncMock(
+        return_value=SimpleNamespace(id="entry-1", name="Revenue KPI")
+    )
+
+    with (
+        patch("sqlsaber.cli.knowledge.config_manager", config),
+        patch("sqlsaber.cli.knowledge._knowledge_manager", manager),
+    ):
+        result = await SlashCommandProcessor().process(
+            '/knowledge add "Revenue KPI" "Case Sensitive Value" -d Analytics',
+            context,
+        )
+
+    assert result.handled is True
+    manager.add_knowledge.assert_awaited_once_with(
+        database_name="Analytics",
+        name="Revenue KPI",
+        description="Case Sensitive Value",
+        sql=None,
+        source=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_quotes_are_rejected_before_dispatch() -> None:
+    context = _context()
+
+    result = await SlashCommandProcessor().process('/knowledge search "open', context)
+
+    assert result.handled is True
+    assert "Unterminated quoted value" in _output(context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("alias", ["/database", "/model", "/thread", "/k"])
+async def test_group_aliases_render_registry_help(alias: str) -> None:
+    context = _context()
+
+    result = await SlashCommandProcessor().process(f"{alias} --help", context)
+
+    assert result.handled is True
+    assert "commands" in _output(context)
+
+
+@pytest.mark.asyncio
+async def test_help_alias_group_leaf_and_flag_use_registry() -> None:
+    processor = SlashCommandProcessor()
+    context = _context()
+
+    await processor.process("/?", context)
+    assert "Session commands" in _output(context)
+    assert "Management commands" in _output(context)
+
+    context.surface.reset_mock()
+    await processor.process("/help db", context)
+    assert "`/db` commands" in _output(context)
+    assert "/db add" in _output(context)
+
+    context.surface.reset_mock()
+    await processor.process("/database remove --help", context)
+    assert "Usage: `/db remove NAME [--yes]`" in _output(context)
+
+
+@pytest.mark.asyncio
+async def test_exact_aliases_and_prefix_regressions() -> None:
+    processor = SlashCommandProcessor()
+    context = _context()
+
+    result = await processor.process("/quit", context)
+    assert result.should_exit is True
+
+    for text in ("/exit-now", "/thinkingxyz", "/unknown"):
+        context.surface.reset_mock()
+        result = await processor.process(text, context)
+        assert result.handled is True
+        assert "Unknown slash command" in _output(context)
+
+    for text in ("quitter", "exit report"):
+        result = await processor.process(text, context)
+        assert result.handled is False
+
+
+@pytest.mark.asyncio
+async def test_thread_resume_uses_cyclopts_parsing_without_nested_dispatch() -> None:
+    context = _context()
+
+    result = await SlashCommandProcessor().process(
+        "/threads resume Thread-ABC -d Analytics -d Reporting", context
+    )
+
+    assert result.resume_request == ThreadResumeRequest(
+        thread_id="Thread-ABC", databases=("Analytics", "Reporting")
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_bound_rendering_isolated_across_worker_threads() -> None:
+    first = MagicMock()
+    second = MagicMock()
+
+    async def emit(surface: MagicMock, text: str) -> None:
+        with bind_cli_surfaces(surface):
+            await asyncio.to_thread(lambda: out(b.success(text)))
+
+    await asyncio.gather(emit(first, "first"), emit(second, "second"))
+
+    assert "first" in md_of(first.emit.call_args.args)
+    assert "second" in md_of(second.emit.call_args.args)
+    assert "second" not in md_of(first.emit.call_args.args)
+
+
+@pytest.mark.asyncio
+async def test_slash_commands_are_not_written_to_disk_history() -> None:
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.current_task = None
+    session._handoff_mode = False
+    session._append_history = MagicMock()
+    session.command_processor = MagicMock()
+    session.command_processor.process = AsyncMock(
+        return_value=CommandResult(handled=True)
+    )
+    session.saber = MagicMock()
+    session.session_usage = SessionUsage()
+    session.log = MagicMock()
+    app = MagicMock()
+
+    await session._handle_submit(
+        app,
+        MagicMock(),
+        "/threads resume id -d postgresql://user:secret@host/db",
+    )
+
+    session._append_history.assert_not_called()
+
+
+def _prepared(saber: MagicMock) -> PreparedThreadResume:
+    return PreparedThreadResume(
+        saber=saber,
+        thread_id="thread-new",
+        history=[],
+        hydrated_results={},
+        unavailable_results=set(),
+        unavailable_artifacts=set(),
+        resolved_artifacts={},
+        storage=object(),
+        artifact_store=object(),
+        query_result_store=object(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_of_active_thread_does_not_prepare_duplicate() -> None:
+    old = MagicMock()
+    old.info = SimpleNamespace(thread_id="thread-new")
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.saber = old
+    prepare = AsyncMock()
+    surface = MagicMock()
+
+    with patch("sqlsaber.cli.threads.prepare_thread_resume", prepare):
+        await session._resume_thread(
+            MagicMock(), surface, ThreadResumeRequest("thread-new")
+        )
+
+    prepare.assert_not_awaited()
+    assert "already active" in _output(CommandContext(surface=surface, saber=old))
+
+
+@pytest.mark.asyncio
+async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
+    old = MagicMock()
+    old.info = SimpleNamespace(thread_id="thread-old")
+    old.end_thread = AsyncMock(return_value="thread-old")
+    old.close = AsyncMock()
+    new = MagicMock()
+    new.info = SimpleNamespace(
+        thread_id="thread-new",
+        database_names=("Analytics",),
+        primary_database_name="Analytics",
+        primary_database_type="SQLite",
+        model_name="test-model",
+        dangerous_mode=False,
+    )
+    new.close = AsyncMock()
+    new.display_registry = {}
+    new.query_result_store = MagicMock()
+    new.list_tables = AsyncMock(return_value=[])
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.saber = old
+    session.session_usage = SessionUsage(total_input_tokens=10)
+    session.autocomplete_provider = MagicMock()
+    session.streaming_handler = MagicMock()
+    app = MagicMock()
+    surface = MagicMock()
+
+    with (
+        patch(
+            "sqlsaber.cli.threads.prepare_thread_resume",
+            AsyncMock(return_value=_prepared(new)),
+        ),
+        patch("sqlsaber.cli.threads.render_prepared_thread") as render,
+    ):
+        await session._resume_thread(app, surface, ThreadResumeRequest("thread-new"))
+
+    old.end_thread.assert_awaited_once_with()
+    old.close.assert_awaited_once_with()
+    assert session.saber is new
+    app.clear_chat.assert_called_once_with()
+    render.assert_called_once()
+    new.list_tables.assert_awaited_once_with()
+    assert session.session_usage.total_input_tokens == 0
+    await session.saber.close()
+    new.close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_resume_keeps_new_session_when_old_cleanup_fails() -> None:
+    old = MagicMock()
+    old.info = SimpleNamespace(thread_id="thread-old")
+    old.end_thread = AsyncMock(return_value="thread-old")
+    old.close = AsyncMock(side_effect=RuntimeError("cleanup broke"))
+    new = MagicMock()
+    new.info = SimpleNamespace(
+        thread_id="thread-new",
+        database_names=("Analytics",),
+        primary_database_name="Analytics",
+        primary_database_type="SQLite",
+        model_name="test-model",
+        dangerous_mode=False,
+    )
+    new.display_registry = {}
+    new.query_result_store = MagicMock()
+    new.list_tables = AsyncMock(return_value=[])
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.saber = old
+    session.session_usage = SessionUsage()
+    session.autocomplete_provider = MagicMock()
+    session.streaming_handler = MagicMock()
+    session.log = MagicMock()
+    surface = MagicMock()
+
+    with (
+        patch(
+            "sqlsaber.cli.threads.prepare_thread_resume",
+            AsyncMock(return_value=_prepared(new)),
+        ),
+        patch("sqlsaber.cli.threads.render_prepared_thread"),
+    ):
+        await session._resume_thread(
+            MagicMock(), surface, ThreadResumeRequest("thread-new")
+        )
+
+    assert session.saber is new
+    assert "Previous session cleanup failed" in _output(
+        CommandContext(surface=surface, saber=new)
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_preparation_failure_keeps_old_session() -> None:
+    old = MagicMock()
+    old.info = SimpleNamespace(thread_id="thread-old")
+    old.end_thread = AsyncMock()
+    old.close = AsyncMock()
+    session = InteractiveSession.__new__(InteractiveSession)
+    session.saber = old
+
+    with patch(
+        "sqlsaber.cli.threads.prepare_thread_resume",
+        AsyncMock(side_effect=ThreadResumePreparationError("cannot resume")),
+    ):
+        with pytest.raises(ThreadResumePreparationError, match="cannot resume"):
+            await session._resume_thread(
+                MagicMock(), MagicMock(), ThreadResumeRequest("thread-new")
+            )
+
+    assert session.saber is old
+    old.end_thread.assert_not_awaited()
+    old.close.assert_not_awaited()

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -37,6 +37,7 @@ from sqlsaber.cli.tui_chat import ChatApp, build_chat_app
 from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
 from sqlsaber.config.settings import ThinkingLevel
 from sqlsaber.render import blocks as b
+from sqlsaber.render.surface import AskSecret, AskText
 from sqlsaber.theme.manager import get_theme_manager
 from sqlsaber.theme.styles import get_styles
 
@@ -336,18 +337,17 @@ def test_status_and_footer_render_within_narrow_terminal_width() -> None:
 
 def test_bare_slash_opens_command_palette_without_editor_autocomplete() -> None:
     terminal = FakeTerminal(columns=80, rows=18)
-    changes: list[tuple[bool, ThinkingLevel | None]] = []
+    submitted: list[str] = []
 
     def open_palette(app: ChatApp) -> None:
         app.show_command_palette(
             thinking_enabled=False,
             thinking_level=ThinkingLevel.MEDIUM,
-            on_thinking_change=lambda enabled, level: changes.append((enabled, level)),
         )
 
     app = build_chat_app(
         terminal=terminal,
-        on_submit=lambda text: None,
+        on_submit=lambda text: submitted.append(text),
         on_open_command_palette=open_palette,
         footer_text="DB: ocean-local (PostgreSQL) | Model: claude-opus-4-6",
     )
@@ -382,12 +382,48 @@ def test_bare_slash_opens_command_palette_without_editor_autocomplete() -> None:
 
     terminal.send_input("\r")
 
-    assert changes == [(True, ThinkingLevel.MINIMAL)]
+    assert submitted == ["/thinking minimal"]
 
     terminal.send_input("\x1b")
 
     assert app.tui.has_overlay() is False
     assert app.editor.focused is True
+
+
+@pytest.mark.asyncio
+async def test_secret_prompt_uses_masked_live_overlay() -> None:
+    terminal = FakeTerminal(columns=80, rows=18)
+    app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
+    app.tui.start()
+
+    prompt = asyncio.create_task(ChatSurface(app).ask(AskSecret("API key:")))
+    for _ in range(100):
+        if app.tui.has_overlay():
+            break
+        await asyncio.sleep(0.001)
+    assert app.tui.has_overlay() is True
+    terminal.send_input("secret-value")
+
+    assert "secret-value" not in "\n".join(app.render_plain_viewport())
+    terminal.send_input("\r")
+    assert await asyncio.wait_for(prompt, timeout=1) == "secret-value"
+    assert app.tui.has_overlay() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_key", ["\x03", "\x04"])
+async def test_prompt_cancel_keys_resolve_live_overlay(cancel_key: str) -> None:
+    terminal = FakeTerminal(columns=80, rows=18)
+    app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
+    app.tui.start()
+
+    prompt = asyncio.create_task(ChatSurface(app).ask(AskText("Name:")))
+    await asyncio.sleep(0)
+    terminal.send_input(cancel_key)
+
+    assert await asyncio.wait_for(prompt, timeout=1) is None
+    assert app.tui.has_overlay() is False
+    assert terminal.stopped is False
 
 
 def test_status_snapshots_loader_across_render_cancel_and_dispose() -> None:
@@ -425,7 +461,6 @@ def test_command_palette_ctrl_c_closes_without_running_cancel_handler() -> None:
         app.show_command_palette(
             thinking_enabled=False,
             thinking_level=ThinkingLevel.MEDIUM,
-            on_thinking_change=lambda _enabled, _level: None,
         )
 
     app = build_chat_app(

--- a/tests/test_cli/workflows/test_auth_setup.py
+++ b/tests/test_cli/workflows/test_auth_setup.py
@@ -18,9 +18,11 @@ class DummyPrompter:
         self,
         selects: list[Any] | None = None,
         confirms: list[bool | None] | None = None,
+        secrets: list[str | None] | None = None,
     ):
         self._selects = deque(selects or [])
         self._confirms = deque(confirms or [])
+        self._secrets = deque(secrets or [])
 
     async def select(
         self,
@@ -46,6 +48,12 @@ class DummyPrompter:
 
     async def path(self, message: str, only_directories: bool = False) -> str | None:
         return None
+
+    async def secret(self, message: str) -> str | None:
+        try:
+            return self._secrets.popleft()
+        except IndexError:
+            return None
 
 
 @pytest.mark.asyncio
@@ -74,3 +82,27 @@ async def test_setup_auth_resets_existing_api_key(monkeypatch: pytest.MonkeyPatc
     assert provider == "openai"
     api_key_manager.delete_api_key.assert_called_once_with("openai")
     configure_api_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_auth_uses_bound_secret_prompt_for_new_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    prompter = DummyPrompter(selects=["openai"], secrets=["  secret-key  "])
+    auth_manager = MagicMock()
+    api_key_manager = MagicMock()
+    api_key_manager.get_env_var_name.return_value = "OPENAI_API_KEY"
+    api_key_manager.has_stored_api_key.return_value = False
+    api_key_manager.get_configured_api_key.return_value = None
+    api_key_manager.store_api_key.return_value = True
+
+    success, provider = await setup_auth(
+        prompter=prompter,
+        auth_manager=auth_manager,
+        api_key_manager=api_key_manager,
+        default_provider="openai",
+    )
+
+    assert (success, provider) == (True, "openai")
+    api_key_manager.store_api_key.assert_called_once_with("openai", "secret-key")


### PR DESCRIPTION
## Summary

- expose all 27 management CLI operations as interactive slash commands
- drive help, completion, aliases, and command-palette entries from one typed registry
- reuse Cyclopts handlers with context-bound TUI output and support in-place thread resume
- add masked secret prompts and focused slash-command coverage

## Verification

- `env -u FORCE_COLOR uv run python -m pytest -q` (`1372 passed, 6 skipped`)
- `uv run ruff check .`
- `uvx ty check src/`
- live TUI verification for `/db list`, `/help db`, unknown command rejection, and exit
