### PR TITLE
fix(cli): document mixed names for repeated -d

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -32,6 +32,12 @@ DANGEROUS_MODE_SCOPE = (
 
 DANGEROUS_MODE_WARNING = f"The assistant can execute {DANGEROUS_MODE_SCOPE}"
 DANGEROUS_MODE_HELP = f"Allow {DANGEROUS_MODE_SCOPE}"
+DATABASE_OPTION_HELP = (
+    "Database connection name, file path (CSV/SQLite/DuckDB), or connection "
+    "string (postgresql://, mysql://, duckdb://). Repeat -d for multiple saved "
+    "names, files, or DSNs. Repeated CSV files merge into one session. Uses "
+    "the default if omitted"
+)
 
 
 class CLIError(Exception):
@@ -49,6 +55,8 @@ app = cyclopts.App(
         "Examples:\n\n"
         'saber "show me all users"\n\n'
         'echo "top customers by revenue" | saber\n\n'
+        'saber -d sales -d analytics "compare revenue to sessions"\n\n'
+        'saber -d users.csv -d orders.csv "join users and orders"\n\n'
         'saber --thread THREAD_ID "now compare that with last quarter"'
     ),
 )
@@ -67,7 +75,7 @@ def meta_handler(
         list[str] | None,
         cyclopts.Parameter(
             ["--database", "-d"],
-            help="Database connection name, file path (CSV/SQLite/DuckDB), connection string (postgresql://, mysql://, duckdb://), or one/more CSV files via repeated -d (uses default if not specified)",
+            help=DATABASE_OPTION_HELP,
         ),
     ] = None,
 ):
@@ -78,6 +86,7 @@ def meta_handler(
         saber                                  # Start interactive mode
         saber "show me all users"              # Run a single query with default database
         saber -d mydb "show me users"          # Run a query with specific database
+        saber -d sales -d analytics "compare revenue"  # Multiple saved connections
         saber -d data.csv "show me users"      # Run a query with ad-hoc CSV file
         saber -d users.csv -d orders.csv "join users and orders"  # Multiple CSV files (one view per file)
         saber -d data.db "show me users"       # Run a query with ad-hoc SQLite file
@@ -103,7 +112,7 @@ def query(
         list[str] | None,
         cyclopts.Parameter(
             ["--database", "-d"],
-            help="Database connection name, file path (CSV/SQLite/DuckDB), connection string (postgresql://, mysql://, duckdb://), or one/more CSV files via repeated -d (uses default if not specified)",
+            help=DATABASE_OPTION_HELP,
         ),
     ] = None,
     thinking: Annotated[
@@ -146,6 +155,7 @@ def query(
     Examples:
         saber                             # Start interactive mode
         saber "show me all users"         # Run a single query
+        saber -d sales -d analytics "compare revenue"  # Multiple saved connections
         saber -d data.csv "show users"    # Run a query with ad-hoc CSV file
         saber -d users.csv -d orders.csv "join users and orders"  # Multiple CSV files (one view per file)
         saber -d data.db "show users"     # Run a query with ad-hoc SQLite file

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -577,7 +577,12 @@ def resume(
         list[str] | None,
         cyclopts.Parameter(
             ["--database", "-d"],
-            help="Database name, DSN override, or one/more CSV files via repeated -d",
+            help=(
+                "Database connection name, file path (CSV/SQLite/DuckDB), or "
+                "connection string (postgresql://, mysql://, duckdb://). Repeat "
+                "-d for multiple saved names, files, or DSNs. Repeated CSV "
+                "files merge into one session. Uses the default if omitted"
+            ),
         ),
     ] = None,
 ):

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -46,3 +46,21 @@ class TestCLICommands:
         assert "knowledge" in captured.out
         assert "models" in captured.out
         assert "auth" in captured.out
+
+    @staticmethod
+    def _help_text(capsys, args: list[str]) -> str:
+        with pytest.raises(SystemExit) as exc_info:
+            app(args)
+        assert exc_info.value.code == 0
+        ascii_only = "".join(
+            ch if ch.isascii() else " " for ch in capsys.readouterr().out
+        )
+        return " ".join(ascii_only.split())
+
+    def test_repeated_database_help_is_not_csv_only(self, capsys):
+        """Repeated -d help must describe mixed selectors, not CSV files only."""
+        text = self._help_text(capsys, ["--help"])
+        assert "one/more CSV files via repeated -d" not in text
+        assert "multiple saved names" in text
+        assert "CSV files merge" in text
+        assert "-d sales -d analytics" in text

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -58,7 +58,6 @@ class TestCLICommands:
         return " ".join(ascii_only.split())
 
     def test_repeated_database_help_is_not_csv_only(self, capsys):
-        """Repeated -d help must describe mixed selectors, not CSV files only."""
         text = self._help_text(capsys, ["--help"])
         assert "one/more CSV files via repeated -d" not in text
         assert "multiple saved names" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`resolve_databases` already accepts mixed saved connection names, files, and DSNs when you repeat `-d`. All-CSV lists still merge into one session. Root `saber --help` (the query command) still described repeated `-d` as CSV files only, so the CLI lied about a contract the resolver already implements.

## Scope

- `DATABASE_OPTION_HELP` in `src/sqlsaber/cli/commands.py` now says repeat `-d` for multiple saved names, files, or DSNs, and that repeated CSV files merge.
- Root examples include `saber -d sales -d analytics` and keep the CSV merge example.
- `saber threads resume --database` uses the same help text.
- `tests/test_cli/test_commands.py` asserts the CSV-only phrase is gone and the mixed-name example is present.
- Resolver behavior is unchanged. `docs/src/content/docs/guides/multi-database.mdx` already matched the resolver, so it is not in this diff.

## Tradeoffs

Help lives in three CLI option sites. The query and meta handlers share `DATABASE_OPTION_HELP`. `threads resume` repeats the same sentence so `cli/threads.py` does not import `cli/commands.py` (that import is circular today).

## Blast Radius

Users who read `saber --help` now see mixed saved names as valid. Query and thread-resume behavior is unchanged. Agents that parse the old CSV-only phrase will see new copy.

## Verification

Failing repro, `uv run saber --help` before the copy change:

```
DATABASE --database -d   Database connection name, file path
  --empty-database       (CSV/SQLite/DuckDB), connection string
                         (postgresql://, mysql://, duckdb://), or one/more
                         CSV files via repeated -d (uses default if not
                         specified)
```

Passing, same command after:

```
DATABASE --database -d   Database connection name, file path
  --empty-database       (CSV/SQLite/DuckDB), or connection string
                         (postgresql://, mysql://, duckdb://). Repeat -d for
                         multiple saved names, files, or DSNs. Repeated CSV
                         files merge into one session. Uses the default if
                         omitted

saber -d sales -d analytics "compare revenue to sessions"
saber -d users.csv -d orders.csv "join users and orders"
```

Isolated `saber -d verification -d nonexistent` still reports `Database connection 'nonexistent' not found`. Duplicate saved names still report `Cannot use duplicate database name 'verification' in a multi-database session`. Those are the mixed-name resolver paths, not the CSV-merge path.

`env -u FORCE_COLOR uv run python -m pytest tests/test_cli/test_commands.py tests/test_cli/test_agent_friendly_cli.py` passed (35 tests). The new help test failed first on the CSV-only phrase, then passed after the copy change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-452b6cce-382c-479d-821b-215e64e4fe7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-452b6cce-382c-479d-821b-215e64e4fe7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

