### PR TITLE
perf(tui): defer retention import until after first paint

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -288,7 +288,6 @@ def query(
                 )
             log.info("cli.onboarding.complete", success=True)
 
-        from sqlsaber.cli.retention import run_cli_retention
         from sqlsaber.render import cli_out
 
         saber = None
@@ -393,6 +392,8 @@ def query(
                     await saber.close()
                 finally:
                     if storage is not None:
+                        from sqlsaber.cli.retention import run_cli_retention
+
                         await run_cli_retention(
                             storage, artifact_store, query_result_store
                         )

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -12,6 +12,52 @@ from sqlsaber.cli.interactive import InteractiveSession
 from tests.test_cli.test_tui_chat import FakeTerminal
 
 
+def test_interactive_query_does_not_import_pydantic_ai_before_first_paint() -> None:
+    """Retention pulls pydantic-ai; it must stay off the first-paint path."""
+    code = """
+import sys
+from unittest.mock import patch
+
+class Probe(Exception):
+    pass
+
+class FakeSession:
+    @classmethod
+    def start_unbound_shell(cls, **kwargs):
+        loaded = [
+            name
+            for name in (
+                "pydantic_ai",
+                "sqlsaber.cli.retention",
+                "sqlsaber.threads.storage",
+                "sqlsaber.sdk.client",
+            )
+            if name in sys.modules
+        ]
+        raise Probe(",".join(loaded) or "clean")
+
+from sqlsaber.cli.commands import query
+
+with (
+    patch("sqlsaber.cli.interactive.InteractiveSession", FakeSession),
+    patch("sqlsaber.cli.commands.schedule_update_check"),
+):
+    try:
+        query(database=["analytics"])
+    except Probe as exc:
+        assert str(exc) == "clean", str(exc)
+    else:
+        raise SystemExit("probe not raised")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_interactive_module_import_does_not_load_pydantic_ai() -> None:
     code = """
 import sys


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Interactive `saber` still imported `sqlsaber.cli.retention` before first paint. That module imports `ThreadStorage`, which imports `pydantic_ai.messages`. `PYTHONPROFILEIMPORTTIME` attributed ~0.74s cumulative to that import, which blocked the editor even after painting before `SQLSaber` construction.

## Scope

- Import `run_cli_retention` in the session `finally` path, after `saber.close()`, not before `start_unbound_shell`.
- Add a subprocess test that probes `start_unbound_shell` and asserts `pydantic_ai` / retention / thread storage are not loaded yet.
- Stacks on #247 (`perf(tui): paint editor before pydantic-ai import`).

## Tradeoffs

Retention still runs on the same close path. The first paint no longer waits on garbage-collection imports. Non-interactive queries also import retention only during cleanup.

## Blast Radius

Interactive and one-shot CLI sessions. Slash palette, editor, and query behavior are unchanged. Cleanup still awaits `run_cli_retention` after close.

## Verification

Frozen harness (do not edit):

```bash
export RUN_ID="sqlsaber-hillclimb-tui"
export OPENAI_API_KEY="sk-test-placeholder"
python3 /opt/cursor/artifacts/hillclimb/measure_tui_ready.py \
  --run-id "$RUN_ID" --n 7 --workload interactive
```

Metric: wall-clock from `uv run saber -d <fixture>` process start until the PTY shows `slash commands`, `table name completions`, and `DB:`. Median of N=7 after 1 warmup. Lower is better.

| | median | N | notes |
| --- | --- | --- | --- |
| Baseline (pre-change) | 2.568s | 7 | stdev 0.105 |
| After #247 (paint before SQLSaber) | 0.945s | 7 | -63.2% vs baseline |
| **This change** | **0.243s** | **7** | **-74.3% vs 0.945s; -90.5% vs baseline** |

Samples (this change): 0.255, 0.258, 0.242, 0.245, 0.243, 0.240, 0.242.

Help contrast: 0.209s median N=5. `uv run saber --help` smoke: 0.251s (<0.5s).

Stop predicate (40% better than baseline **and** 8 iterations logged): percent target met; iteration floor not yet met (this is kept iteration 4 of 8).

Iterations so far: 2 kept (this + #247), 2 reverted (banner deferral; lazy cyclopts sub-apps). Decision log is on the VM only (`/opt/cursor/artifacts/hillclimb/decision.tsv`).

Regression gate: `env -u FORCE_COLOR uv run python -m pytest` — **1503 passed, 6 skipped**. `uv run ruff check .` and `uvx ty check src/` green.

Interactive session: palette (`Thinking mode`, `Command help`), Clear conversation, Ctrl+D `Goodbye!`. Transcript: `.agents/skills/verify-sqlsaber/artifacts/sqlsaber-hillclimb-tui/hillclimb/h4-palette-clear-exit.txt`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f693245e-0c1f-47b3-a655-be8642a98759?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f693245e-0c1f-47b3-a655-be8642a98759&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

