### PR TITLE
feat(config): add xAI Grok provider

### DIFF
--- a/.agents/skills/verify-sqlsaber/bin/verify-sqlsaber
+++ b/.agents/skills/verify-sqlsaber/bin/verify-sqlsaber
@@ -285,6 +285,7 @@ def doctor(run_id: str) -> None:
             "MISTRAL_API_KEY",
             "COHERE_API_KEY",
             "HUGGINGFACE_API_KEY",
+            "XAI_API_KEY",
         )
         if os.getenv(name)
     ]

--- a/.agents/skills/verify-sqlsaber/features/authentication.md
+++ b/.agents/skills/verify-sqlsaber/features/authentication.md
@@ -22,7 +22,8 @@ Preconditions:
 - Never type a real API key into a transcript.
 
 - **Fresh status.** Capture `saber auth status`. A fresh run prints `Authentication Status`, says no method is configured, and points to `saber auth setup`.
-- **Environment status.** If `OPENAI_API_KEY` is present, run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input-sequence '[[3, "\r"]]' --evidence authentication/setup-openai.txt -- uv run saber auth setup`. Enter with zero down-arrows selects `openai`. Output includes `Existing authentication found for openai: OPENAI_API_KEY` and `Openai API key configured successfully!`. Then capture `saber auth status`. It prints `API Key authentication configured` and `configured via OPENAI_API_KEY` without the secret. `path auth-config` is `{"auth_method": "api_key"}`.
+- **Provider list.** `saber auth setup` offers registered keys including `xai` (xAI Grok, `XAI_API_KEY`) and `groq` (Groq). They are different vendors. `grok` is not a live prefix.
+- **Environment status.** If `OPENAI_API_KEY` is present, run `"$VERIFY_SQLSABER" drive "$RUN_ID" --timeout 30 --input-sequence '[[3, "\r"]]' --evidence authentication/setup-openai.txt -- uv run saber auth setup`. Enter with zero down-arrows selects `openai`. Output includes `Existing authentication found for openai: OPENAI_API_KEY` and `Openai API key configured successfully!`. Then capture `saber auth status`. It prints `API Key authentication configured` and `configured via OPENAI_API_KEY` without the secret. When `XAI_API_KEY` is absent, the `xai` row is `not configured`. `path auth-config` is `{"auth_method": "api_key"}`.
 - **Reset without stored credentials.** Run `"$VERIFY_SQLSABER" drive "$RUN_ID" --evidence authentication/reset-empty.txt -- uv run saber auth reset openai --yes`. With the null keyring it exits `0` and says no stored credentials were found. This proves the no-op route, not credential deletion.
 - **Typed-key setup.** Cancel at the provider or key prompt and retain the transcript. Key storage and the corresponding destructive reset are `verified-unreachable` in this harness because the null backend blocks any persistent keyring. Their concrete prerequisite is a disposable credential store with a seeded test key; never use the operator's OS keyring.
 
@@ -33,3 +34,4 @@ Preconditions:
 - `auth reset` never changes environment variables.
 - Without an explicit provider, reset opens an interactive selector and fails usage when stdin is not a terminal.
 - The verification harness uses a null keyring to protect the operator's credentials. Do not weaken that isolation to make setup pass.
+- `xai` is xAI Grok (`XAI_API_KEY`). `groq` is Groq (`GROQ_API_KEY`). Doctor reports present credential names without values; a missing `XAI_API_KEY` is not a live-query proof.

--- a/.agents/skills/verify-sqlsaber/features/model-configuration.md
+++ b/.agents/skills/verify-sqlsaber/features/model-configuration.md
@@ -25,7 +25,7 @@ Preconditions:
 - Model configuration does not require a provider key. A later query does.
 
 - **Initial state.** Capture `saber models current`. A fresh home prints `openai:gpt-5.6-sol`, `Thinking: enabled (medium)`, and rows for `handoff`, `viz`, and `notebook`.
-- **Main selection.** Set `openai:gpt-5 --thinking-level off`, capture `models current --agent main`, and require the model plus `Thinking: disabled`.
+- **Main selection.** Set `openai:gpt-5 --thinking-level off`, capture `models current --agent main`, and require the model plus `Thinking: disabled`. `saber models set xai:grok-4.6` is accepted (no catalog rejection). That is the recommended xAI id; it does not change the product default `openai:gpt-5.6-sol`.
 - **Subagent override.** Set `openai:gpt-5-mini --agent handoff`, then capture `models current --agent handoff`. It shows the override and main model. Reset the override with `--yes` and confirm it uses main again.
 - **Main reset.** Run `models reset --yes`, then capture current state. It shows `openai:gpt-5.6-sol`, the reset target printed by the command.
 - **Persisted proof.** Copy the file from `path model-config` before reset and after reset. The JSON matches each `models current` read-back.
@@ -34,7 +34,7 @@ Preconditions:
 ## Gotchas
 
 - `--thinking-level` applies only to the main model.
-- Model IDs must use a supported `PROVIDER:MODEL` prefix, but saving one does not prove the provider accepts it.
+- Model IDs must use a supported `PROVIDER:MODEL` prefix, but saving one does not prove the provider accepts it. `xai:grok-4.6` is valid; `grok:grok-4.6` is not (pydantic-ai's live prefix is `xai`, not the deprecated `grok:`). `groq:` remains Groq.
 - `models list` calls `https://models.dev/api.json`; current and set are local.
 - `main`, `handoff`, `viz`, and `notebook` are the accepted agent names.
 - Fresh config uses `openai:gpt-5.6-sol` with thinking enabled at medium. `models reset` writes that same model id and leaves thinking as stored. Assert the model identifier in `models current` and in the file from `path model-config`.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ saber -d sales -d analytics "Compare last month's revenue to web sessions"
 - **Works with your stack** — PostgreSQL, MySQL, SQLite, DuckDB, and CSV files.
 - **Remembers your work** — Resume previous analysis with conversation threads.
 - **Learns your business context** — Store KPI definitions, SQL patterns, and domain notes in a searchable knowledge base.
-- **Flexible model support** — Use Anthropic, OpenAI, Google, Groq, Mistral, Cohere, Hugging Face, and other supported providers.
+- **Flexible model support** — Use Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, Hugging Face, and other supported providers.
 
 ## Common workflows
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -7,6 +7,10 @@ All notable changes to SQLsaber will be documented here.
 
 ### Unreleased
 
+### Features
+
+* add xAI Grok as a first-class provider (`xai:grok-4.6`)
+
 ---
 
 ## [0.72.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-v0.71.0...sqlsaber-v0.72.0) (2026-08-18)

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: "Set up API keys for Anthropic, OpenAI, Google, Groq, and other LLM providers in SQLsaber. Secure credential storage via OS keychain."
+description: "Set up API keys for Anthropic, OpenAI, Google, Groq, xAI, and other LLM providers in SQLsaber. Secure credential storage via OS keychain."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -18,6 +18,7 @@ SQLsaber supports the following LLM providers:
 - **Mistral** - API key
 - **Cohere** - API key
 - **Hugging Face** - API key
+- **xAI** - API key (`XAI_API_KEY`; recommended model `xai:grok-4.6`)
 
 <Aside type="note">
   SQLsaber stores API keys securely using your operating system's credentials
@@ -107,6 +108,9 @@ export OPENAI_API_KEY="your-api-key"
 
 # Google
 export GOOGLE_API_KEY="your-api-key"
+
+# xAI
+export XAI_API_KEY="your-api-key"
 ```
 
 Environment variables take precedence over stored credentials.

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -20,6 +20,7 @@ While SQLsaber supports a lot of models, we recommend the following for best res
 - Claude Opus 5
 - Gemini 3.1 Pro, 3.5 Flash or later
 - Codex-5.3, 5.2, GPT-5.4, 5.5 or later
+- Grok 4.6 (`xai:grok-4.6`)
 
 <Aside type="tip">
   Consider using one of the recommended models for best results.

--- a/docs/src/content/docs/sdk/credentials-and-models.mdx
+++ b/docs/src/content/docs/sdk/credentials-and-models.mdx
@@ -41,7 +41,7 @@ options = SQLSaberOptions(
 ```
 
 Each provider has its own variable (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-`GOOGLE_API_KEY`, `GROQ_API_KEY`).
+`GOOGLE_API_KEY`, `GROQ_API_KEY`, `XAI_API_KEY`).
 
 ## 3. Pass keys explicitly in code
 
@@ -63,7 +63,7 @@ options = SQLSaberOptions(
 ```
 
 `api_keys` is a mapping of provider name to key. Supported provider keys are
-`anthropic`, `openai`, `google`, and `groq`.
+`anthropic`, `openai`, `google`, `groq`, and `xai`.
 
 <Aside type="caution">
   Avoid hard-coding API keys in source files. Prefer environment variables or a
@@ -89,6 +89,7 @@ Models are identified as `"provider:model"`:
 SQLSaberOptions(database="...", model_name="anthropic:claude-sonnet-4-5-20250929")
 SQLSaberOptions(database="...", model_name="openai:gpt-5-mini")
 SQLSaberOptions(database="...", model_name="google:gemini-2.5-pro")
+SQLSaberOptions(database="...", model_name="xai:grok-4.6")
 ```
 
 If `model_name` is omitted, the session uses your configured default model. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "asyncpg>=0.30.0",
-    "pydantic-ai[cohere,groq,huggingface,mistral]>=2.9,<3",
+    "pydantic-ai[cohere,groq,huggingface,mistral,xai]>=2.9,<3",
     "keyring>=25.6.0",
     "keyrings.cryptfile; sys_platform == 'linux'",
     "platformdirs>=4.0.0",

--- a/src/sqlsaber/agents/model_factory.py
+++ b/src/sqlsaber/agents/model_factory.py
@@ -54,4 +54,9 @@ def build_model(full_model_str: str, api_key: str | None) -> Model | str:
             model_name,
             provider=OpenAIProvider(api_key=api_key),
         )
+    if provider == "xai":
+        from pydantic_ai.models.xai import XaiModel
+        from pydantic_ai.providers.xai import XaiProvider
+
+        return XaiModel(model_name, provider=XaiProvider(api_key=api_key))
     return normalized_model_str

--- a/src/sqlsaber/cli/models.py
+++ b/src/sqlsaber/cli/models.py
@@ -61,6 +61,7 @@ _RECOMMENDATION_SPECS: Mapping[str, _RecommendationSpec] = {
     "groq": "llama-3-3-70b-versatile",
     "mistral": "mistral-large-latest",
     "cohere": "command-r-plus",
+    "xai": "grok-4.6",
 }
 
 

--- a/src/sqlsaber/config/providers.py
+++ b/src/sqlsaber/config/providers.py
@@ -55,6 +55,11 @@ _PROVIDERS: List[ProviderSpec] = [
         env_var="HUGGINGFACE_API_KEY",
         aliases=(),
     ),
+    ProviderSpec(
+        key="xai",
+        env_var="XAI_API_KEY",
+        aliases=(),
+    ),
 ]
 
 

--- a/tests/test_agents/test_model_factory.py
+++ b/tests/test_agents/test_model_factory.py
@@ -8,6 +8,7 @@ from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.models.xai import XaiModel
 
 from sqlsaber.agents.model_factory import UNIFIED_EFFORT_MAP, build_model
 from sqlsaber.agents.pydantic_ai_agent import SQLSaberAgent
@@ -22,6 +23,7 @@ from sqlsaber.database.sqlite import SQLiteConnection
         ("google:gemini-test", GoogleModel, "gemini-test"),
         ("google-gla:gemini-test", GoogleModel, "gemini-test"),
         ("openai:gpt-test", OpenAIResponsesModel, "gpt-test"),
+        ("xai:grok-4.6", XaiModel, "grok-4.6"),
     ],
 )
 def test_build_model_with_explicit_key(
@@ -35,6 +37,21 @@ def test_build_model_with_explicit_key(
 
 def test_build_model_without_key_returns_provider_string() -> None:
     assert build_model("anthropic:claude-test", None) == "anthropic:claude-test"
+    assert build_model("xai:grok-4.6", None) == "xai:grok-4.6"
+
+
+def test_build_model_groq_with_key_stays_discovery_string() -> None:
+    assert build_model("groq:llama-3-3-70b-versatile", "test-key") == (
+        "groq:llama-3-3-70b-versatile"
+    )
+
+
+def test_build_model_xai_explicit_key_injects_provider() -> None:
+    model = build_model("xai:grok-4.6", "test-key")
+
+    assert isinstance(model, XaiModel)
+    assert model.model_name == "grok-4.6"
+    assert model.system == "xai"
 
 
 def test_build_model_normalizes_google_alias() -> None:

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -82,6 +82,34 @@ def test_models_set_directly_without_fetching_or_prompting():
     config.model.set_thinking.assert_called_once_with(True, ThinkingLevel.HIGH)
 
 
+def test_models_set_accepts_xai_grok_4_6():
+    with patch.object(
+        models_cli.model_manager, "set_model", return_value=True
+    ) as set_model:
+        models_cli.set_model_command("xai:grok-4.6")
+
+    set_model.assert_called_once_with("xai:grok-4.6")
+
+
+def test_models_set_accepts_groq_without_confusing_xai():
+    with patch.object(
+        models_cli.model_manager, "set_model", return_value=True
+    ) as set_model:
+        models_cli.set_model_command("groq:llama-3-3-70b-versatile")
+
+    set_model.assert_called_once_with("groq:llama-3-3-70b-versatile")
+
+
+def test_models_set_rejects_deprecated_grok_prefix(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        models_cli.set_model_command("grok:grok-4.6")
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "supported PROVIDER:MODEL" in err
+    assert "xai" in err
+
+
 def test_models_set_rejects_unsupported_provider(capsys):
     with pytest.raises(SystemExit) as exc_info:
         models_cli.set_model_command("unknown:model")

--- a/tests/test_cli/test_model_recommendations.py
+++ b/tests/test_cli/test_model_recommendations.py
@@ -12,6 +12,7 @@ CURRENT_QUALIFIED_RECS = {
     "groq": "groq:llama-3-3-70b-versatile",
     "mistral": "mistral:mistral-large-latest",
     "cohere": "cohere:command-r-plus",
+    "xai": "xai:grok-4.6",
 }
 
 
@@ -27,6 +28,10 @@ def test_anthropic_recommendation_is_opus_5():
 
 def test_huggingface_has_no_recommendation():
     assert ModelManager.recommended_model_id("huggingface") is None
+
+
+def test_xai_recommendation_is_grok_4_6():
+    assert ModelManager.recommended_model_id("xai") == "xai:grok-4.6"
 
 
 @pytest.mark.parametrize(
@@ -109,6 +114,7 @@ async def test_select_model_empty_fetch_uses_qualified_recommendation(monkeypatc
     assert await select_model_for_provider("openai") == ModelConfigManager.DEFAULT_MODEL
     assert await select_model_for_provider("anthropic") == "anthropic:claude-opus-5"
     assert await select_model_for_provider("huggingface") == ModelManager.DEFAULT_MODEL
+    assert await select_model_for_provider("xai") == "xai:grok-4.6"
 
 
 @pytest.mark.asyncio
@@ -125,3 +131,4 @@ async def test_select_model_fetch_exception_uses_qualified_recommendation(
     assert await select_model_for_provider("openai") == ModelConfigManager.DEFAULT_MODEL
     assert await select_model_for_provider("anthropic") == "anthropic:claude-opus-5"
     assert await select_model_for_provider("huggingface") == ModelManager.DEFAULT_MODEL
+    assert await select_model_for_provider("xai") == "xai:grok-4.6"

--- a/tests/test_cli/workflows/test_model_selection.py
+++ b/tests/test_cli/workflows/test_model_selection.py
@@ -52,3 +52,19 @@ async def test_choose_model_labels_qualified_recommendation_and_returns_it_on_ca
     assert prompter.choices[0].title == "GPT-5.6 Sol (Recommended)"
     assert prompter.choices[0].value == "openai:gpt-5.6-sol"
     assert all("GPT-5 (Recommended)" not in choice.title for choice in prompter.choices)
+
+
+@pytest.mark.asyncio
+async def test_choose_model_labels_xai_grok_4_6_recommendation():
+    prompter = CancelPrompter()
+    models = [
+        _model("xai:grok-4.5", "xai", "Grok 4.5"),
+        _model("xai:grok-4.6", "xai", "Grok 4.6"),
+        _model("xai:grok-4.3", "xai", "Grok 4.3"),
+    ]
+
+    selected = await choose_model(prompter, models, restrict_provider="xai")
+
+    assert selected == "xai:grok-4.6"
+    assert prompter.choices[0].title == "Grok 4.6 (Recommended)"
+    assert prompter.choices[0].value == "xai:grok-4.6"

--- a/tests/test_config/test_providers.py
+++ b/tests/test_config/test_providers.py
@@ -16,6 +16,7 @@ def test_all_keys_contains_expected_providers():
         "mistral",
         "cohere",
         "huggingface",
+        "xai",
     ]:
         assert k in keys
 
@@ -23,6 +24,7 @@ def test_all_keys_contains_expected_providers():
 def test_env_var_name_mapping():
     assert providers.env_var_name("openai") == "OPENAI_API_KEY"
     assert providers.env_var_name("anthropic") == "ANTHROPIC_API_KEY"
+    assert providers.env_var_name("xai") == "XAI_API_KEY"
     assert providers.env_var_name("unknown") == "AI_API_KEY"
 
 
@@ -33,6 +35,8 @@ def test_env_var_name_mapping():
         ("pydantic_ai.models.mistral", "MistralModel"),
         ("pydantic_ai.models.cohere", "CohereModel"),
         ("pydantic_ai.models.huggingface", "HuggingFaceModel"),
+        ("pydantic_ai.models.xai", "XaiModel"),
+        ("pydantic_ai.providers.xai", "XaiProvider"),
     ],
 )
 def test_supported_provider_dependencies_are_installed(
@@ -50,9 +54,21 @@ def test_supported_provider_dependencies_are_installed(
         ("google:gemini-1.5-pro", "google"),
         ("google-gla:gemini-1.5-pro", "google"),
         ("mistral:large", "mistral"),
+        ("groq:llama-3-3-70b-versatile", "groq"),
+        ("xai:grok-4.6", "xai"),
+        ("grok:grok-4.6", None),
         ("unknown:model", None),
         ("", None),
     ],
 )
 def test_provider_from_model(model: str, expected: str | None):
     assert providers.provider_from_model(model) == expected
+
+
+def test_xai_is_distinct_from_groq():
+    assert providers.canonical("xai") == "xai"
+    assert providers.canonical("groq") == "groq"
+    assert providers.canonical("grok") is None
+    assert providers.env_var_name("xai") == "XAI_API_KEY"
+    assert providers.env_var_name("groq") == "GROQ_API_KEY"
+    assert "grok" not in providers.all_keys()

--- a/uv.lock
+++ b/uv.lock
@@ -1193,6 +1193,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.83.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/b1/46539f5050d7c316a13396d185451f95084a74ddc68b12d818595bef0377/grpcio-1.83.1.tar.gz", hash = "sha256:9cee6fcbf2eb57c4b49451787bfa87be8efc1ca02a0b327dd4b54d44502e362b", size = 13445033, upload-time = "2026-08-28T07:09:11.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/9e/a3ba13e08bbee5bf6e57597dfe4823961fd7e94c0b8afe3a4bb7dca639f3/grpcio-1.83.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:5acd14c6ddf047de62cbf8745b11103ea91abbf57d1b8edd5395ccd9fcd13abb", size = 6303170, upload-time = "2026-08-28T07:08:08.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ae/65ce56a2527faa17d02cba4c2231c74047ad898be339486ba87f093bfb66/grpcio-1.83.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:16138031a47b771860a16a975b53087f4fd5bbdbb2c03a188c5d90ad65d2bdae", size = 12165806, upload-time = "2026-08-28T07:08:10.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/91/40432480088a2243d360864de072ed5b78c4ebbaabd29c28918f1e1b1454/grpcio-1.83.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5ccc26715fd4defca5e129e280dd883b1737b65045ec50ffe22ce42104089519", size = 6872490, upload-time = "2026-08-28T07:08:12.355Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/62/3da2300c8c79fd20a78a8a4bb6251e5068d9af33bc8fd389b98fec35e8a3/grpcio-1.83.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b74f2a1d9ab1dfa3e263ef33d581613679b78d0884babf11671af26e45570ead", size = 7618367, upload-time = "2026-08-28T07:08:14.025Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/19/9fc702e31a631262d7a752fa699f6022821e707fefc8bff49b1550a57729/grpcio-1.83.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:72578aa07a4008f17521ef52debcc3acfd1e2c5426243bc3ffb56a38bfe610b7", size = 7040936, upload-time = "2026-08-28T07:08:15.963Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/56/95933cc44cba2429765fa065c951dd529e5771b119d9d2481b4646f1d6a5/grpcio-1.83.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c12e1fc59c6dc26d10d9144453ddc6cbfe4cd4c31e874ed2d0132f88e685eb8b", size = 7573096, upload-time = "2026-08-28T07:08:17.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/80/af63359da06b016de48cb111f144703a10043850dafa43ae0a038907b9e8/grpcio-1.83.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4910b62f7d12197160bfb7de06d876d64dd12d43483e8292f98f49ca09b628d9", size = 8609442, upload-time = "2026-08-28T07:08:19.777Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fa/f0586c56bdfb8a7a2adda01e0ac2413447cde3141ab09411a5d5afdcffd3/grpcio-1.83.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e703effe3ae779925c82ac24fdb82cf4105e1096810151ed9501c5f34546b9c", size = 7984321, upload-time = "2026-08-28T07:08:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8a/14ec05669f9eb295801e26c2ea8c561a1b786b0e3557c2c22131165ab010/grpcio-1.83.1-cp312-cp312-win32.whl", hash = "sha256:a2aea8bd6e0a34f12cbaddb7bb70bec836818789fa5c7ab7572c6b745396a2d4", size = 4395604, upload-time = "2026-08-28T07:08:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/37/8c2f7cc16089e36a3fbacaacc7a3d043912aa0d2dfae5556f6450414ea6e/grpcio-1.83.1-cp312-cp312-win_amd64.whl", hash = "sha256:583bf2e8255040a4a312f9572dfe62a05271437b149550e1a536d5c47d2d1e8a", size = 5161512, upload-time = "2026-08-28T07:08:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fd/d1fc58933bf88c9209f89dc570c810f1aa57cb04b3459cf2b26f61e32112/grpcio-1.83.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:8d228e253b77865efcbdd7b5894ca882c9e0ea98c02b7d20582e61ded8dfd4b5", size = 6305628, upload-time = "2026-08-28T07:08:27.872Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/49/0b40bae059c619505c9b751cee6caa208e4904e290aaefa1728c4c2c67a5/grpcio-1.83.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0468b627f2987c9a77f7580030207cbd85457ffe52998beff4f0b5c38c58a72c", size = 12156839, upload-time = "2026-08-28T07:08:30.191Z" },
+    { url = "https://files.pythonhosted.org/packages/61/4b/e8c0d635da0ee5ddd9950c8d540f5dcdd0ef1854a382cc55496a487a8d31/grpcio-1.83.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6a282e81530cead60bbd752cc04950a57f224379e9821495d6a35bd5ce9b1f4", size = 6877036, upload-time = "2026-08-28T07:08:32.285Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d4/760a33f339a7dd3d5f4b3e0e9bec5472d95592a80f887b2e9dab4e41cfbc/grpcio-1.83.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:947d945f52e8ecf3cafd2bb7113502a16ccfda3e12c854443094de32d83ad432", size = 7624404, upload-time = "2026-08-28T07:08:34.194Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ec/bd798654b06fb42a92b57d1dc1b530084fa89ed442806fcd0a833a36f9b3/grpcio-1.83.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:55656318d5dd387077396dffb929171ca3966e24bfead9a6c5dba9f889062cb4", size = 7042942, upload-time = "2026-08-28T07:08:36.208Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b0/c00f86614566dd0961825cf0f43d4f96a74371d9d95f952bcbc4b86d9a27/grpcio-1.83.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9daf5acf4fc9d5f5627229969c2580a91e511779d76e4ccdeb9f4770f05d8bc2", size = 7576937, upload-time = "2026-08-28T07:08:38.041Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/38/85eff43a5c89dc666a252b5c9f8e9ab03f89e11c95b6263d2933f08fdbe7/grpcio-1.83.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7b94174cbca93316888f805efbeb08f1c020f7b7493d2d50cc4f6b64ebb7e8bd", size = 8608391, upload-time = "2026-08-28T07:08:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/82835483e2f812494be865e7965c0d626cb9e71ab0d83a420d75aea4ad67/grpcio-1.83.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:65c5a7210911ffe0f67b1cdc5308f9854b6d1f1b345e3e49ab7cac1ba50fa346", size = 7980060, upload-time = "2026-08-28T07:08:42.434Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/68a98bef733fef704fbcfb3957c8dba67e3e38ca7a7fea851195bc97c648/grpcio-1.83.1-cp313-cp313-win32.whl", hash = "sha256:179368d9361854616ce6f397d4716e07480129652752fcbcfc5a7260455ad6f2", size = 4395226, upload-time = "2026-08-28T07:08:44.463Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a0/df4de3b51d37ac8fb0320bb9668381ce2bd3b7aa990880bfc56a8a26f665/grpcio-1.83.1-cp313-cp313-win_amd64.whl", hash = "sha256:2e57af456385491a76e13c4aada8c8f43a8e47051e06ea97a9dbe2a49654e6db", size = 5160273, upload-time = "2026-08-28T07:08:46.216Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/484d981d8b90c4e6abf3030bd2ed747e84d1eb192b3ec9cbb41e0b73e4bf/grpcio-1.83.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:8b3c87ca908296bf125f841d3e1a2225a2b39aaa8ed7a57e7ccde465ee519bab", size = 6306089, upload-time = "2026-08-28T07:08:48.379Z" },
+    { url = "https://files.pythonhosted.org/packages/84/01/0afec1c92e4f292f74a44ecf75eabbf40903125b8c4df103c9868d6338da/grpcio-1.83.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c0f3f20c90e72a171917ae65706500b096a1c3eb5f162c3ce702a2e25635f132", size = 12170381, upload-time = "2026-08-28T07:08:50.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5a/e9a2383804433a0a61d6d93777ad321c7f36ac1cfdaa4c6d1a7c9ac846b7/grpcio-1.83.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81bbf35a46bf8cad2dfbb2eccc19c711befb58b288acb534bbcd0d74283202a6", size = 6883286, upload-time = "2026-08-28T07:08:53.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/f8ca8f76994e14c70b9a0052e82f10de497a23db450c36379c9716ebfc4d/grpcio-1.83.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:215cec07d11176507387bda4bf2751816e880f9bff8dc1ca524bfbb8ed8f2fad", size = 7624293, upload-time = "2026-08-28T07:08:55.709Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7a/4b672814b0cd0fe63bdd735379d88b165759f3144ab023ad8ec5fc4d53ac/grpcio-1.83.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:abce7d43ec29cd39230fa8339de1a07643b55adc412a454850fbd875349950ff", size = 7044346, upload-time = "2026-08-28T07:08:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/d89fe60e4239ad51be333dd9cc703741d449a35064e51f8a0b5bfa755432/grpcio-1.83.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e256f95a40e3b0183a98556fb7164d24b97eeb353123ccabfcba94712b35ee2a", size = 7584187, upload-time = "2026-08-28T07:08:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/b290d7402633d9166e4dd47e6f5f74a24ce10a8340b84455896ebc349f85/grpcio-1.83.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2110059146fb0ea216e1ffddb29377b5cc2fd412a5b0a92e102616bd5edf18c2", size = 8608730, upload-time = "2026-08-28T07:09:02.592Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/44/fa89e44d1b5cf5b9fa71b2fd7abf506f182fd43917231a92fbf1ea326b02/grpcio-1.83.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20d944d967843f8183f9f23d5916388362e5f8eeeae855bbe4354d906dc9f31b", size = 7983283, upload-time = "2026-08-28T07:09:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/9db73ed1f35ffa76124ac574bf296d06a359798dfd6b50d382f2b8a060a1/grpcio-1.83.1-cp314-cp314-win32.whl", hash = "sha256:623c87c6d4a1cb30d82c4e896f95477050f2e01b4a1f8cf91ff2b1abdf89c457", size = 4474327, upload-time = "2026-08-28T07:09:07.179Z" },
+    { url = "https://files.pythonhosted.org/packages/65/22/fc9a622d885a7a37ff972a12faaef443d74e47407181da70d0ab62ab41f0/grpcio-1.83.1-cp314-cp314-win_amd64.whl", hash = "sha256:47e6934ad38779271e2e7cc5f78a63a407cf3d98114c65c1fdbcd3f5a716f29b", size = 5302032, upload-time = "2026-08-28T07:09:09.285Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2441,6 +2482,9 @@ huggingface = [
 mistral = [
     { name = "pydantic-ai-slim", extra = ["mistral"] },
 ]
+xai = [
+    { name = "pydantic-ai-slim", extra = ["xai"] },
+]
 
 [[package]]
 name = "pydantic-ai-slim"
@@ -2507,6 +2551,9 @@ web = [
     { name = "httpx" },
     { name = "starlette" },
     { name = "uvicorn" },
+]
+xai = [
+    { name = "xai-sdk" },
 ]
 
 [[package]]
@@ -3153,7 +3200,7 @@ dependencies = [
     { name = "keyring" },
     { name = "keyrings-cryptfile", marker = "sys_platform == 'linux'" },
     { name = "platformdirs" },
-    { name = "pydantic-ai", extra = ["cohere", "groq", "huggingface", "mistral"] },
+    { name = "pydantic-ai", extra = ["cohere", "groq", "huggingface", "mistral", "xai"] },
     { name = "saber-tui" },
     { name = "sqlglot", extra = ["c"] },
     { name = "structlog" },
@@ -3183,7 +3230,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "keyrings-cryptfile", marker = "sys_platform == 'linux'" },
     { name = "platformdirs", specifier = ">=4.0.0" },
-    { name = "pydantic-ai", extras = ["cohere", "groq", "huggingface", "mistral"], specifier = ">=2.9,<3" },
+    { name = "pydantic-ai", extras = ["cohere", "groq", "huggingface", "mistral", "xai"], specifier = ">=2.9,<3" },
     { name = "saber-tui", specifier = ">=0.6.0" },
     { name = "sqlglot", extras = ["c"], specifier = ">=30.1.0" },
     { name = "structlog", specifier = ">=25.4.0" },
@@ -3749,6 +3796,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "xai-sdk"
+version = "1.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/85/85ae73cbc9de7e1529e87a5eb807fa11727dd59eac887957c87c0e721893/xai_sdk-1.19.0.tar.gz", hash = "sha256:65733bfb83826b10872b8c8af58003104cbd33ce69f0fdfc0d52bb670de7b0e7", size = 466299, upload-time = "2026-08-18T18:02:06.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b5/6f6783b97fb3a5498eb852ccaa706e1a2c0de2409480e3c99428e85234fe/xai_sdk-1.19.0-py3-none-any.whl", hash = "sha256:4af1a629ad9304d0b05fa052d84ce77b7b61242a6d59d5936b692fec95fb52c1", size = 278826, upload-time = "2026-08-18T18:02:04.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PydanticAI already supports xAI Grok (`xai:` prefix, `XAI_API_KEY`, `pydantic-ai[xai]`). SQLsaber listed Groq and omitted xAI, so `saber models set xai:grok-4.6` was rejected and keyring/SDK key injection had no xAI path.

## Scope

- Register `xai` in `ProviderSpec` with `XAI_API_KEY`. No `grok` alias: pydantic-ai's live prefix is `xai` (`grok` is history-replay only). Groq stays `groq`.
- Add the `xai` extra to `pydantic-ai[...]` and refresh the lockfile (`xai-sdk`).
- Recommend `grok-4.6` (qualified `xai:grok-4.6`) in the frozen post-#244 table. Default model remains `openai:gpt-5.6-sol`.
- `build_model` constructs `XaiModel` + `XaiProvider(api_key=)` when a key is explicit (same keyring/SDK path as OpenAI/Anthropic/Google). Without a key, return `xai:grok-4.6` for discovery.
- Docs and verify-sqlsaber maps name the provider, env var, and recommended id.

## Tradeoffs

- **No `grok:` alias.** `google-gla` exists because that prefix is still live. pydantic-ai `infer_provider_class` only accepts `xai`. Inventing `grok:` would be a second live prefix.
- **Explicit-key construction for xAI only.** Groq/Mistral/Cohere/Hugging Face still use string discovery plus env hydration. xAI gets the OpenAI-style branch because SDK `api_key` overrides skip `AuthConfig.validate`.
- **Lazy import of `XaiModel`.** Avoids loading `xai-sdk`/gRPC on the default OpenAI path.
- **Catalog id `grok-4.6`.** models.dev lists it under provider `xai` as `Grok 4.6`. pydantic-ai 2.9 `KnownModelName` has not caught up; SQLsaber `models set` does not use that list.

## Blast Radius

- `saber auth setup` / `auth status` gain an `xai` row. OpenAI remains the default selection.
- `saber models list` fetches xAI models from models.dev.
- Installing SQLsaber now pulls `xai-sdk` and `grpcio`.
- Groq, OpenAI, Anthropic, and `DEFAULT_MODEL` are unchanged.

## Verification

- `env -u FORCE_COLOR uv run python -m pytest`: 1487 passed, 6 skipped.
- `saber auth setup` lists `xai` next to `groq`. `saber auth reset` / `models set` provider lists include `xai`.
- `saber models set xai:grok-4.6` accepted; `saber models current` shows `xai:grok-4.6`.
- `saber models set groq:llama-3-3-70b-versatile` still works. `grok:grok-4.6` is rejected.
- `saber models list` returns `xai:grok-4.6` named `Grok 4.6` from models.dev.
- Recommendation: `ModelManager.recommended_model_id("xai")` → `xai:grok-4.6`; groq remains `groq:llama-3-3-70b-versatile`. Interactive `(Recommended)` label covered by `test_choose_model_labels_xai_grok_4_6_recommendation`.
- Doctor: `model credentials present: OPENAI_API_KEY` (no `XAI_API_KEY`). After OpenAI auth setup, `saber auth status` shows `xai | not configured`.
- Live xAI query: unreachable (missing `XAI_API_KEY`). Did not stub one.
- `saber models reset --yes` restored `openai:gpt-5.6-sol`.

`architect skipped: pstack architect is not in this checkout; the change is one ProviderSpec row plus the existing recommendation and explicit-key patterns.`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-842125c0-deb4-478c-abcf-70b5d8b488fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-842125c0-deb4-478c-abcf-70b5d8b488fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

