### PR TITLE
fix(tui): clear stale editor after layout shrink

### DIFF
--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -723,7 +723,7 @@ def build_chat_app(
     term = terminal if terminal is not None else _default_process_terminal()
     tui = TUI(term)
     tui.set_show_hardware_cursor(True)
-    tui.set_clear_on_shrink(False)
+    tui.set_clear_on_shrink(True)
 
     theme = _build_tui_theme()
     chat_container = Container()

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -335,6 +335,41 @@ def test_status_and_footer_render_within_narrow_terminal_width() -> None:
     assert all(visible_width(line) <= terminal.columns for line in lines)
 
 
+def test_chat_app_clears_terminal_on_layout_shrink() -> None:
+    terminal = FakeTerminal(columns=80, rows=18)
+
+    def open_palette(app: ChatApp) -> None:
+        app.show_command_palette(
+            thinking_enabled=False,
+            thinking_level=ThinkingLevel.MEDIUM,
+        )
+
+    app = build_chat_app(
+        terminal=terminal,
+        on_submit=lambda text: None,
+        on_open_command_palette=open_palette,
+    )
+    app.tui.start()
+    editor_height = len(app.tui.previous_lines)
+
+    terminal.send_input("/")
+    app.tui.flush_render()
+    palette_height = len(app.tui.previous_lines)
+
+    assert app.is_command_palette_open() is True
+    assert palette_height > editor_height
+    redraws_after_open = app.tui.full_redraws
+
+    terminal.send_input("\x1b")
+    app.tui.flush_render()
+    restored_editor_height = len(app.tui.previous_lines)
+
+    assert app.is_command_palette_open() is False
+    assert app.editor.focused is True
+    assert restored_editor_height == editor_height
+    assert app.tui.full_redraws == redraws_after_open + 1
+
+
 def test_bare_slash_opens_command_palette_without_editor_autocomplete() -> None:
     terminal = FakeTerminal(columns=80, rows=18)
     submitted: list[str] = []


### PR DESCRIPTION
## Summary

- enable saber-tui shrink clearing so stale editor and footer rows are removed
- add a behavioral regression test covering command-palette expansion and contraction

## Root cause

Closing the command palette contracted the rendered frame while `clear_on_shrink` was disabled. Delayed multi-block command output could then leave the previous editor and footer in the terminal before rendering the current ones.

## Testing

- `env -u FORCE_COLOR uv run python -m pytest -q` (`1373 passed, 6 skipped`)
- `uv run ruff check .`
- `uvx ty check src/`
- `git diff --check`
