### PR TITLE
perf(tui): configure logging and httpx after first paint

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -1,27 +1,16 @@
 """CLI command definitions and handlers."""
 
-from sqlsaber.config.logging import setup_logging
-
-setup_logging()
-
-# ruff: noqa: E402
+from __future__ import annotations
 
 import asyncio
 import sys
+from collections.abc import Callable
 from typing import Annotated
 
 import cyclopts
 
-from sqlsaber.cli.auth import create_auth_app
-from sqlsaber.cli.database import create_db_app
-from sqlsaber.cli.knowledge import create_knowledge_app
-from sqlsaber.cli.models import create_models_app
 from sqlsaber.cli.onboarding import needs_onboarding, run_onboarding
 from sqlsaber.cli.output import fail, fail_usage, out
-from sqlsaber.cli.theme import create_theme_app
-from sqlsaber.cli.threads import create_threads_app
-from sqlsaber.cli.update_check import bind_update_notice, schedule_update_check
-from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 
 DANGEROUS_MODE_SCOPE = (
@@ -38,6 +27,28 @@ DATABASE_OPTION_HELP = (
     "names, files, or DSNs. Repeated CSV files merge into one session. Uses "
     "the default if omitted"
 )
+
+
+def _ensure_logging():
+    """Configure file logging after the first TUI frame is on screen."""
+    from sqlsaber.config.logging import get_logger, setup_logging
+
+    setup_logging()
+    return get_logger(__name__)
+
+
+def schedule_update_check() -> None:
+    """Schedule a PyPI update check without importing httpx at module load."""
+    from sqlsaber.cli.update_check import schedule_update_check as schedule
+
+    schedule()
+
+
+def bind_update_notice(emit: Callable[..., None] | None) -> None:
+    """Bind the update-notice sink without importing httpx at module load."""
+    from sqlsaber.cli.update_check import bind_update_notice as bind
+
+    bind(emit)
 
 
 class CLIError(Exception):
@@ -143,12 +154,36 @@ app = cyclopts.App(
     ),
 )
 
-app.command(create_auth_app(), name="auth")
-app.command(create_db_app(), name="db")
-app.command(create_knowledge_app(), name="knowledge")
-app.command(create_models_app(), name="models")
-app.command(create_theme_app(), name="theme")
-app.command(create_threads_app(), name="threads")
+app.command(
+    "sqlsaber.cli.auth:auth_app",
+    name="auth",
+    help="Manage authentication configuration",
+)
+app.command(
+    "sqlsaber.cli.database:db_app",
+    name="db",
+    help="Manage database connections",
+)
+app.command(
+    "sqlsaber.cli.knowledge:knowledge_app",
+    name="knowledge",
+    help="Manage database-specific knowledge entries",
+)
+app.command(
+    "sqlsaber.cli.models:models_app",
+    name="models",
+    help="Select and manage models",
+)
+app.command(
+    "sqlsaber.cli.theme:theme_app",
+    name="theme",
+    help="Manage theme settings",
+)
+app.command(
+    "sqlsaber.cli.threads:threads_app",
+    name="threads",
+    help="Manage SQLsaber threads",
+)
 
 
 @app.meta.default
@@ -250,21 +285,7 @@ def query(
     """
 
     async def run_session():
-        schedule_update_check()
-
         selected_database: str | list[str] | None = database
-
-        log = get_logger(__name__)
-        log.info(
-            "cli.session.start",
-            argv=sys.argv[1:],
-            database=selected_database,
-            has_query=query_text is not None,
-            thread_id=thread,
-            thinking=thinking,
-            allow_dangerous=allow_dangerous,
-            system_prompt_provided=system_prompt is not None,
-        )
 
         actual_query = query_text
         if query_text is None and not sys.stdin.isatty():
@@ -280,6 +301,7 @@ def query(
             )
 
         if thread is None and needs_onboarding(selected_database):
+            log = _ensure_logging()
             log.debug("cli.onboarding.start")
             onboarding_success = await run_onboarding()
             if not onboarding_success:
@@ -297,6 +319,18 @@ def query(
         shell = None
         try:
             if actual_query:
+                log = _ensure_logging()
+                schedule_update_check()
+                log.info(
+                    "cli.session.start",
+                    argv=sys.argv[1:],
+                    database=selected_database,
+                    has_query=True,
+                    thread_id=thread,
+                    thinking=thinking,
+                    allow_dangerous=allow_dangerous,
+                    system_prompt_provided=system_prompt is not None,
+                )
                 bind_update_notice(out)
                 from sqlsaber.cli.stream_presenter import AgentStreamPresenter
                 from sqlsaber.cli.usage import UsageMeter, session_summary_blocks
@@ -364,6 +398,18 @@ def query(
                     database=selected_database,
                     allow_dangerous=allow_dangerous,
                 )
+                log = _ensure_logging()
+                schedule_update_check()
+                log.info(
+                    "cli.session.start",
+                    argv=sys.argv[1:],
+                    database=selected_database,
+                    has_query=False,
+                    thread_id=thread,
+                    thinking=thinking,
+                    allow_dangerous=allow_dangerous,
+                    system_prompt_provided=system_prompt is not None,
+                )
                 (
                     saber,
                     storage,
@@ -403,7 +449,7 @@ def query(
     try:
         asyncio.run(run_session())
     except CLIError as e:
-        get_logger(__name__).error("cli.error", error=str(e))
+        _ensure_logging().error("cli.error", error=str(e))
         if e.exit_code == 2:
             fail_usage(str(e))
         fail(str(e), code=e.exit_code)
@@ -411,5 +457,4 @@ def query(
 
 def main():
     """Entry point for the CLI application."""
-    get_logger(__name__).info("cli.start")
     app()

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -21,8 +21,6 @@ from sqlsaber.cli.tui_chat import (
     ChatApp,
     build_chat_app,
 )
-from sqlsaber.cli.update_check import bind_update_notice
-from sqlsaber.config.logging import get_logger
 from sqlsaber.render import blocks as b
 
 if TYPE_CHECKING:
@@ -32,6 +30,14 @@ if TYPE_CHECKING:
     from sqlsaber.cli.chat_surface import ChatSurface
     from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
     from sqlsaber.cli.usage import UsageMeter
+
+
+def bind_update_notice(emit: Callable[..., None] | None) -> None:
+    """Bind the update-notice sink without importing httpx at module load."""
+    from sqlsaber.cli.update_check import bind_update_notice as bind
+
+    bind(emit)
+
 
 QUERY_CANCEL_GRACE_SECONDS = 0.1
 
@@ -70,6 +76,7 @@ class InteractiveSession:
 
     def __init__(self, saber: SQLSaber) -> None:
         from sqlsaber.cli.usage import UsageMeter
+        from sqlsaber.config.logging import get_logger
 
         self.saber = saber
         self.streaming_handler: TUIStreamingQueryHandler | None = None

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -24,6 +24,8 @@ from sqlsaber.cli.tui_chat import (
 from sqlsaber.render import blocks as b
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from saber_tui import Terminal
 
     from sqlsaber import SQLSaber, SQLSaberResult

--- a/src/sqlsaber/cli/onboarding.py
+++ b/src/sqlsaber/cli/onboarding.py
@@ -2,11 +2,7 @@
 
 import sys
 
-from sqlsaber.cli.models import ModelManager
 from sqlsaber.cli.output import err, out
-from sqlsaber.config.api_keys import APIKeyManager
-from sqlsaber.config.auth import AuthConfigManager
-from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.render import blocks as b
 
 BANNER = """
@@ -29,6 +25,8 @@ def needs_onboarding(database_arg: str | list[str] | None = None) -> bool:
 
     if database_arg:
         return False
+
+    from sqlsaber.config.database import DatabaseConfigManager
 
     db_manager = DatabaseConfigManager()
     has_db = db_manager.has_databases()
@@ -69,6 +67,7 @@ async def setup_database_guided() -> str | None:
         save_database,
         test_connection,
     )
+    from sqlsaber.config.database import DatabaseConfigManager
 
     out(b.md("**Step 1 of 2: Database Connection**", role="primary"))
 
@@ -134,6 +133,7 @@ async def select_model_for_provider(provider: str) -> str | None:
 
     """
 
+    from sqlsaber.cli.models import ModelManager
     from sqlsaber.cli.prompts import AsyncPrompter
     from sqlsaber.cli.workflows.model_selection import choose_model, fetch_models
 
@@ -172,8 +172,11 @@ async def setup_auth_guided() -> tuple[bool, str | None]:
 
     """
 
+    from sqlsaber.cli.models import ModelManager
     from sqlsaber.cli.prompts import AsyncPrompter
     from sqlsaber.cli.workflows.auth_setup import setup_auth
+    from sqlsaber.config.api_keys import APIKeyManager
+    from sqlsaber.config.auth import AuthConfigManager
 
     out(b.md("**Step 2 of 2: Authentication**", role="primary"))
 

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -12,6 +12,36 @@ from sqlsaber.cli.interactive import InteractiveSession
 from tests.test_cli.test_tui_chat import FakeTerminal
 
 
+def test_commands_import_does_not_load_structlog_or_httpx() -> None:
+    code = """
+import sys
+import sqlsaber.cli.commands  # noqa: F401
+
+loaded = [
+    name
+    for name in (
+        "structlog",
+        "httpx",
+        "keyring",
+        "pydantic_ai",
+        "sqlsaber.cli.auth",
+        "sqlsaber.cli.models",
+        "sqlsaber.cli.update_check",
+        "sqlsaber.config.logging",
+    )
+    if name in sys.modules
+]
+assert not loaded, loaded
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_interactive_query_does_not_import_pydantic_ai_before_first_paint() -> None:
     """Retention pulls pydantic-ai; it must stay off the first-paint path."""
     code = """
@@ -31,6 +61,10 @@ class FakeSession:
                 "sqlsaber.cli.retention",
                 "sqlsaber.threads.storage",
                 "sqlsaber.sdk.client",
+                "structlog",
+                "httpx",
+                "sqlsaber.config.logging",
+                "sqlsaber.cli.update_check",
             )
             if name in sys.modules
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After painting before `SQLSaber` and retention, the remaining editor delay was still dominated by `setup_logging()` (structlog) and `update_check` (httpx) during `commands` import, plus management CLI modules that call `get_logger()` at import time.

## Scope

- Paint `start_unbound_shell` before configuring logging or scheduling the PyPI check.
- Lazy-import `update_check` / `setup_logging` so httpx and structlog stay off first paint.
- Lazy-register cyclopts sub-apps (`auth`, `db`, `knowledge`, `models`, `theme`, `threads`) with the same help strings as today, so those modules cannot pull logging/httpx back onto the boot path.
- Defer onboarding's ModelManager/keyring imports until `run_onboarding`.
- Stacks on #248 (which stacks on #247).

## Tradeoffs

`saber --help` and `--version` no longer open the rotating log file. Interactive and one-shot sessions still configure logging after first paint (or at query start). `cli.start` is no longer logged from `main()`; `cli.session.start` still fires once logging is on.

## Blast Radius

CLI boot, onboarding, update notices, and root help. Subcommand behavior is unchanged; modules load when the subcommand or onboarding actually runs. Palette, slash commands, and retention cleanup are unchanged.

## Verification

Frozen harness:

```bash
export RUN_ID="sqlsaber-hillclimb-tui"
export OPENAI_API_KEY="sk-test-placeholder"
python3 /opt/cursor/artifacts/hillclimb/measure_tui_ready.py \
  --run-id "$RUN_ID" --n 7 --workload interactive
```

Metric: wall-clock from `uv run saber -d <fixture>` until the PTY shows `slash commands`, `table name completions`, and `DB:`. Median of N=7 after 1 warmup. Lower is better.

| | median | N |
| --- | --- | --- |
| Baseline | 2.568s | 7 |
| #247 paint before SQLSaber | 0.945s | 7 |
| #248 defer retention | 0.243s | 7 |
| **This change** | **0.189s** | **7** |

Delta vs #248: **-22.3%**. Vs baseline: **-92.6%**. Samples: 0.186, 0.188, 0.187, 0.197, 0.189, 0.200, 0.190.

Help contrast: 0.157s median N=5 (was 0.209s). `uv run saber --help` smoke: 0.189s (<0.5s).

Stop predicate: **met**. Median is 92.6% better than baseline (target 40%) and 8 iterations are logged (3 kept, 5 reverted).

Kept commits (land order):

| PR | commit | delta vs previous kept |
| --- | --- | --- |
| #247 | `perf(tui): paint editor before pydantic-ai import` | 2.568s → 0.945s (−63.2%) |
| #248 | `perf(tui): defer retention import until after first paint` | 0.945s → 0.243s (−74.3%) |
| #249 | `perf(tui): configure logging and httpx after first paint` | 0.243s → 0.189s (−22.3%) |

Regression gate: `env -u FORCE_COLOR uv run python -m pytest` — **1504 passed, 6 skipped**. `uv run ruff check .` and `uvx ty check src/` green.

Interactive session: palette (`Thinking mode`, `Command help`, `Clear conversation`), Ctrl+D `Goodbye!`. Transcript: `.agents/skills/verify-sqlsaber/artifacts/sqlsaber-hillclimb-tui/hillclimb/h7-palette-clear-exit.txt`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f693245e-0c1f-47b3-a655-be8642a98759?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f693245e-0c1f-47b3-a655-be8642a98759&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

