### PR TITLE
feat(cli): refresh the usage footer after each model message

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -197,7 +197,7 @@ def query(
             ThreadResumeMetadataError,
         )
         from sqlsaber.cli.retention import run_cli_retention
-        from sqlsaber.cli.usage import SessionUsage, session_summary_blocks
+        from sqlsaber.cli.usage import UsageMeter, session_summary_blocks
         from sqlsaber.database.resolver import DatabaseResolutionError
         from sqlsaber.render import cli_out
         from sqlsaber.render.terminal import TerminalSurface
@@ -308,23 +308,15 @@ def query(
                 if allow_dangerous:
                     out(b.warn(DANGEROUS_MODE_WARNING, label="DANGEROUS MODE ENABLED"))
                 log.info("query.execute.start", db_name=db_name, db_type=db_type)
-                result = await streaming_handler.execute_streaming_query(
+                meter = UsageMeter(model_id=lambda: info.model_id or info.model_name)
+                await streaming_handler.execute_streaming_query(
                     actual_query,
-                    run_query=saber.query,
+                    run_query=meter.metered(saber.query),
                 )
 
-                if result is not None and result.usage is not None:
-                    session_usage = SessionUsage()
-                    session_usage.add_run(
-                        result.usage,
-                        result.final_context_tokens,
-                        model_name=info.model_id or info.model_name,
-                        request_usages=result.request_usages,
-                    )
-                    if isinstance(surface, TerminalSurface):
-                        summary = session_summary_blocks(session_usage)
-                        if summary:
-                            surface.emit(*summary)
+                if isinstance(surface, TerminalSurface):
+                    if summary := session_summary_blocks(meter.session):
+                        surface.emit(*summary)
 
                 thread_id = saber.info.thread_id
                 if thread_id:

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -22,7 +22,12 @@ from sqlsaber.cli.tui_chat import (
 )
 from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
 from sqlsaber.cli.update_check import bind_update_notice
-from sqlsaber.cli.usage import SessionUsage, format_cost_usd, format_tokens
+from sqlsaber.cli.usage import (
+    SessionUsage,
+    UsageMeter,
+    format_cost_usd,
+    format_tokens,
+)
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 
@@ -45,7 +50,7 @@ class InteractiveSession:
         self._handoff_mode = False
         self._exit_finalized = False
         self.command_processor = SlashCommandProcessor()
-        self.session_usage = SessionUsage()
+        self.usage = UsageMeter(model_id=self._model_id, on_change=self._refresh_footer)
         self.log = get_logger(__name__)
 
     def _history_path(self) -> Path:
@@ -119,7 +124,8 @@ class InteractiveSession:
         return DANGEROUS_MODE_FOOTER_LABEL if self.saber.info.dangerous_mode else None
 
     def _usage_footer_text(self) -> str:
-        session_usage = getattr(self, "session_usage", SessionUsage())
+        usage: UsageMeter | None = getattr(self, "usage", None)
+        session_usage = usage.session if usage is not None else SessionUsage()
         return (
             f"Usage: ↑{format_tokens(session_usage.total_input_tokens)} "
             f"↓{format_tokens(session_usage.total_output_tokens)} | "
@@ -196,7 +202,7 @@ class InteractiveSession:
             display_registry_provider=lambda: self.saber.display_registry,
             query_result_store=self.saber.query_result_store,
         )
-        self.session_usage = SessionUsage()
+        self.usage.reset()
         app.clear_chat()
         render_prepared_thread(surface, prepared)
         await self._update_table_cache()
@@ -261,22 +267,14 @@ class InteractiveSession:
         query_task = asyncio.create_task(
             self.streaming_handler.execute_streaming_query(
                 user_query,
-                run_query=self.saber.query,
+                run_query=self.usage.metered(self.saber.query),
                 cancellation_token=self.cancellation_token,
             )
         )
         self.current_task = query_task
 
         try:
-            result = await query_task
-            if result is not None and result.usage is not None:
-                self.session_usage.add_run(
-                    result.usage,
-                    result.final_context_tokens,
-                    model_name=self._model_id(),
-                    request_usages=result.request_usages,
-                )
-                self._refresh_footer()
+            await query_task
         finally:
             self.current_task = None
             self.cancellation_token = None
@@ -349,7 +347,7 @@ class InteractiveSession:
             context = CommandContext(
                 surface=surface,
                 saber=self.saber,
-                session_usage=self.session_usage,
+                session_usage=self.usage.session,
             )
 
             cmd_result = await self.command_processor.process(user_query, context)

--- a/src/sqlsaber/cli/usage.py
+++ b/src/sqlsaber/cli/usage.py
@@ -25,8 +25,6 @@ type EventStreamHandler = Callable[
 
 
 class StreamingQuery(Protocol):
-    """The slice of ``SQLSaber.query`` that the stream presenter calls."""
-
     async def __call__(
         self,
         prompt: str,
@@ -38,10 +36,7 @@ class StreamingQuery(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class SessionUsage:
-    """Cumulative model usage and current context size for one session.
-
-    Frozen so that ``UsageMeter`` is the only thing able to produce a new one.
-    """
+    """Cumulative model usage and current context size for one session."""
 
     requests: int = 0
     tool_calls: int = 0
@@ -55,13 +50,10 @@ class SessionUsage:
     cache_write_tokens: int = 0
 
     total_cost_usd: float | None = 0.0
-    """``None`` means not priceable and is absorbing until :meth:`UsageMeter.reset`."""
 
 
 @dataclass(frozen=True, slots=True)
 class _PricedResponse:
-    """One complete model message: what it consumed and what it cost."""
-
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
@@ -81,14 +73,8 @@ class _PricedResponse:
 
 @dataclass(frozen=True, slots=True)
 class _TurnCursor:
-    """High-water mark for the agent run currently in flight.
-
-    ``responses`` is how many of this run's model messages have been folded and
-    ``tool_calls`` is the run's tool-call counter as of the last fold.
-    """
-
-    responses: int = 0
-    tool_calls: int = 0
+    folded_responses: int = 0
+    folded_tool_calls: int = 0
 
 
 def _add_cost(total: float | None, addition: float | None) -> float | None:
@@ -119,7 +105,6 @@ def _fold(
 
 
 def _price(usage: RequestUsage, model_id: str | None) -> float | None:
-    """Cache-aware USD estimate for one model request, or ``None`` if unknown."""
     if not model_id:
         return None
 
@@ -153,9 +138,7 @@ def _price(usage: RequestUsage, model_id: str | None) -> float | None:
 def _run_request_usages(
     messages: Sequence[ModelMessage], run_id: str
 ) -> list[RequestUsage]:
-    """Usage of every complete model message this run produced, in order.
-
-    ``ctx.messages`` is the whole conversation; pydantic-ai stamps ``run_id`` on
+    """``ctx.messages`` is the whole conversation; pydantic-ai stamps ``run_id`` on
     each response as it appends it, which isolates this run without index math.
     """
     return [
@@ -168,13 +151,7 @@ def _run_request_usages(
 
 
 class UsageMeter:
-    """Keeps one ``SessionUsage`` current across agent runs.
-
-    Wrap the query callable with :meth:`metered` and the meter folds usage into
-    the session after every graph node and once more from the run result. Each
-    observation is a cumulative snapshot of the run, so overlapping observations
-    cannot double-count.
-    """
+    """Keeps one ``SessionUsage`` current across agent runs."""
 
     def __init__(
         self,
@@ -182,12 +159,6 @@ class UsageMeter:
         model_id: Callable[[], str | None],
         on_change: Callable[[], None] | None = None,
     ) -> None:
-        """
-        Args:
-            model_id: Read on each fold, so swapping the underlying ``SQLSaber``
-                prices later responses with the new model.
-            on_change: Called after any fold that changed the session.
-        """
         self._model_id = model_id
         self._on_change = on_change
         self._session = SessionUsage()
@@ -197,21 +168,10 @@ class UsageMeter:
 
     @property
     def session(self) -> SessionUsage:
-        """Current totals; immutable and safe to hand to renderers and commands."""
         return self._session
 
     def metered(self, query: StreamingQuery) -> StreamingQuery:
-        """Wrap a query callable so its usage lands in this meter.
-
-        Args:
-            query: The SDK query to observe, typically ``SQLSaber.query``.
-
-        Returns:
-            A callable with the same signature. Each call is one turn: it opens a
-            fresh cursor, wraps the caller's event-stream handler, and folds the
-            run result on the way out. If the run raises, whatever pydantic-ai
-            had already applied to the last seen ``RunContext`` is folded first.
-        """
+        """Wrap a query callable so its usage lands in this meter."""
 
         async def metered_query(
             prompt: str,
@@ -243,7 +203,6 @@ class UsageMeter:
         return metered_query
 
     def reset(self) -> None:
-        """Start a new accounting epoch, notifying if the session was non-empty."""
         changed = self._session != SessionUsage()
         self._session = SessionUsage()
         self._turn = _TurnCursor()
@@ -279,18 +238,19 @@ class UsageMeter:
     ) -> None:
         usages = list(request_usages)
         cursor = self._turn
-        if len(usages) < cursor.responses:
+        if len(usages) < cursor.folded_responses:
             log.warning(
                 "usage.meter.cursor_reset",
                 observed=len(usages),
-                folded=cursor.responses,
+                folded=cursor.folded_responses,
             )
             self._session = self._turn_base
             cursor = _TurnCursor()
-        fresh = usages[cursor.responses :]
-        new_tool_calls = max(0, tool_calls - cursor.tool_calls)
+        fresh = usages[cursor.folded_responses :]
+        new_tool_calls = max(0, tool_calls - cursor.folded_tool_calls)
         self._turn = _TurnCursor(
-            responses=len(usages), tool_calls=max(cursor.tool_calls, tool_calls)
+            folded_responses=len(usages),
+            folded_tool_calls=max(cursor.folded_tool_calls, tool_calls),
         )
         if not fresh and not new_tool_calls:
             return

--- a/src/sqlsaber/cli/usage.py
+++ b/src/sqlsaber/cli/usage.py
@@ -1,14 +1,47 @@
 """Session usage tracking for the CLI."""
 
-from collections.abc import Sequence
-from dataclasses import dataclass
+from __future__ import annotations
 
-from pydantic_ai.usage import RequestUsage, RunUsage
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.usage import RequestUsage
+
+from sqlsaber.config.logging import get_logger
+
+if TYPE_CHECKING:
+    from pydantic_ai import RunContext
+    from pydantic_ai.messages import AgentStreamEvent, ModelMessage
+
+    from sqlsaber import SQLSaberResult
+
+log = get_logger(__name__)
+
+type EventStreamHandler = Callable[
+    [RunContext[Any], AsyncIterable[AgentStreamEvent]], Awaitable[None]
+]
 
 
-@dataclass
+class StreamingQuery(Protocol):
+    """The slice of ``SQLSaber.query`` that the stream presenter calls."""
+
+    async def __call__(
+        self,
+        prompt: str,
+        /,
+        *,
+        event_stream_handler: EventStreamHandler | None = ...,
+    ) -> SQLSaberResult: ...
+
+
+@dataclass(frozen=True, slots=True)
 class SessionUsage:
-    """Tracks cumulative model usage and the current context size."""
+    """Cumulative model usage and current context size for one session.
+
+    Frozen so that ``UsageMeter`` is the only thing able to produce a new one.
+    """
 
     requests: int = 0
     tool_calls: int = 0
@@ -22,69 +55,72 @@ class SessionUsage:
     cache_write_tokens: int = 0
 
     total_cost_usd: float | None = 0.0
+    """``None`` means not priceable and is absorbing until :meth:`UsageMeter.reset`."""
 
-    def add_run(
-        self,
-        usage: RunUsage,
-        final_context_tokens: int,
-        *,
-        model_name: str | None = None,
-        request_usages: Sequence[RequestUsage] | None = None,
-    ) -> None:
-        """Add usage from a single agent run.
 
-        Args:
-            usage: The RunUsage from the agent run, summed across model requests.
-            final_context_tokens: Input tokens for the final request only, representing
-                the current context window size.
-            model_name: Optional provider-prefixed model name for cost calculation.
-            request_usages: Optional per-model-request usage entries for accurate
-                pricing of multi-request agent runs.
-        """
-        self.requests += usage.requests
-        self.tool_calls += usage.tool_calls
+@dataclass(frozen=True, slots=True)
+class _PricedResponse:
+    """One complete model message: what it consumed and what it cost."""
 
-        self.total_input_tokens += usage.input_tokens
-        self.total_output_tokens += usage.output_tokens
-        self.current_context_tokens = final_context_tokens
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    cost_usd: float | None
 
-        self.cache_read_tokens += usage.cache_read_tokens
-        self.cache_write_tokens += usage.cache_write_tokens
-
-        run_cost = calculate_usages_cost_usd(
-            request_usages if request_usages else [usage],
-            model_name,
+    @classmethod
+    def from_request(cls, usage: RequestUsage, model_id: str | None) -> _PricedResponse:
+        return cls(
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+            cost_usd=_price(usage, model_id),
         )
-        if run_cost is None:
-            self.total_cost_usd = None
-            return
-        if self.total_cost_usd is not None:
-            self.total_cost_usd += run_cost
 
 
-def calculate_usages_cost_usd(
-    usages: Sequence[RunUsage | RequestUsage], model_name: str | None
-) -> float | None:
-    """Calculate a cache-aware USD cost estimate from one or more request usages."""
-    if not model_name:
+@dataclass(frozen=True, slots=True)
+class _TurnCursor:
+    """High-water mark for the agent run currently in flight.
+
+    ``responses`` is how many of this run's model messages have been folded and
+    ``tool_calls`` is the run's tool-call counter as of the last fold.
+    """
+
+    responses: int = 0
+    tool_calls: int = 0
+
+
+def _add_cost(total: float | None, addition: float | None) -> float | None:
+    if total is None or addition is None:
         return None
-
-    total = 0.0
-    for usage in usages:
-        usage_cost = calculate_run_cost_usd(usage, model_name)
-        if usage_cost is None:
-            return None
-        total += usage_cost
-    return total
+    return total + addition
 
 
-def calculate_run_cost_usd(
-    usage: RunUsage | RequestUsage, model_name: str | None
-) -> float | None:
-    """Calculate a cache-aware USD cost estimate for one model request."""
-    if not model_name:
-        return None
-    if isinstance(usage, RunUsage) and usage.requests > 1:
+def _fold(
+    base: SessionUsage, responses: Sequence[_PricedResponse], *, tool_calls: int
+) -> SessionUsage:
+    folded = replace(
+        base,
+        requests=base.requests + len(responses),
+        tool_calls=base.tool_calls + tool_calls,
+    )
+    for response in responses:
+        folded = replace(
+            folded,
+            total_input_tokens=folded.total_input_tokens + response.input_tokens,
+            total_output_tokens=folded.total_output_tokens + response.output_tokens,
+            cache_read_tokens=folded.cache_read_tokens + response.cache_read_tokens,
+            cache_write_tokens=folded.cache_write_tokens + response.cache_write_tokens,
+            current_context_tokens=response.input_tokens,
+            total_cost_usd=_add_cost(folded.total_cost_usd, response.cost_usd),
+        )
+    return folded
+
+
+def _price(usage: RequestUsage, model_id: str | None) -> float | None:
+    """Cache-aware USD estimate for one model request, or ``None`` if unknown."""
+    if not model_id:
         return None
 
     try:
@@ -92,9 +128,9 @@ def calculate_run_cost_usd(
         from genai_prices.types import Usage as GenAIUsage
 
         provider_id: str | None = None
-        model_ref = model_name
-        if ":" in model_name:
-            provider_id, model_ref = model_name.split(":", 1)
+        model_ref = model_id
+        if ":" in model_id:
+            provider_id, model_ref = model_id.split(":", 1)
 
         result = calc_price(
             usage=GenAIUsage(
@@ -112,6 +148,163 @@ def calculate_run_cost_usd(
         return float(result.total_price)
     except Exception:
         return None
+
+
+def _run_request_usages(
+    messages: Sequence[ModelMessage], run_id: str
+) -> list[RequestUsage]:
+    """Usage of every complete model message this run produced, in order.
+
+    ``ctx.messages`` is the whole conversation; pydantic-ai stamps ``run_id`` on
+    each response as it appends it, which isolates this run without index math.
+    """
+    return [
+        message.usage
+        for message in messages
+        if isinstance(message, ModelResponse)
+        and message.run_id == run_id
+        and message.state == "complete"
+    ]
+
+
+class UsageMeter:
+    """Keeps one ``SessionUsage`` current across agent runs.
+
+    Wrap the query callable with :meth:`metered` and the meter folds usage into
+    the session after every graph node and once more from the run result. Each
+    observation is a cumulative snapshot of the run, so overlapping observations
+    cannot double-count.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_id: Callable[[], str | None],
+        on_change: Callable[[], None] | None = None,
+    ) -> None:
+        """
+        Args:
+            model_id: Read on each fold, so swapping the underlying ``SQLSaber``
+                prices later responses with the new model.
+            on_change: Called after any fold that changed the session.
+        """
+        self._model_id = model_id
+        self._on_change = on_change
+        self._session = SessionUsage()
+        self._turn = _TurnCursor()
+        self._turn_base = SessionUsage()
+        self._ctx: RunContext[Any] | None = None
+
+    @property
+    def session(self) -> SessionUsage:
+        """Current totals; immutable and safe to hand to renderers and commands."""
+        return self._session
+
+    def metered(self, query: StreamingQuery) -> StreamingQuery:
+        """Wrap a query callable so its usage lands in this meter.
+
+        Args:
+            query: The SDK query to observe, typically ``SQLSaber.query``.
+
+        Returns:
+            A callable with the same signature. Each call is one turn: it opens a
+            fresh cursor, wraps the caller's event-stream handler, and folds the
+            run result on the way out. If the run raises, whatever pydantic-ai
+            had already applied to the last seen ``RunContext`` is folded first.
+        """
+
+        async def metered_query(
+            prompt: str,
+            /,
+            *,
+            event_stream_handler: EventStreamHandler | None = None,
+            **kwargs: Any,
+        ) -> SQLSaberResult:
+            self._turn = _TurnCursor()
+            self._turn_base = self._session
+            self._ctx = None
+            result: SQLSaberResult | None = None
+            try:
+                result = await query(
+                    prompt,
+                    event_stream_handler=self._observing(event_stream_handler),
+                    **kwargs,
+                )
+            finally:
+                if result is None and self._ctx is not None:
+                    self._absorb_context(self._ctx)
+            run_usage = result.usage
+            self._absorb(
+                result.request_usages,
+                tool_calls=run_usage.tool_calls if run_usage is not None else 0,
+            )
+            return result
+
+        return metered_query
+
+    def reset(self) -> None:
+        """Start a new accounting epoch, notifying if the session was non-empty."""
+        changed = self._session != SessionUsage()
+        self._session = SessionUsage()
+        self._turn = _TurnCursor()
+        self._turn_base = SessionUsage()
+        self._ctx = None
+        if changed:
+            self._notify()
+
+    def _observing(self, inner: EventStreamHandler | None) -> EventStreamHandler:
+        async def observing_handler(
+            ctx: RunContext[Any], event_stream: AsyncIterable[AgentStreamEvent]
+        ) -> None:
+            self._ctx = ctx
+            if inner is not None:
+                await inner(ctx, event_stream)
+            else:
+                async for _ in event_stream:
+                    pass
+            self._absorb_context(ctx)
+
+        return observing_handler
+
+    def _absorb_context(self, ctx: RunContext[Any]) -> None:
+        run_id = ctx.run_id
+        if run_id is None:
+            return
+        self._absorb(
+            _run_request_usages(ctx.messages, run_id), tool_calls=ctx.usage.tool_calls
+        )
+
+    def _absorb(
+        self, request_usages: Iterable[RequestUsage], *, tool_calls: int
+    ) -> None:
+        usages = list(request_usages)
+        cursor = self._turn
+        if len(usages) < cursor.responses:
+            log.warning(
+                "usage.meter.cursor_reset",
+                observed=len(usages),
+                folded=cursor.responses,
+            )
+            self._session = self._turn_base
+            cursor = _TurnCursor()
+        fresh = usages[cursor.responses :]
+        new_tool_calls = max(0, tool_calls - cursor.tool_calls)
+        self._turn = _TurnCursor(
+            responses=len(usages), tool_calls=max(cursor.tool_calls, tool_calls)
+        )
+        if not fresh and not new_tool_calls:
+            return
+        model_id = self._model_id()
+        self._session = _fold(
+            self._session,
+            [_PricedResponse.from_request(usage, model_id) for usage in fresh],
+            tool_calls=new_tool_calls,
+        )
+        self._notify()
+
+    def _notify(self) -> None:
+        if self._on_change is not None:
+            self._on_change()
 
 
 def format_cost_usd(cost_usd: float | None) -> str:

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -2,7 +2,7 @@
 
 from io import StringIO
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -244,7 +244,9 @@ def test_root_thread_option_resumes_through_public_sdk():
             )
             self.display_registry = {}
             self.query_result_store = query_result_store
-            self.query = AsyncMock()
+            self.query = AsyncMock(
+                return_value=SimpleNamespace(usage=None, request_usages=[])
+            )
 
         @classmethod
         async def resume(cls, thread_id, *, options, storage):
@@ -261,8 +263,7 @@ def test_root_thread_option_resumes_through_public_sdk():
 
         async def execute_streaming_query(self, user_query, *, run_query):
             captured["query"] = user_query
-            captured["run_query"] = run_query
-            return None
+            return await run_query(user_query, event_stream_handler=None)
 
     retention = AsyncMock(
         side_effect=lambda *args: lifecycle_events.append("retention")
@@ -292,7 +293,9 @@ def test_root_thread_option_resumes_through_public_sdk():
     assert storage is store
     assert options.database is None
     assert options.thread_manager is None
-    assert captured["run_query"] is captured["saber"].query
+    captured["saber"].query.assert_awaited_once_with(
+        captured["query"], event_stream_handler=ANY
+    )
     assert captured["query"] == "Compare this year"
     assert captured["closed"] is True
     retention.assert_awaited_once_with(store, artifact_store, query_result_store)
@@ -327,7 +330,9 @@ def test_root_one_shot_modes_construct_public_sdk(
             )
             self.display_registry = {}
             self.query_result_store = query_result_store
-            self.query = AsyncMock()
+            self.query = AsyncMock(
+                return_value=SimpleNamespace(usage=None, request_usages=[])
+            )
 
         async def close(self):
             captured["closed"] = True
@@ -338,8 +343,7 @@ def test_root_one_shot_modes_construct_public_sdk(
 
         async def execute_streaming_query(self, user_query, *, run_query):
             captured["query"] = user_query
-            captured["run_query"] = run_query
-            return None
+            return await run_query(user_query, event_stream_handler=None)
 
     retention = AsyncMock()
     with (
@@ -366,7 +370,9 @@ def test_root_one_shot_modes_construct_public_sdk(
     options = captured["options"]
     assert options.thread_manager.storage is store
     assert captured["query"] == expected_query
-    assert captured["run_query"] is captured["saber"].query
+    captured["saber"].query.assert_awaited_once_with(
+        captured["query"], event_stream_handler=ANY
+    )
     assert captured["closed"] is True
     retention.assert_awaited_once_with(store, artifact_store, query_result_store)
 

--- a/tests/test_cli/test_slash_management.py
+++ b/tests/test_cli/test_slash_management.py
@@ -24,7 +24,7 @@ from sqlsaber.cli.threads import (
     ThreadResumePreparationError,
 )
 from sqlsaber.cli.tui_chat import ChatApp
-from sqlsaber.cli.usage import SessionUsage
+from sqlsaber.cli.usage import SessionUsage, UsageMeter
 from sqlsaber.config.settings import ThinkingLevel
 from sqlsaber.render import bind_cli_surfaces, blocks as b
 from sqlsaber.render.markdown_text import md_of
@@ -267,7 +267,7 @@ async def test_slash_commands_are_not_written_to_disk_history() -> None:
         return_value=CommandResult(handled=True)
     )
     session.saber = MagicMock()
-    session.session_usage = SessionUsage()
+    session.usage = UsageMeter(model_id=session._model_id)
     session.log = MagicMock()
     app = MagicMock()
 
@@ -334,7 +334,10 @@ async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
     new.list_tables = AsyncMock(return_value=[])
     session = InteractiveSession.__new__(InteractiveSession)
     session.saber = old
-    session.session_usage = SessionUsage(total_input_tokens=10)
+    session.usage = UsageMeter(
+        model_id=session._model_id, on_change=session._refresh_footer
+    )
+    session.usage._session = SessionUsage(total_input_tokens=10)
     session.autocomplete_provider = MagicMock()
     session.streaming_handler = MagicMock()
     app = MagicMock()
@@ -355,7 +358,7 @@ async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
     app.clear_chat.assert_called_once_with()
     render.assert_called_once()
     new.list_tables.assert_awaited_once_with()
-    assert session.session_usage.total_input_tokens == 0
+    assert session.usage.session.total_input_tokens == 0
     await session.saber.close()
     new.close.assert_awaited_once_with()
 
@@ -380,7 +383,9 @@ async def test_resume_keeps_new_session_when_old_cleanup_fails() -> None:
     new.list_tables = AsyncMock(return_value=[])
     session = InteractiveSession.__new__(InteractiveSession)
     session.saber = old
-    session.session_usage = SessionUsage()
+    session.usage = UsageMeter(
+        model_id=session._model_id, on_change=session._refresh_footer
+    )
     session.autocomplete_provider = MagicMock()
     session.streaming_handler = MagicMock()
     session.log = MagicMock()

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -10,6 +10,7 @@ import saber_tui.utils as tui_utils
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
+    ModelResponse,
     PartDeltaEvent,
     PartEndEvent,
     PartStartEvent,
@@ -617,11 +618,13 @@ def test_chat_app_renders_footer_text() -> None:
 def test_interactive_footer_includes_usage_cost_and_context() -> None:
     session = InteractiveSession.__new__(InteractiveSession)
     session.saber = _fake_saber()
-    session.session_usage = interactive.SessionUsage(
-        total_input_tokens=4200,
-        total_output_tokens=820,
-        current_context_tokens=999,
-        total_cost_usd=0.0123,
+    session.usage = SimpleNamespace(
+        session=interactive.SessionUsage(
+            total_input_tokens=4200,
+            total_output_tokens=820,
+            current_context_tokens=999,
+            total_cost_usd=0.0123,
+        )
     )
 
     footer = session._footer_text()
@@ -636,7 +639,7 @@ def test_interactive_footer_includes_usage_cost_and_context() -> None:
 def test_interactive_footer_includes_dangerous_mode_when_enabled() -> None:
     session = InteractiveSession.__new__(InteractiveSession)
     session.saber = _fake_saber(dangerous_mode=True)
-    session.session_usage = interactive.SessionUsage()
+    session.usage = SimpleNamespace(session=interactive.SessionUsage())
 
     footer = session._footer_text()
 
@@ -649,7 +652,7 @@ def test_interactive_footer_shows_all_database_names() -> None:
         database_names=("prod", "staging", "warehouse"),
         database_type="PostgreSQL",
     )
-    session.session_usage = interactive.SessionUsage()
+    session.usage = SimpleNamespace(session=interactive.SessionUsage())
 
     footer = session._footer_text()
 
@@ -674,7 +677,9 @@ async def test_execute_query_refreshes_footer_usage_cost_and_context() -> None:
         model_name="claude-sonnet-4-5",
         model_id="anthropic:claude-sonnet-4-5",
     )
-    session.session_usage = interactive.SessionUsage()
+    session.usage = interactive.UsageMeter(
+        model_id=session._model_id, on_change=session._refresh_footer
+    )
     session.current_task = None
     session.cancellation_token = None
 
@@ -686,6 +691,32 @@ async def test_execute_query_refreshes_footer_usage_cost_and_context() -> None:
             RequestUsage(input_tokens=150_000, output_tokens=0),
         ]
 
+    async def no_events():
+        return
+        yield
+
+    footers_during_run: list[str] = []
+
+    async def fake_query(prompt, *, event_stream_handler=None, **kwargs):
+        assert prompt == "show revenue"
+        messages = []
+        ctx = SimpleNamespace(run_id="run-1", messages=messages, usage=RunUsage())
+        for request_usage in FakeSQLSaberResult.request_usages:
+            messages.append(
+                ModelResponse(
+                    parts=[TextPart("...")], usage=request_usage, run_id="run-1"
+                )
+            )
+            await event_stream_handler(ctx, no_events())
+            footers_during_run.append("\n".join(app.render_plain_viewport()))
+        return FakeSQLSaberResult()
+
+    session.saber.query = fake_query
+
+    async def presenter_handler(ctx, event_stream):
+        async for _ in event_stream:
+            pass
+
     class FakeStreamingHandler:
         def __init__(self, target_app: ChatApp) -> None:
             self.app = target_app
@@ -694,14 +725,16 @@ async def test_execute_query_refreshes_footer_usage_cost_and_context() -> None:
             self, user_query, *, run_query, cancellation_token
         ) -> FakeSQLSaberResult:
             assert user_query == "show revenue"
-            assert run_query is session.saber.query
             assert cancellation_token is session.cancellation_token
-            return FakeSQLSaberResult()
+            return await run_query(user_query, event_stream_handler=presenter_handler)
 
     session.streaming_handler = FakeStreamingHandler(app)
 
     await session._execute_query_with_cancellation("show revenue")
 
+    assert "Usage: ↑150.0k ↓0" in footers_during_run[0]
+    assert "Ctx: 150.0k" in footers_during_run[0]
+    assert "Cost: $0.4500" in footers_during_run[0]
     viewport = "\n".join(app.render_plain_viewport())
     assert "Usage: ↑300.0k ↓0" in viewport
     assert "Ctx: 150.0k" in viewport

--- a/tests/test_cli/test_update_check.py
+++ b/tests/test_cli/test_update_check.py
@@ -116,7 +116,9 @@ async def test_interactive_session_binds_update_notice_before_tui_start(
     session.current_task = None
     session._submit_pending = False
     session._exit_finalized = False
-    session.session_usage = interactive_mod.SessionUsage()
+    session.usage = interactive_mod.UsageMeter(
+        model_id=session._model_id, on_change=session._refresh_footer
+    )
     session.before_prompt_loop = lambda: asyncio.sleep(0)
     session._load_history = lambda: []
     session.show_welcome_message = lambda app: None

--- a/tests/test_cli/test_usage.py
+++ b/tests/test_cli/test_usage.py
@@ -1,85 +1,495 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelResponseState,
+    TextPart,
+)
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.usage import RequestUsage, RunUsage
 
-from sqlsaber.cli.usage import SessionUsage, format_cost_usd, session_summary_blocks
+import sqlsaber.cli.usage as usage_mod
+from sqlsaber.cli.usage import (
+    SessionUsage,
+    UsageMeter,
+    format_cost_usd,
+    session_summary_blocks,
+)
 from sqlsaber.render.markdown_text import md_of
 
+SONNET = "anthropic:claude-sonnet-4-5"
+OPUS = "anthropic:claude-opus-4-6"
+RUN_ID = "run-1"
 
-def test_session_usage_tracks_cumulative_usage_context_and_cache_aware_cost() -> None:
-    usage = SessionUsage()
 
-    usage.add_run(
-        RunUsage(
-            input_tokens=3100,
-            cache_write_tokens=1000,
-            cache_read_tokens=2000,
-            output_tokens=10,
-            requests=1,
-            tool_calls=1,
-        ),
-        final_context_tokens=100,
-        model_name="anthropic:claude-opus-4-6",
+def _response(
+    usage: RequestUsage,
+    *,
+    run_id: str = RUN_ID,
+    state: ModelResponseState = "complete",
+) -> ModelResponse:
+    return ModelResponse(
+        parts=[TextPart("ok")], usage=usage, run_id=run_id, state=state
     )
 
-    assert usage.total_input_tokens == 3100
-    assert usage.total_output_tokens == 10
-    assert usage.current_context_tokens == 100
-    assert usage.cache_write_tokens == 1000
-    assert usage.cache_read_tokens == 2000
-    assert usage.total_cost_usd == pytest.approx(0.008)
+
+async def _no_events() -> AsyncIterator[Any]:
+    return
+    yield
 
 
-def test_session_usage_marks_cost_unknown_when_model_name_is_missing() -> None:
-    usage = SessionUsage()
+async def _drain(ctx: Any, event_stream: AsyncIterator[Any]) -> None:
+    async for _ in event_stream:
+        pass
 
-    usage.add_run(
-        RunUsage(input_tokens=1000, output_tokens=100, requests=1),
-        final_context_tokens=1000,
-        model_name=None,
+
+class FakeResult:
+    """The ``SQLSaberResult`` fields the meter reads, built the way the SDK builds them."""
+
+    def __init__(
+        self, new_messages: Iterable[ModelMessage], usage: RunUsage | None
+    ) -> None:
+        self.request_usages = [
+            message.usage
+            for message in new_messages
+            if isinstance(message, ModelResponse)
+        ]
+        self.usage = usage
+        self.final_context_tokens = (
+            self.request_usages[-1].input_tokens if self.request_usages else 0
+        )
+
+
+class FakeRun:
+    """Drives an event-stream handler with live run state, like pydantic-ai's graph.
+
+    ``ctx.messages`` and ``ctx.usage`` are the objects the run mutates, so a
+    handler that keeps the context sees later appends.
+    """
+
+    def __init__(
+        self,
+        handler: Callable[..., Awaitable[None]] | None,
+        *,
+        history: Sequence[ModelMessage] = (),
+    ) -> None:
+        self.handler = handler
+        self.history = list(history)
+        self.messages: list[ModelMessage] = list(history)
+        self.usage = RunUsage()
+        self.ctx = SimpleNamespace(
+            run_id=RUN_ID, messages=self.messages, usage=self.usage
+        )
+
+    async def node(self) -> None:
+        if self.handler is not None:
+            await self.handler(self.ctx, _no_events())
+
+    def respond(self, usage: RequestUsage, **kwargs: Any) -> None:
+        self.messages.append(_response(usage, **kwargs))
+        self.usage.incr(usage)
+
+    def tool_call(self) -> None:
+        self.usage.tool_calls += 1
+
+    def result(self) -> FakeResult:
+        return FakeResult(self.messages[len(self.history) :], self.usage)
+
+
+def _two_step_query(
+    first: RequestUsage,
+    second: RequestUsage,
+    *,
+    history: Sequence[ModelMessage] = (),
+) -> Callable[..., Awaitable[FakeResult]]:
+    """A run shaped like model message, tool call, model message.
+
+    The handler runs once per graph node: for a model request node before its
+    response is appended, for a tool node after the response and its tool call
+    have been applied. That is the cadence pydantic-ai 2.9 produces.
+    """
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler, history=history)
+        await run.node()
+        run.respond(first)
+        run.tool_call()
+        await run.node()
+        await run.node()
+        run.respond(second)
+        await run.node()
+        return run.result()
+
+    return query
+
+
+def _meter(model_id: str | None) -> tuple[UsageMeter, list[SessionUsage]]:
+    snapshots: list[SessionUsage] = []
+    meter = UsageMeter(
+        model_id=lambda: model_id, on_change=lambda: snapshots.append(meter.session)
     )
-
-    assert usage.total_input_tokens == 1000
-    assert usage.total_output_tokens == 100
-    assert usage.current_context_tokens == 1000
-    assert usage.total_cost_usd is None
-    assert format_cost_usd(usage.total_cost_usd) == "n/a"
+    return meter, snapshots
 
 
-def test_session_usage_marks_multi_request_aggregate_cost_unknown_without_request_usages() -> (
+@pytest.mark.asyncio
+async def test_meter_notifies_after_each_completed_response_without_double_counting() -> (
     None
 ):
-    usage = SessionUsage()
-
-    usage.add_run(
-        RunUsage(input_tokens=3100, output_tokens=10, requests=2),
-        final_context_tokens=100,
-        model_name="anthropic:claude-opus-4-6",
+    meter, snapshots = _meter(SONNET)
+    query = _two_step_query(
+        RequestUsage(input_tokens=150_000), RequestUsage(input_tokens=150_000)
     )
 
-    assert usage.total_input_tokens == 3100
-    assert usage.total_output_tokens == 10
-    assert usage.current_context_tokens == 100
-    assert usage.total_cost_usd is None
-    assert format_cost_usd(usage.total_cost_usd) == "n/a"
+    result = await meter.metered(query)("show revenue")
+
+    assert [snapshot.total_input_tokens for snapshot in snapshots] == [
+        150_000,
+        300_000,
+    ]
+    assert meter.session.requests == 2
+    assert meter.session.tool_calls == 1
+    assert meter.session.total_input_tokens == sum(
+        usage.input_tokens for usage in result.request_usages
+    )
+    assert meter.session.current_context_tokens == 150_000
+    assert meter.session.total_cost_usd == pytest.approx(0.9)
+    assert format_cost_usd(meter.session.total_cost_usd) == "$0.9000"
 
 
-def test_session_usage_prices_multi_request_usages_individually() -> None:
-    usage = SessionUsage()
+@pytest.mark.asyncio
+async def test_replaying_an_observation_folds_nothing_and_does_not_notify() -> None:
+    meter, snapshots = _meter(SONNET)
 
-    usage.add_run(
-        RunUsage(input_tokens=300_000, output_tokens=0, requests=2),
-        final_context_tokens=150_000,
-        model_name="anthropic:claude-sonnet-4-5",
-        request_usages=[
-            RequestUsage(input_tokens=150_000, output_tokens=0),
-            RequestUsage(input_tokens=150_000, output_tokens=0),
-        ],
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        run.respond(RequestUsage(input_tokens=100, output_tokens=10))
+        await run.node()
+        await run.node()
+        return run.result()
+
+    await meter.metered(query)("go")
+
+    assert len(snapshots) == 1
+    assert meter.session.requests == 1
+    assert meter.session.total_input_tokens == 100
+    assert meter.session.total_output_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_metered_forwards_extra_keyword_arguments() -> None:
+    meter, _ = _meter(SONNET)
+    received: dict[str, Any] = {}
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        received.update(kwargs)
+        return FakeResult([], RunUsage())
+
+    await meter.metered(query)("go", conversation_id="conv-1")
+
+    assert received == {"conversation_id": "conv-1"}
+
+
+@pytest.mark.asyncio
+async def test_result_without_run_usage_still_folds_request_usages() -> None:
+    meter, snapshots = _meter(SONNET)
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        return FakeResult([_response(RequestUsage(input_tokens=150_000))], None)
+
+    await meter.metered(query)("go")
+
+    assert len(snapshots) == 1
+    assert meter.session.requests == 1
+    assert meter.session.tool_calls == 0
+    assert meter.session.total_input_tokens == 150_000
+
+
+@pytest.mark.asyncio
+async def test_shrunk_observation_replaces_this_turn_instead_of_stacking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        usage_mod,
+        "log",
+        SimpleNamespace(
+            warning=lambda event, **fields: warnings.append({"event": event, **fields})
+        ),
+    )
+    meter, _ = _meter(None)
+    prior = _two_step_query(RequestUsage(input_tokens=7), RequestUsage(input_tokens=8))
+    await meter.metered(prior)("earlier")
+    assert meter.session.total_input_tokens == 15
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        run.respond(RequestUsage(input_tokens=10))
+        run.respond(RequestUsage(input_tokens=20))
+        await run.node()
+        run.messages[:] = [_response(RequestUsage(input_tokens=30))]
+        await run.node()
+        run.messages.append(_response(RequestUsage(input_tokens=40)))
+        await run.node()
+        return FakeResult(run.messages, None)
+
+    await meter.metered(query)("go")
+
+    assert meter.session.requests == 4
+    assert meter.session.total_input_tokens == 85
+    assert meter.session.current_context_tokens == 40
+    assert warnings == [
+        {"event": "usage.meter.cursor_reset", "observed": 1, "folded": 2}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exception_from_the_presenter_handler_keeps_completed_responses() -> None:
+    meter, _ = _meter(SONNET)
+
+    class Interrupted(Exception):
+        pass
+
+    calls = 0
+
+    async def presenter(ctx: Any, event_stream: AsyncIterator[Any]) -> None:
+        nonlocal calls
+        calls += 1
+        await _drain(ctx, event_stream)
+        if calls == 3:
+            raise Interrupted
+
+    query = _two_step_query(
+        RequestUsage(input_tokens=150_000), RequestUsage(input_tokens=150_000)
     )
 
-    assert usage.total_input_tokens == 300_000
-    assert usage.current_context_tokens == 150_000
-    assert usage.total_cost_usd == pytest.approx(0.9)
-    assert format_cost_usd(usage.total_cost_usd) == "$0.9000"
+    with pytest.raises(Interrupted):
+        await meter.metered(query)("go", event_stream_handler=presenter)
+
+    assert meter.session.requests == 1
+    assert meter.session.tool_calls == 1
+    assert meter.session.total_input_tokens == 150_000
+    assert meter.session.total_cost_usd == pytest.approx(0.45)
+
+
+@pytest.mark.asyncio
+async def test_cancel_between_nodes_banks_responses_from_the_last_context() -> None:
+    meter, snapshots = _meter(SONNET)
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        await run.node()
+        run.respond(RequestUsage(input_tokens=150_000))
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await meter.metered(query)("go")
+
+    assert len(snapshots) == 1
+    assert meter.session.requests == 1
+    assert meter.session.total_input_tokens == 150_000
+    assert meter.session.total_cost_usd == pytest.approx(0.45)
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_totals_latch_and_cursor() -> None:
+    meter, snapshots = _meter("nosuchprovider:nosuchmodel")
+    query = _two_step_query(
+        RequestUsage(input_tokens=100), RequestUsage(input_tokens=100)
+    )
+    await meter.metered(query)("go")
+    assert meter.session.total_input_tokens == 200
+    assert meter.session.total_cost_usd is None
+    notified = len(snapshots)
+
+    meter.reset()
+
+    assert meter.session == SessionUsage()
+    assert meter.session.total_cost_usd == 0.0
+    assert len(snapshots) == notified + 1
+    meter._absorb([RequestUsage(input_tokens=1)] * 3, tool_calls=0)
+    assert meter.session.requests == 3
+
+
+def test_reset_of_an_empty_session_does_not_notify() -> None:
+    meter, snapshots = _meter(SONNET)
+
+    meter.reset()
+
+    assert snapshots == []
+
+
+@pytest.mark.asyncio
+async def test_prior_turn_responses_with_another_run_id_are_excluded() -> None:
+    meter, _ = _meter(SONNET)
+    history = [
+        ModelRequest.user_text_prompt("earlier turn"),
+        _response(
+            RequestUsage(input_tokens=999_999, output_tokens=999_999), run_id="run-0"
+        ),
+    ]
+    query = _two_step_query(
+        RequestUsage(input_tokens=100),
+        RequestUsage(input_tokens=100),
+        history=history,
+    )
+
+    await meter.metered(query)("go")
+
+    assert meter.session.requests == 2
+    assert meter.session.total_input_tokens == 200
+    assert meter.session.total_output_tokens == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["incomplete", "interrupted"])
+async def test_responses_that_did_not_complete_are_excluded(
+    state: ModelResponseState,
+) -> None:
+    meter, _ = _meter(SONNET)
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        run.respond(RequestUsage(input_tokens=100))
+        run.respond(RequestUsage(input_tokens=999), state=state)
+        await run.node()
+        raise RuntimeError("model stream cut")
+
+    with pytest.raises(RuntimeError):
+        await meter.metered(query)("go")
+
+    assert meter.session.requests == 1
+    assert meter.session.total_input_tokens == 100
+    assert meter.session.current_context_tokens == 100
+
+
+@pytest.mark.asyncio
+async def test_meter_prices_cache_aware_request_and_counts_tool_calls() -> None:
+    meter, _ = _meter(OPUS)
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        run.respond(
+            RequestUsage(
+                input_tokens=3100,
+                cache_write_tokens=1000,
+                cache_read_tokens=2000,
+                output_tokens=10,
+            )
+        )
+        run.tool_call()
+        await run.node()
+        return run.result()
+
+    await meter.metered(query)("go")
+
+    session = meter.session
+    assert session.requests == 1
+    assert session.tool_calls == 1
+    assert session.total_input_tokens == 3100
+    assert session.total_output_tokens == 10
+    assert session.current_context_tokens == 3100
+    assert session.cache_write_tokens == 1000
+    assert session.cache_read_tokens == 2000
+    assert session.total_cost_usd == pytest.approx(0.008)
+
+
+@pytest.mark.asyncio
+async def test_meter_marks_cost_unknown_when_model_id_is_missing() -> None:
+    meter, _ = _meter(None)
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run = FakeRun(event_stream_handler)
+        run.respond(RequestUsage(input_tokens=1000, output_tokens=100))
+        await run.node()
+        return run.result()
+
+    await meter.metered(query)("go")
+
+    assert meter.session.total_input_tokens == 1000
+    assert meter.session.total_output_tokens == 100
+    assert meter.session.current_context_tokens == 1000
+    assert meter.session.total_cost_usd is None
+    assert format_cost_usd(meter.session.total_cost_usd) == "n/a"
+
+
+@pytest.mark.asyncio
+async def test_meter_matches_pydantic_ai_totals_on_a_real_agent_run() -> None:
+    steps = 0
+
+    async def stream_fn(
+        messages: list[ModelMessage], info: AgentInfo
+    ) -> AsyncIterator[Any]:
+        nonlocal steps
+        steps += 1
+        if steps == 1:
+            yield {0: DeltaToolCall(name="echo", json_args='{"text": "hi"}')}
+        else:
+            yield "done"
+
+    agent = Agent(FunctionModel(stream_function=stream_fn), name="probe")
+
+    @agent.tool_plain
+    def echo(text: str) -> str:
+        return text
+
+    history = [
+        ModelRequest.user_text_prompt("earlier turn"),
+        _response(
+            RequestUsage(input_tokens=999_999, output_tokens=999_999), run_id="run-0"
+        ),
+    ]
+
+    async def query(
+        prompt: str, /, *, event_stream_handler: Any = None, **kwargs: Any
+    ) -> FakeResult:
+        run_result = await agent.run(
+            prompt, message_history=history, event_stream_handler=event_stream_handler
+        )
+        return FakeResult(run_result.new_messages(), run_result.usage)
+
+    meter, snapshots = _meter(SONNET)
+
+    result = await meter.metered(query)("go", event_stream_handler=_drain)
+
+    run_usage = result.usage
+    assert run_usage is not None
+    assert meter.session.requests == run_usage.requests == 2
+    assert meter.session.tool_calls == run_usage.tool_calls == 1
+    assert meter.session.total_input_tokens == run_usage.input_tokens
+    assert meter.session.total_output_tokens == run_usage.output_tokens
+    assert (
+        meter.session.current_context_tokens == result.request_usages[-1].input_tokens
+    )
+    assert meter.session.total_cost_usd is not None
+    assert snapshots[0].requests == 1
+    assert snapshots[-1].requests == 2
 
 
 def test_format_cost_usd_handles_known_zero_tiny_and_unknown_costs() -> None:
@@ -90,11 +500,13 @@ def test_format_cost_usd_handles_known_zero_tiny_and_unknown_costs() -> None:
 
 
 def test_session_summary_labels_total_usage_and_current_context() -> None:
-    session_usage = SessionUsage()
-    session_usage.add_run(
-        RunUsage(input_tokens=4200, output_tokens=820, requests=1, tool_calls=7),
-        final_context_tokens=999,
-        model_name="anthropic:claude-opus-4-6",
+    session_usage = SessionUsage(
+        requests=1,
+        tool_calls=7,
+        total_input_tokens=4200,
+        total_output_tokens=820,
+        current_context_tokens=999,
+        total_cost_usd=0.0415,
     )
 
     output = md_of(session_summary_blocks(session_usage))

--- a/tests/test_cli/test_usage.py
+++ b/tests/test_cli/test_usage.py
@@ -53,8 +53,6 @@ async def _drain(ctx: Any, event_stream: AsyncIterator[Any]) -> None:
 
 
 class FakeResult:
-    """The ``SQLSaberResult`` fields the meter reads, built the way the SDK builds them."""
-
     def __init__(
         self, new_messages: Iterable[ModelMessage], usage: RunUsage | None
     ) -> None:
@@ -70,9 +68,7 @@ class FakeResult:
 
 
 class FakeRun:
-    """Drives an event-stream handler with live run state, like pydantic-ai's graph.
-
-    ``ctx.messages`` and ``ctx.usage`` are the objects the run mutates, so a
+    """``ctx.messages`` and ``ctx.usage`` are the objects the run mutates, so a
     handler that keeps the context sees later appends.
     """
 
@@ -111,9 +107,7 @@ def _two_step_query(
     *,
     history: Sequence[ModelMessage] = (),
 ) -> Callable[..., Awaitable[FakeResult]]:
-    """A run shaped like model message, tool call, model message.
-
-    The handler runs once per graph node: for a model request node before its
+    """The handler runs once per graph node: for a model request node before its
     response is appended, for a tool node after the response and its tool call
     have been applied. That is the cadence pydantic-ai 2.9 produces.
     """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The interactive editor footer showed `Usage`, `Ctx`, and `Cost` only after the whole agent turn finished. During a multi-step turn the spinner moved and the meter stayed frozen. pydantic-ai already attaches `RequestUsage` to each complete `ModelResponse`, and `genai_prices` already prices those per request. The footer should move after each complete model message, not only at turn end.

## Scope

`UsageMeter` in `src/sqlsaber/cli/usage.py` is the only writer of a frozen `SessionUsage`. `metered()` wraps the query callable the presenter already calls. After each pydantic-ai graph node it folds newly completed `RequestUsage` values through a monotone `_TurnCursor`. The same fold runs from the run result, so a missing last handler invocation cannot drop the final message.

`InteractiveSession._execute_query_with_cancellation` passes `run_query=self.usage.metered(self.saber.query)` and no longer calls `add_run`. `commands.py` uses the same wrapper for the one-shot session summary. `SessionUsage.add_run`, `calculate_usages_cost_usd`, and `calculate_run_cost_usd` are deleted.

`AgentStreamPresenter`, `tui_chat.py`, the SDK, and the agents are unchanged.

## Tradeoffs

We intercept `event_stream_handler` as a keyword on the wrapped query. The presenter already passes it that way. A future positional call would stop metering. Tests assert `on_change` during a turn so that drift fails loudly.

If the current-run `ModelResponse` list shrinks, the meter rewinds to the turn's start snapshot and refolds. That path is defensive. The repo history processor does not drop responses today.

`requests` is the count of folded responses, and `Ctx` is the last folded response's `input_tokens`. Real runs match the old `RunUsage` and `final_context_tokens` values. Synthetic tests that passed an unrelated context size had to change.

## Blast Radius

Interactive footer and one-shot TTY session summary share one accumulation path. Slash commands still receive a `SessionUsage` snapshot. Nested plugin agents are not folded, matching the old `new_messages` extraction. Interrupted turns now keep completed-before-cancel usage instead of dropping the whole turn.

## Verification

`env -u FORCE_COLOR uv run python -m pytest` is 1498 passed, 6 skipped.

`uvx ty check src/` is clean.

`tests/test_cli/test_tui_chat.py::test_execute_query_refreshes_footer_usage_cost_and_context` asserts the viewport shows `↑150.0k` and `$0.4500` after the first complete message, then `↑300.0k` and `$0.9000` after the second.

A live `saber` session against the verify-sqlsaber SQLite fixture with `openai:gpt-5` captured the footer six times while `Crunching data...` was still on screen. The line moved from `Usage: ↑0 ↓0 | Ctx: 0 | Cost: $0.0000` to `↑622 ↓261` at 13.8s, then through `↑1.5k`, `↑2.6k`, `↑3.8k`, `↑5.2k`, and `↑6.8k` before the turn settled. Employee count in that run was 3.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d2ea6f5-c50a-4141-ac13-ae0079d39549?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d2ea6f5-c50a-4141-ac13-ae0079d39549&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

