### PR TITLE
perf(tui): paint editor before pydantic-ai import

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -48,6 +48,88 @@ class CLIError(Exception):
         self.exit_code = exit_code
 
 
+async def _create_cli_saber(
+    *,
+    selected_database: str | list[str] | None,
+    thinking: bool | None,
+    allow_dangerous: bool,
+    system_prompt: str | None,
+    thread: str | None,
+    log,
+):
+    """Construct SQLSaber and persistence handles for a CLI session."""
+    from sqlsaber.cli.artifacts import cli_artifact_store
+    from sqlsaber.cli.query_results import cli_query_result_store
+    from sqlsaber import (
+        SQLSaber,
+        SQLSaberOptions,
+        ThreadDatabaseRequiredError,
+        ThreadDatabaseUnavailableError,
+        ThreadNotFoundError,
+        ThreadResumeHistoryError,
+        ThreadResumeMetadataError,
+    )
+    from sqlsaber.database.resolver import DatabaseResolutionError
+    from sqlsaber.threads import ThreadStorage
+    from sqlsaber.threads.manager import ThreadManager
+
+    storage = ThreadStorage()
+    artifact_store = cli_artifact_store()
+    query_result_store = cli_query_result_store()
+    options = SQLSaberOptions(
+        database=selected_database,
+        thinking_enabled=thinking,
+        allow_dangerous=allow_dangerous,
+        system_prompt=system_prompt,
+        thread_manager=(ThreadManager(storage=storage) if thread is None else None),
+        artifact_store=artifact_store,
+        query_result_store=query_result_store,
+    )
+    try:
+        saber = (
+            await SQLSaber.resume(thread, options=options, storage=storage)
+            if thread is not None
+            else SQLSaber(options=options)
+        )
+        info = saber.info
+        log.info("db.resolve.success", name=info.primary_database_name)
+        log.info("db.connection.created", db_type=info.primary_database_type)
+    except ThreadNotFoundError:
+        raise CLIError(
+            f"Thread not found: {thread}. List threads with: saber threads list"
+        ) from None
+    except ThreadResumeHistoryError as exc:
+        raise CLIError(f"Thread history cannot be resumed: {exc.reason}") from None
+    except ThreadDatabaseUnavailableError:
+        raise CLIError(
+            "The thread database is not configured for automatic continuation. "
+            "Retry with: "
+            f'saber --thread {thread} --database DATABASE "follow-up question"'
+        ) from None
+    except ThreadDatabaseRequiredError as exc:
+        if exc.reason == "No configured database selector is stored for this thread.":
+            raise CLIError(
+                "No database is stored with this thread. Retry with: "
+                f'saber --thread {thread} --database DATABASE "follow-up question"'
+            ) from None
+        raise CLIError(
+            f"Invalid thread metadata: {exc.reason}. Retry with: "
+            f'saber --thread {thread} --database DATABASE "follow-up question"'
+        ) from None
+    except ThreadResumeMetadataError as exc:
+        raise CLIError(
+            f"Invalid thread metadata: {exc.reason}. Retry with: "
+            f'saber --thread {thread} --database DATABASE "follow-up question"'
+        ) from None
+    except DatabaseResolutionError as exc:
+        log.error("db.resolve.error", error=str(exc))
+        raise CLIError(str(exc)) from None
+    except (ValueError, OSError) as exc:
+        log.exception("db.connection.error", error=str(exc))
+        raise CLIError(f"Error creating database connection: {exc}") from None
+    return saber, storage, artifact_store, query_result_store
+
+
 app = cyclopts.App(
     name="sqlsaber",
     help="SQLsaber - Open-source agentic SQL assistant for your database",
@@ -183,26 +265,6 @@ def query(
             allow_dangerous=allow_dangerous,
             system_prompt_provided=system_prompt is not None,
         )
-        from sqlsaber.cli.artifacts import cli_artifact_store
-        from sqlsaber.cli.interactive import InteractiveSession
-        from sqlsaber.cli.query_results import cli_query_result_store
-        from sqlsaber.cli.stream_presenter import AgentStreamPresenter
-        from sqlsaber import (
-            SQLSaber,
-            SQLSaberOptions,
-            ThreadDatabaseRequiredError,
-            ThreadDatabaseUnavailableError,
-            ThreadNotFoundError,
-            ThreadResumeHistoryError,
-            ThreadResumeMetadataError,
-        )
-        from sqlsaber.cli.retention import run_cli_retention
-        from sqlsaber.cli.usage import UsageMeter, session_summary_blocks
-        from sqlsaber.database.resolver import DatabaseResolutionError
-        from sqlsaber.render import cli_out
-        from sqlsaber.render.terminal import TerminalSurface
-        from sqlsaber.threads import ThreadStorage
-        from sqlsaber.threads.manager import ThreadManager
 
         actual_query = query_text
         if query_text is None and not sys.stdin.isatty():
@@ -210,10 +272,6 @@ def query(
             if not actual_query:
                 actual_query = None
 
-        if actual_query:
-            bind_update_notice(out)
-
-        storage = ThreadStorage()
         if thread is not None and actual_query is None:
             raise CLIError(
                 "A query is required with --thread. Example: "
@@ -229,66 +287,36 @@ def query(
                     "Setup incomplete. Please configure your database and try again."
                 )
             log.info("cli.onboarding.complete", success=True)
-        artifact_store = cli_artifact_store()
-        query_result_store = cli_query_result_store()
-        options = SQLSaberOptions(
-            database=selected_database,
-            thinking_enabled=thinking,
-            allow_dangerous=allow_dangerous,
-            system_prompt=system_prompt,
-            thread_manager=(ThreadManager(storage=storage) if thread is None else None),
-            artifact_store=artifact_store,
-            query_result_store=query_result_store,
-        )
-        try:
-            saber = (
-                await SQLSaber.resume(thread, options=options, storage=storage)
-                if thread is not None
-                else SQLSaber(options=options)
-            )
-            info = saber.info
-            log.info("db.resolve.success", name=info.primary_database_name)
-            log.info("db.connection.created", db_type=info.primary_database_type)
-        except ThreadNotFoundError:
-            raise CLIError(
-                f"Thread not found: {thread}. List threads with: saber threads list"
-            ) from None
-        except ThreadResumeHistoryError as exc:
-            raise CLIError(f"Thread history cannot be resumed: {exc.reason}") from None
-        except ThreadDatabaseUnavailableError:
-            raise CLIError(
-                "The thread database is not configured for automatic continuation. "
-                "Retry with: "
-                f'saber --thread {thread} --database DATABASE "follow-up question"'
-            ) from None
-        except ThreadDatabaseRequiredError as exc:
-            if (
-                exc.reason
-                == "No configured database selector is stored for this thread."
-            ):
-                raise CLIError(
-                    "No database is stored with this thread. Retry with: "
-                    f'saber --thread {thread} --database DATABASE "follow-up question"'
-                ) from None
-            raise CLIError(
-                f"Invalid thread metadata: {exc.reason}. Retry with: "
-                f'saber --thread {thread} --database DATABASE "follow-up question"'
-            ) from None
-        except ThreadResumeMetadataError as exc:
-            raise CLIError(
-                f"Invalid thread metadata: {exc.reason}. Retry with: "
-                f'saber --thread {thread} --database DATABASE "follow-up question"'
-            ) from None
-        except DatabaseResolutionError as exc:
-            log.error("db.resolve.error", error=str(exc))
-            raise CLIError(str(exc)) from None
-        except (ValueError, OSError) as exc:
-            log.exception("db.connection.error", error=str(exc))
-            raise CLIError(f"Error creating database connection: {exc}") from None
 
-        surface = cli_out()
+        from sqlsaber.cli.retention import run_cli_retention
+        from sqlsaber.render import cli_out
+
+        saber = None
+        storage = None
+        artifact_store = None
+        query_result_store = None
+        shell = None
         try:
             if actual_query:
+                bind_update_notice(out)
+                from sqlsaber.cli.stream_presenter import AgentStreamPresenter
+                from sqlsaber.cli.usage import UsageMeter, session_summary_blocks
+                from sqlsaber.render.terminal import TerminalSurface
+
+                (
+                    saber,
+                    storage,
+                    artifact_store,
+                    query_result_store,
+                ) = await _create_cli_saber(
+                    selected_database=selected_database,
+                    thinking=thinking,
+                    allow_dangerous=allow_dangerous,
+                    system_prompt=system_prompt,
+                    thread=thread,
+                    log=log,
+                )
+                surface = cli_out()
                 streaming_handler = AgentStreamPresenter(
                     surface,
                     display_registry=saber.display_registry,
@@ -329,21 +357,47 @@ def query(
                     )
                     log.info("thread.save.success", thread_id=thread_id)
             else:
+                from sqlsaber.cli.interactive import InteractiveSession
+
                 if allow_dangerous:
                     out(b.warn(DANGEROUS_MODE_WARNING, label="DANGEROUS MODE ENABLED"))
+                shell = InteractiveSession.start_unbound_shell(
+                    database=selected_database,
+                    allow_dangerous=allow_dangerous,
+                )
+                (
+                    saber,
+                    storage,
+                    artifact_store,
+                    query_result_store,
+                ) = await _create_cli_saber(
+                    selected_database=selected_database,
+                    thinking=thinking,
+                    allow_dangerous=allow_dangerous,
+                    system_prompt=system_prompt,
+                    thread=thread,
+                    log=log,
+                )
                 interactive_session = InteractiveSession(saber)
                 try:
-                    await interactive_session.run()
+                    await interactive_session.run(shell=shell)
                 finally:
                     saber = getattr(interactive_session, "saber", saber)
-
+        except BaseException:
+            if shell is not None:
+                shell.stop()
+            raise
         finally:
-            try:
-                await saber.close()
-            finally:
-                await run_cli_retention(storage, artifact_store, query_result_store)
-            log.info("db.connection.closed")
-            out(b.success("Goodbye!"))
+            if saber is not None:
+                try:
+                    await saber.close()
+                finally:
+                    if storage is not None:
+                        await run_cli_retention(
+                            storage, artifact_store, query_result_store
+                        )
+                log.info("db.connection.closed")
+                out(b.success("Goodbye!"))
 
     try:
         asyncio.run(run_session())

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -20,27 +21,56 @@ from sqlsaber.cli.tui_chat import (
     ChatApp,
     build_chat_app,
 )
-from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
 from sqlsaber.cli.update_check import bind_update_notice
-from sqlsaber.cli.usage import (
-    SessionUsage,
-    UsageMeter,
-    format_cost_usd,
-    format_tokens,
-)
 from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 
 if TYPE_CHECKING:
+    from saber_tui import Terminal
+
     from sqlsaber import SQLSaber, SQLSaberResult
+    from sqlsaber.cli.chat_surface import ChatSurface
+    from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
+    from sqlsaber.cli.usage import UsageMeter
 
 QUERY_CANCEL_GRACE_SECONDS = 0.1
+
+
+def __getattr__(name: str):
+    """Expose usage types without importing pydantic-ai at module load."""
+    if name in {"UsageMeter", "SessionUsage", "format_cost_usd", "format_tokens"}:
+        from sqlsaber.cli import usage as usage_mod
+
+        return getattr(usage_mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+@dataclass
+class ChatShell:
+    """Painted chat TUI that can bind an InteractiveSession after first paint."""
+
+    app: ChatApp
+    session_slot: dict[str, InteractiveSession]
+    exit_event: asyncio.Event
+    loop: asyncio.AbstractEventLoop
+    _stopped: bool = False
+
+    def stop(self) -> None:
+        """Stop the TUI if it is still running."""
+        if self._stopped:
+            return
+        self._stopped = True
+        if not self.app.tui.stopped:
+            self.app.stop()
+        self.exit_event.set()
 
 
 class InteractiveSession:
     """Manages interactive CLI sessions."""
 
-    def __init__(self, saber: "SQLSaber") -> None:
+    def __init__(self, saber: SQLSaber) -> None:
+        from sqlsaber.cli.usage import UsageMeter
+
         self.saber = saber
         self.streaming_handler: TUIStreamingQueryHandler | None = None
         self.current_task: asyncio.Task[SQLSaberResult | None] | None = None
@@ -52,6 +82,112 @@ class InteractiveSession:
         self.command_processor = SlashCommandProcessor()
         self.usage = UsageMeter(model_id=self._model_id, on_change=self._refresh_footer)
         self.log = get_logger(__name__)
+
+    @staticmethod
+    def boot_footer(
+        database: str | list[str] | None,
+        *,
+        allow_dangerous: bool = False,
+    ) -> str:
+        """Footer shown before SQLSaber is constructed."""
+        if isinstance(database, list) and len(database) > 1:
+            db_part = f"DBs: {', '.join(database)}"
+        elif isinstance(database, list) and database:
+            db_part = f"DB: {Path(database[0]).stem}"
+        elif isinstance(database, str) and database:
+            db_part = f"DB: {Path(database).stem}"
+        else:
+            db_part = "DB: starting..."
+        parts = [db_part]
+        if allow_dangerous:
+            parts.append(DANGEROUS_MODE_FOOTER_LABEL)
+        return " | ".join(parts)
+
+    @classmethod
+    def start_unbound_shell(
+        cls,
+        *,
+        database: str | list[str] | None = None,
+        allow_dangerous: bool = False,
+        terminal: Terminal | None = None,
+    ) -> ChatShell:
+        """Paint the editor before importing pydantic-ai or constructing SQLSaber."""
+        from sqlsaber.cli.chat_surface import ChatSurface
+
+        loop = asyncio.get_running_loop()
+        exit_event = asyncio.Event()
+        session_slot: dict[str, InteractiveSession] = {}
+        app_ref: dict[str, ChatApp] = {}
+        surface_ref: dict[str, ChatSurface] = {}
+
+        def on_submit(user_query: str) -> bool:
+            session = session_slot.get("session")
+            app = app_ref["app"]
+            surface = surface_ref["surface"]
+            if session is None:
+                surface.emit(b.warn("Still starting..."))
+                app.tui.set_focus(app.editor)
+                return False
+            return session._queue_submit(app, surface, user_query, loop=loop)
+
+        def open_command_palette(app: ChatApp) -> None:
+            session = session_slot.get("session")
+            if session is None:
+                from sqlsaber.config.settings import Config
+
+                settings = Config.default()
+                app.show_command_palette(
+                    thinking_enabled=settings.model.thinking_enabled,
+                    thinking_level=settings.model.thinking_level,
+                    commands=SlashCommandProcessor().palette_commands(),
+                )
+                return
+            info = session.saber.info
+            app.show_command_palette(
+                thinking_enabled=info.thinking.enabled,
+                thinking_level=info.thinking.level,
+                commands=session.command_processor.palette_commands(),
+                model_name=info.model_name,
+                database_name=info.primary_database_name,
+            )
+
+        def on_cancel() -> None:
+            session = session_slot.get("session")
+            app = app_ref["app"]
+            if session is None:
+                return
+            loop.call_soon_threadsafe(
+                lambda: asyncio.create_task(session._cancel_current_task(app))
+            )
+
+        def on_exit() -> None:
+            loop.call_soon_threadsafe(exit_event.set)
+
+        app = build_chat_app(
+            terminal=terminal,
+            on_submit=on_submit,
+            on_exit=on_exit,
+            on_cancel=on_cancel,
+            should_submit_empty=lambda: bool(
+                (session := session_slot.get("session")) and session._handoff_mode
+            ),
+            footer_text=cls.boot_footer(database, allow_dangerous=allow_dangerous),
+            on_open_command_palette=open_command_palette,
+        )
+        surface = ChatSurface(app)
+        app_ref["app"] = app
+        surface_ref["surface"] = surface
+        surface.emit(
+            b.panel((b.md(f"```\n{cls._banner()}\n```"),), role="primary"),
+            b.md(cls._instructions()),
+        )
+        app.tui.start()
+        return ChatShell(
+            app=app,
+            session_slot=session_slot,
+            exit_event=exit_event,
+            loop=loop,
+        )
 
     def _history_path(self) -> Path:
         """Get the history file path, ensuring directory exists."""
@@ -79,7 +215,8 @@ class InteractiveSession:
         except OSError:
             return
 
-    def _banner(self) -> str:
+    @staticmethod
+    def _banner() -> str:
         """Get the ASCII banner."""
         return """
 ███████  ██████  ██      ███████  █████  ██████  ███████ ██████
@@ -90,7 +227,8 @@ class InteractiveSession:
             ▀▀
 """.strip()
 
-    def _instructions(self) -> str:
+    @staticmethod
+    def _instructions() -> str:
         """Get the instruction text."""
         return dedent("""
                     - Use `/` for slash commands
@@ -124,6 +262,8 @@ class InteractiveSession:
         return DANGEROUS_MODE_FOOTER_LABEL if self.saber.info.dangerous_mode else None
 
     def _usage_footer_text(self) -> str:
+        from sqlsaber.cli.usage import SessionUsage, format_cost_usd, format_tokens
+
         usage: UsageMeter | None = getattr(self, "usage", None)
         session_usage = usage.session if usage is not None else SessionUsage()
         return (
@@ -136,6 +276,15 @@ class InteractiveSession:
     def _refresh_footer(self) -> None:
         if self.streaming_handler is not None:
             self.streaming_handler.app.set_footer(self._footer_text())
+
+    def _create_streaming_handler(self, app: ChatApp) -> None:
+        from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
+
+        self.streaming_handler = TUIStreamingQueryHandler(
+            app,
+            display_registry_provider=lambda: self.saber.display_registry,
+            query_result_store=self.saber.query_result_store,
+        )
 
     def show_welcome_message(self, app: ChatApp) -> None:
         """Display welcome message for interactive mode."""
@@ -197,11 +346,7 @@ class InteractiveSession:
             self.log.warning("interactive.resume.cleanup_failed", error=str(exc))
             surface.emit(b.warn(f"Previous session cleanup failed: {exc}"))
 
-        self.streaming_handler = TUIStreamingQueryHandler(
-            app,
-            display_registry_provider=lambda: self.saber.display_registry,
-            query_result_store=self.saber.query_result_store,
-        )
+        self._create_streaming_handler(app)
         self.usage.reset()
         app.clear_chat()
         render_prepared_thread(surface, prepared)
@@ -385,89 +530,110 @@ class InteractiveSession:
             out(b.md(f"You can continue this thread using: `{hint}`", role="muted"))
         self._exit_finalized = True
 
-    async def run(self) -> None:
-        """Run the interactive session loop."""
+    def _queue_submit(
+        self,
+        app: ChatApp,
+        surface,
+        user_query: str,
+        *,
+        loop: asyncio.AbstractEventLoop,
+    ) -> bool:
+        if self._submit_pending or (self.current_task and not self.current_task.done()):
+            surface.emit(
+                b.warn("A query is already running. Press Ctrl+C to interrupt it.")
+            )
+            app.tui.set_focus(app.editor)
+            return False
+
+        self._submit_pending = True
+
+        async def submit_query() -> None:
+            try:
+                await self._handle_submit(app, surface, user_query)
+            finally:
+                self._submit_pending = False
+
+        loop.call_soon_threadsafe(lambda: asyncio.create_task(submit_query()))
+        return True
+
+    async def run(self, shell: ChatShell | None = None) -> None:
+        """Run the interactive session loop.
+
+        Args:
+            shell: Pre-started TUI from ``start_unbound_shell``. When omitted,
+                this method builds and starts the TUI itself.
+        """
         self.log.info(
             "interactive.start", database=self.saber.info.primary_database_name
         )
-        await self.before_prompt_loop()
-
         from sqlsaber.cli.chat_surface import ChatSurface
 
-        exit_event = asyncio.Event()
-        loop = asyncio.get_running_loop()
-        app_ref: dict[str, ChatApp] = {}
-        surface_ref: dict[str, ChatSurface] = {}
+        if shell is None:
+            await self.before_prompt_loop()
+            exit_event = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            app_ref: dict[str, ChatApp] = {}
+            surface_ref: dict[str, ChatSurface] = {}
 
-        def on_submit(user_query: str) -> bool:
-            app = app_ref["app"]
-            surface = surface_ref["surface"]
-
-            if self._submit_pending or (
-                self.current_task and not self.current_task.done()
-            ):
-                surface.emit(
-                    b.warn("A query is already running. Press Ctrl+C to interrupt it.")
+            def on_submit(user_query: str) -> bool:
+                return self._queue_submit(
+                    app_ref["app"], surface_ref["surface"], user_query, loop=loop
                 )
-                app.tui.set_focus(app.editor)
-                return False
 
-            self._submit_pending = True
+            def open_command_palette(app: ChatApp) -> None:
+                info = self.saber.info
+                app.show_command_palette(
+                    thinking_enabled=info.thinking.enabled,
+                    thinking_level=info.thinking.level,
+                    commands=self.command_processor.palette_commands(),
+                    model_name=info.model_name,
+                    database_name=info.primary_database_name,
+                )
 
-            async def submit_query() -> None:
-                try:
-                    await self._handle_submit(app, surface, user_query)
-                finally:
-                    self._submit_pending = False
+            def on_cancel() -> None:
+                app = app_ref["app"]
+                loop.call_soon_threadsafe(
+                    lambda: asyncio.create_task(self._cancel_current_task(app))
+                )
 
-            loop.call_soon_threadsafe(lambda: asyncio.create_task(submit_query()))
-            return True
+            def on_exit() -> None:
+                loop.call_soon_threadsafe(exit_event.set)
 
-        def open_command_palette(app: ChatApp) -> None:
-            info = self.saber.info
-            app.show_command_palette(
-                thinking_enabled=info.thinking.enabled,
-                thinking_level=info.thinking.level,
-                commands=self.command_processor.palette_commands(),
-                model_name=info.model_name,
-                database_name=info.primary_database_name,
+            app = build_chat_app(
+                on_submit=on_submit,
+                on_exit=on_exit,
+                on_cancel=on_cancel,
+                should_submit_empty=lambda: self._handoff_mode,
+                autocomplete_provider=self.autocomplete_provider,
+                footer_text=self._footer_text(),
+                on_open_command_palette=open_command_palette,
             )
+            surface = ChatSurface(app)
+            app_ref["app"] = app
+            surface_ref["surface"] = surface
+            app.editor.history = self._load_history()
+            self._create_streaming_handler(app)
+            self.show_welcome_message(app)
+            bind_update_notice(surface.emit)
+            app.tui.start()
+        else:
+            app = shell.app
+            surface = ChatSurface(app)
+            shell.session_slot["session"] = self
+            app.editor.set_autocomplete_provider(self.autocomplete_provider)
+            app.editor.history = self._load_history()
+            self._create_streaming_handler(app)
+            bind_update_notice(surface.emit)
+            self._refresh_footer()
+            await self.before_prompt_loop()
+            exit_event = shell.exit_event
 
-        def on_cancel() -> None:
-            app = app_ref["app"]
-            loop.call_soon_threadsafe(
-                lambda: asyncio.create_task(self._cancel_current_task(app))
-            )
-
-        def on_exit() -> None:
-            loop.call_soon_threadsafe(exit_event.set)
-
-        app = build_chat_app(
-            on_submit=on_submit,
-            on_exit=on_exit,
-            on_cancel=on_cancel,
-            should_submit_empty=lambda: self._handoff_mode,
-            autocomplete_provider=self.autocomplete_provider,
-            footer_text=self._footer_text(),
-            on_open_command_palette=open_command_palette,
-        )
-        surface = ChatSurface(app)
-        app_ref["app"] = app
-        surface_ref["surface"] = surface
-        app.editor.history = self._load_history()
-        self.streaming_handler = TUIStreamingQueryHandler(
-            app,
-            display_registry_provider=lambda: self.saber.display_registry,
-            query_result_store=self.saber.query_result_store,
-        )
-        self.show_welcome_message(app)
-        bind_update_notice(surface.emit)
-
-        app.tui.start()
         try:
             await exit_event.wait()
         finally:
             bind_update_notice(None)
-            if not app.tui.stopped:
+            if shell is not None:
+                shell.stop()
+            elif not app.tui.stopped:
                 app.stop()
             await self._finalize_exit()

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -579,7 +579,7 @@ class ChatApp:
         if self.on_open_command_palette is None:
             return False
         self.on_open_command_palette(self)
-        return True
+        return self.is_command_palette_open()
 
     def is_command_palette_open(self) -> bool:
         return self._command_palette_component is not None

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -398,11 +398,23 @@ def test_root_bare_mode_passes_public_sdk_to_tui():
             captured["closed"] = True
 
     class FakeInteractiveSession:
+        @classmethod
+        def start_unbound_shell(cls, **kwargs):
+            captured["shell_kwargs"] = kwargs
+
+            class FakeShell:
+                def stop(self):
+                    captured["shell_stopped"] = True
+
+            captured["shell"] = FakeShell()
+            return captured["shell"]
+
         def __init__(self, saber):
             captured["interactive_saber"] = saber
 
-        async def run(self):
+        async def run(self, shell=None):
             captured["ran"] = True
+            captured["run_shell"] = shell
 
     retention = AsyncMock()
     with (

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -1,0 +1,81 @@
+"""Interactive TUI boot paints before pydantic-ai import."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from sqlsaber.cli.interactive import InteractiveSession
+
+from tests.test_cli.test_tui_chat import FakeTerminal
+
+
+def test_interactive_module_import_does_not_load_pydantic_ai() -> None:
+    code = """
+import sys
+from sqlsaber.cli.interactive import InteractiveSession, ChatShell
+
+assert "pydantic_ai" not in sys.modules
+assert "sqlsaber.sdk.client" not in sys.modules
+assert "sqlsaber.cli.usage" not in sys.modules
+assert "sqlsaber.cli.tui_streaming" not in sys.modules
+assert "sqlsaber.cli.stream_presenter" not in sys.modules
+assert InteractiveSession.__name__ == "InteractiveSession"
+assert ChatShell.__name__ == "ChatShell"
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_boot_footer_includes_db_ready_needle() -> None:
+    assert "DB:" in InteractiveSession.boot_footer("verification.db")
+    assert "verification" in InteractiveSession.boot_footer(
+        "/tmp/fixtures/verification.db"
+    )
+    assert "DB:" in InteractiveSession.boot_footer(None)
+
+
+@pytest.mark.asyncio
+async def test_start_unbound_shell_paints_slash_hint_and_db_footer() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database="/tmp/fixtures/verification.db",
+        terminal=terminal,
+    )
+    try:
+        shell.app.tui.flush_render()
+        text = "\n".join(shell.app.render_plain_viewport())
+        folded = text.casefold()
+        assert "slash commands" in folded
+        assert "table name completions" in folded
+        assert "DB:" in text
+        assert "verification" in folded
+        assert terminal.started is True
+    finally:
+        shell.stop()
+    assert terminal.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_unbound_shell_slash_opens_palette() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database="verification.db",
+        terminal=terminal,
+    )
+    try:
+        terminal.send_input("/")
+        shell.app.tui.flush_render()
+        text = "\n".join(shell.app.render_plain_viewport())
+        assert shell.app.is_command_palette_open() is True
+        assert "Thinking mode" in text
+        assert "Command help" in text
+    finally:
+        shell.stop()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`saber` with no question waited on pydantic-ai and `SQLSaber` construction before the interactive editor appeared. Process logs showed about 2.2s between `cli.session.start` and `db.resolve.success`. That matches the 1–4s delay before typing works.

## Scope

- `InteractiveSession.start_unbound_shell()` paints the banner, slash-command hint, and a `DB:` footer, then starts the TUI.
- `query()` constructs `SQLSaber` after that first paint and binds it with `run(shell=...)`.
- Slash `/` during boot opens the palette from local settings instead of swallowing the key.
- Queries that need the agent still wait until the runtime is attached (`Still starting...`).
- One-shot `saber "question"` still imports the agent before work, as before.

## Tradeoffs

The first frame can show `DB: <stem>` before the full `DB: name (SQLite) | Model: ...` footer. Typing works immediately. Submit and agent-backed slash commands wait until `SQLSaber` exists. That is the cost of moving a 2s import off the first-paint path.

## Blast radius

Interactive `saber` boot and the `/` key while the runtime is still loading. Thread resume still builds `SQLSaber` first, then `InteractiveSession.run()`. `--help` is unchanged.

## Verification

Frozen harness (do not edit after baseline):

```bash
python3 /opt/cursor/artifacts/hillclimb/measure_tui_ready.py \
  --run-id "$RUN_ID" --n 7 --workload interactive
```

Metric: wall-clock from `uv run saber -d <fixture>` process start until the PTY shows `slash commands`, `table name completions`, and `DB:`. Median of N=7 after 1 warmup. Lower is better.

| | median | N | notes |
| --- | --- | --- | --- |
| Baseline | 2.568s | 7 | samples 2.426–2.732, stdev 0.105 |
| This change | 0.945s | 7 | samples 0.937–0.996, stdev 0.020 |
| Delta | **-63.2%** | | target was -40% |

Contrast: `saber --help` median 0.207s (N=5). Interactive was the slow path. `--help` smoke after the change: 0.265s (<0.5s).

Iterations so far: 1 kept, 0 reverted.

| commit | delta |
| --- | --- |
| `perf(tui): paint editor before pydantic-ai import` | 2.568s → 0.945s (−63%) |

Regression gate: `env -u FORCE_COLOR uv run python -m pytest` 1502 passed, 6 skipped. `ruff check` and `ty check src/` clean.

Interactive proof (verify-sqlsaber drive): editor, `/` palette (`Thinking mode`, `Command help`), Clear conversation (`Conversation history cleared.`), Ctrl+D (`Goodbye!`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f693245e-0c1f-47b3-a655-be8642a98759?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f693245e-0c1f-47b3-a655-be8642a98759&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

