### PR TITLE
feat: Add opt-in CSV model-facing SQL tool results

### DIFF
--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -36,6 +36,7 @@ saber --thread a1b2c3d4 "Now compare that with last quarter"
 - `QUERY-TEXT` - SQL query in natural language (optional, starts interactive mode if not provided)
 - `-d, --database` - Database connection name, file path (CSV/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://). Repeat the flag to connect to [multiple databases](/guides/multi-database) at once (or to merge multiple CSV files into one session).
 - `--thinking` / `--no-thinking` - Enable/disable extended thinking/reasoning mode
+- `--csv-tool-results` / `--no-csv-tool-results` - Opt in to experimental CSV tables in model-facing SQL tool results. Defaults to JSON; applies to both single-shot queries and interactive mode.
 - `--allow-dangerous` - Allow INSERT/UPDATE/DELETE and restricted DDL (CREATE TABLE/VIEW/INDEX, ALTER TABLE). DROP/TRUNCATE and admin/security operations remain blocked; UPDATE/DELETE require WHERE.
 - `--system-prompt` - Custom system prompt text or path to a file (overrides built-in prompt)
 - `--thread` - Continue a saved thread non-interactively. Requires a query; uses the stored configured database unless `-d` overrides it.
@@ -44,6 +45,36 @@ saber --thread a1b2c3d4 "Now compare that with last quarter"
 
 - `--help, -h` - Display help message
 - `--version` - Show version information
+
+### Experimental CSV tool results
+
+```bash
+# One query (also works with a query piped through stdin)
+saber --csv-tool-results -d analytics "Show recent orders"
+
+# Interactive session
+saber --csv-tool-results -d analytics
+
+# Resume interactively, opting in for new tool calls
+saber threads resume THREAD_ID --csv-tool-results
+
+# Resume for a single follow-up
+saber --thread THREAD_ID --csv-tool-results "Compare with last month"
+```
+
+JSON remains the default. CSV applies only to tabular results sent to the model
+by `list_tables`, `introspect_schema`, `execute_sql`, and `list_dbs`. Metadata,
+errors, and empty results remain JSON. Displayed terminal tables and complete
+saved JSON results do not change, and SQL previews retain their 12 KiB limit.
+
+This is a session option, not a persisted preference. Interactive thread switches
+keep the current session's choice; a new CLI invocation defaults to JSON unless
+the flag is supplied again. Existing thread messages are not converted. There is
+no in-session toggle; launch with the desired flag.
+
+CSV often reduces token usage for multi-row data, but small results may be larger.
+The effect on model answer quality is not yet established, so this remains opt-in.
+For Python usage, see [SDK configuration](/sdk/configuration#experimental-csv-tool-results).
 
 ---
 

--- a/docs/src/content/docs/sdk/capabilities.mdx
+++ b/docs/src/content/docs/sdk/capabilities.mdx
@@ -49,6 +49,20 @@ agent = Agent("openai:gpt-5.2", capabilities=[sql])
 
 SQLsaber includes a database catalog in the capability instructions. Cross-database joins are not attempted; the model queries each database separately.
 
+### Experimental CSV tool results
+
+JSON is the default. Opt in to CSV tables for model-facing SQL tool results:
+
+```python
+sql = SqlTools(database="analytics", csv_tool_results=True)
+```
+
+The option applies to all SQL tools in this capability, including `list_dbs`.
+Metadata and errors remain JSON; retained query data and terminal rendering do
+not change. Token savings do not establish equivalent answer quality. See
+[CSV tool result behavior](/sdk/configuration#experimental-csv-tool-results)
+for details. Managed sessions use `SQLSaberOptions(csv_tool_results=True)` instead.
+
 ### Allow writes
 
 SQL execution is read-only by default. Enable guarded write operations explicitly:

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -38,12 +38,44 @@ options = SQLSaberOptions(
 | `workspace_input_resolver` | `WorkspaceInputResolver \| None` | `None` | Application-owned resolver for opaque, authorized inputs to the managed notebook analyst. |
 | `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)).                            |
 | `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL (see [Advanced](/sdk/advanced)).       |
+| `csv_tool_results` | `bool` | `False` | Opt in to experimental CSV tables in model-facing SQL tool results. JSON remains the default. |
 
 <Aside type="note">
   `model_name`, `thinking_*`, `system_prompt`, and the injectable components all
   have sensible defaults. For many use cases just `database` (plus credentials in
   your environment) is enough.
 </Aside>
+
+## Experimental CSV tool results
+
+SQL tool results use JSON by default. Opt in per session:
+
+```python
+from sqlsaber import SQLSaber, SQLSaberOptions
+
+saber = SQLSaber(options=SQLSaberOptions(
+    database="analytics.db",
+    csv_tool_results=True,
+))
+```
+
+This changes the tabular portions of `list_tables`, `introspect_schema`,
+`execute_sql`, and multi-database `list_dbs` results sent to the model. Metadata,
+schema constraints, errors, and empty results remain JSON. CSV cells use standard
+quoting, `\N` for null, and escaped backslashes; nested cell values use JSON.
+Complete retained query results remain typed JSON. Terminal tables, plugin access,
+and the 12 KiB SQL preview limit are unchanged. Structured rendering data is kept
+in message metadata, not sent to the model as a second copy of the result.
+
+CSV can reduce tokens for multi-row results, but tiny results can be larger and
+its effect on answer quality has not been established. Evaluate it with your
+models and queries before enabling it broadly.
+
+The setting is available as `saber.info.csv_tool_results`. It is not a saved
+global preference or restored from thread history: pass it again in
+`SQLSaber.resume(..., options=SQLSaberOptions(csv_tool_results=True))` to opt in
+for new calls. Existing messages are not rewritten. For a standalone capability,
+use [`SqlTools(csv_tool_results=True)`](/sdk/capabilities#experimental-csv-tool-results).
 
 ## Artifact storage
 

--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -58,6 +58,7 @@ class SQLSaberAgent:
         model_name: str | None = None,
         api_key: str | None = None,
         allow_dangerous: bool = False,
+        csv_tool_results: bool = False,
         system_prompt: str | None = None,
         tool_overides: ToolOveridesInput | None = None,
         extra_capabilities: Sequence[AbstractCapability[Any]] = (),
@@ -89,6 +90,7 @@ class SQLSaberAgent:
         self._api_key_override = api_key
         self.db_type = self.db_connection.display_name
         self.allow_dangerous = allow_dangerous
+        self.csv_tool_results = csv_tool_results
         self._tool_overides = normalize_tool_overides(tool_overides)
         self._extra_capabilities = tuple(extra_capabilities)
         self._artifact_store = artifact_store
@@ -149,6 +151,7 @@ class SQLSaberAgent:
             SqlTools(
                 registry=self.registry,
                 allow_dangerous=self.allow_dangerous,
+                csv_tool_results=self.csv_tool_results,
                 include_catalog_instructions=include_guidance,
                 query_result_store=self.query_result_store,
             ),

--- a/src/sqlsaber/capabilities/sql_tools.py
+++ b/src/sqlsaber/capabilities/sql_tools.py
@@ -21,6 +21,7 @@ from sqlsaber.prompts.dangerous_mode import DANGEROUS_MODE
 from sqlsaber.prompts.sql_guidance import SQL_GUIDANCE, SQL_GUIDANCE_MULTI
 from sqlsaber.query_results import InMemoryQueryResultStore, QueryResultStore
 from sqlsaber.tools.base import Tool
+from sqlsaber.tools.model_output import model_output_wrapper
 from sqlsaber.tools.sql_tools import (
     ExecuteSQLTool,
     IntrospectSchemaTool,
@@ -91,6 +92,7 @@ class SqlTools(SqlSaberCapability):
         *,
         registry: DatabaseRegistry | None = None,
         allow_dangerous: bool = False,
+        csv_tool_results: bool = False,
         include_catalog_instructions: bool = True,
         query_result_store: QueryResultStore | None = None,
     ) -> None:
@@ -115,6 +117,7 @@ class SqlTools(SqlSaberCapability):
             else InMemoryQueryResultStore()
         )
         self.allow_dangerous = allow_dangerous
+        self.csv_tool_results = csv_tool_results
         self.include_catalog_instructions = include_catalog_instructions
         self._owned = owned
         self._toolset = _SqlToolset(registry, owned=owned)
@@ -122,7 +125,10 @@ class SqlTools(SqlSaberCapability):
         tools: list[Tool] = [
             ListTablesTool(),
             IntrospectSchemaTool(),
-            ExecuteSQLTool(query_result_store=self.query_result_store),
+            ExecuteSQLTool(
+                query_result_store=self.query_result_store,
+                csv_tool_results=csv_tool_results,
+            ),
         ]
         if len(registry) > 1:
             tools.append(ListDatabasesTool())
@@ -157,6 +163,8 @@ class SqlTools(SqlSaberCapability):
                 function = wrap_add_db_name(tool, names)
             else:
                 function = wrap_strip_db_name(tool)
+            if self.csv_tool_results:
+                function = model_output_wrapper(function, tool.name)
             self._toolset.add_function(
                 function,
                 name=tool.name,

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -67,6 +67,7 @@ async def _create_cli_saber(
     system_prompt: str | None,
     thread: str | None,
     log,
+    csv_tool_results: bool = False,
 ):
     """Construct SQLSaber and persistence handles for a CLI session."""
     from sqlsaber.cli.artifacts import cli_artifact_store
@@ -91,6 +92,7 @@ async def _create_cli_saber(
         database=selected_database,
         thinking_enabled=thinking,
         allow_dangerous=allow_dangerous,
+        csv_tool_results=csv_tool_results,
         system_prompt=system_prompt,
         thread_manager=(ThreadManager(storage=storage) if thread is None else None),
         artifact_store=artifact_store,
@@ -147,6 +149,8 @@ app = cyclopts.App(
     help_epilogue=(
         "Examples:\n\n"
         'saber "show me all users"\n\n'
+        'saber --csv-tool-results "show me all users"\n\n'
+        "saber --csv-tool-results  # Interactive session\n\n"
         'echo "top customers by revenue" | saber\n\n'
         'saber -d sales -d analytics "compare revenue to sessions"\n\n'
         'saber -d users.csv -d orders.csv "join users and orders"\n\n'
@@ -246,6 +250,13 @@ def query(
             help=DANGEROUS_MODE_HELP,
         ),
     ] = False,
+    csv_tool_results: Annotated[
+        bool,
+        cyclopts.Parameter(
+            ["--csv-tool-results"],
+            help="Opt in to experimental CSV tool results for the model (default: JSON; also applies to interactive mode)",
+        ),
+    ] = False,
     system_prompt: Annotated[
         str | None,
         cyclopts.Parameter(
@@ -271,6 +282,7 @@ def query(
 
     Examples:
         saber                             # Start interactive mode
+        saber --csv-tool-results          # Opt in to CSV tool results interactively
         saber "show me all users"         # Run a single query
         saber -d sales -d analytics "compare revenue"  # Multiple saved connections
         saber -d data.csv "show users"    # Run a query with ad-hoc CSV file
@@ -345,6 +357,7 @@ def query(
                     selected_database=selected_database,
                     thinking=thinking,
                     allow_dangerous=allow_dangerous,
+                    csv_tool_results=csv_tool_results,
                     system_prompt=system_prompt,
                     thread=thread,
                     log=log,
@@ -419,6 +432,7 @@ def query(
                     selected_database=selected_database,
                     thinking=thinking,
                     allow_dangerous=allow_dangerous,
+                    csv_tool_results=csv_tool_results,
                     system_prompt=system_prompt,
                     thread=thread,
                     log=log,

--- a/src/sqlsaber/cli/html_export.py
+++ b/src/sqlsaber/cli/html_export.py
@@ -56,6 +56,7 @@ def _render_tool_result_html(
     args: dict | None = None,
     *,
     replay_messages: list[ModelMessage] | None = None,
+    metadata: object = None,
 ) -> str:
     content_payload = content
     if isinstance(content, (dict, list)):
@@ -66,12 +67,22 @@ def _render_tool_result_html(
     from sqlsaber.render.html import html_of
     from sqlsaber.tools.renderer import ToolRenderContext
 
+    # Artifact publications have their own linked HTML below. Forward only the
+    # structured SQL result needed to render model-facing CSV without duplicating
+    # those publications through ToolRenderer's generic artifact blocks.
+    render_metadata = (
+        {"sqlsaber_structured_result": metadata.get("sqlsaber_structured_result")}
+        if isinstance(metadata, dict)
+        else None
+    )
     html = html_of(
         tuple(
             renderer.result(
                 tool_name,
                 content_payload,
-                context=ToolRenderContext(replay_messages=replay_messages),
+                context=ToolRenderContext(
+                    replay_messages=replay_messages, metadata=render_metadata
+                ),
             )
         )
     )
@@ -686,6 +697,7 @@ def render_thread_html(
                         content_str,
                         args=tool_args,
                         replay_messages=all_msgs,
+                        metadata=getattr(part, "metadata", None),
                     )
                     result_html += _render_artifact_links(
                         getattr(part, "metadata", None)

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -327,6 +327,7 @@ class InteractiveSession:
         prepared = await prepare_thread_resume(
             request.thread_id,
             list(request.databases) or None,
+            csv_tool_results=self.saber.info.csv_tool_results,
         )
         prepared_saber = prepared.saber
         previous = self.saber

--- a/src/sqlsaber/cli/threads.py
+++ b/src/sqlsaber/cli/threads.py
@@ -434,6 +434,7 @@ async def prepare_thread_resume(
     storage: ThreadStorage | None = None,
     artifact_store: ArtifactStore | None = None,
     query_result_store: QueryResultStore | None = None,
+    csv_tool_results: bool = False,
 ) -> PreparedThreadResume:
     from sqlsaber import (
         SQLSaber,
@@ -463,6 +464,7 @@ async def prepare_thread_resume(
                 database=database,
                 artifact_store=artifacts,
                 query_result_store=query_results,
+                csv_tool_results=csv_tool_results,
             ),
             storage=store,
         )
@@ -568,7 +570,8 @@ def render_prepared_thread(surface: Surface, prepared: PreparedThreadResume) -> 
     help_epilogue=(
         "Examples:\n\n"
         "saber threads resume THREAD_ID\n\n"
-        "saber threads resume THREAD_ID --database analytics"
+        "saber threads resume THREAD_ID --database analytics\n\n"
+        "saber threads resume THREAD_ID --csv-tool-results"
     )
 )
 def resume(
@@ -585,6 +588,13 @@ def resume(
             ),
         ),
     ] = None,
+    csv_tool_results: Annotated[
+        bool,
+        cyclopts.Parameter(
+            ["--csv-tool-results"],
+            help="Opt in to experimental CSV tool results for new model calls (default: JSON)",
+        ),
+    ] = False,
 ):
     """Render transcript, then resume thread in interactive mode.
 
@@ -612,6 +622,7 @@ def resume(
                 storage=store,
                 artifact_store=artifact_store,
                 query_result_store=query_result_store,
+                csv_tool_results=csv_tool_results,
             )
         except ThreadResumePreparationError as exc:
             fail(str(exc))

--- a/src/sqlsaber/query_results.py
+++ b/src/sqlsaber/query_results.py
@@ -617,12 +617,18 @@ class FilesystemQueryResultStore:
             os.close(fd)
 
 
-def _projection_json(value: Mapping[str, Any]) -> bytes:
-    return json_dumps(
+def _projection_size(value: Mapping[str, Any], csv_tool_results: bool) -> int:
+    json_bytes = json_dumps(
         value,
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
+    if not csv_tool_results:
+        return len(json_bytes)
+    from sqlsaber.tools.model_output import format_sql_output
+
+    csv_bytes = format_sql_output("execute_sql", value).encode("utf-8")
+    return max(len(json_bytes), len(csv_bytes))
 
 
 def build_model_projection(
@@ -630,8 +636,9 @@ def build_model_projection(
     descriptor: StoredQueryResult,
     *,
     max_bytes: int = MAX_MODEL_QUERY_RESULT_BYTES,
+    csv_tool_results: bool = False,
 ) -> dict[str, Any]:
-    """Build a stable, valid JSON projection within a hard UTF-8 byte budget."""
+    """Bound both structured and model-facing projections by UTF-8 bytes."""
 
     if max_bytes < 256:
         raise ValueError("max_bytes must be at least 256")
@@ -648,7 +655,7 @@ def build_model_projection(
         base["auto_limit_applied"] = True
 
     complete = {**base, "results": rows, "results_truncated": False}
-    if len(_projection_json(complete)) <= max_bytes:
+    if _projection_size(complete, csv_tool_results) <= max_bytes:
         return complete
 
     warning = (
@@ -661,15 +668,15 @@ def build_model_projection(
         "results_truncated": True,
         "warning": warning,
     }
-    if len(_projection_json(projected)) > max_bytes:
+    if _projection_size(projected, csv_tool_results) > max_bytes:
         projected["columns"] = []
         projected["columns_truncated"] = True
-    if len(_projection_json(projected)) > max_bytes:
+    if _projection_size(projected, csv_tool_results) > max_bytes:
         projected.pop("warning", None)
         projected["warning"] = (
             "Preview omitted; use the result handle for complete data."
         )
-    if len(_projection_json(projected)) > max_bytes:
+    if _projection_size(projected, csv_tool_results) > max_bytes:
         minimal: dict[str, Any] = {
             "success": True,
             "result_id": descriptor.id,
@@ -680,21 +687,23 @@ def build_model_projection(
             "preview_rows": [],
             "results_truncated": True,
         }
-        if len(_projection_json(minimal)) > max_bytes:
+        if _projection_size(minimal, csv_tool_results) > max_bytes:
             raise ValueError("max_bytes is too small for a query result descriptor")
         projected = minimal
 
     preview: list[Any] = []
     for row in rows:
         candidate = {**projected, "preview_rows": [*preview, row]}
-        if len(_projection_json(candidate)) > max_bytes:
+        if _projection_size(candidate, csv_tool_results) > max_bytes:
             break
         preview.append(row)
     projected["preview_rows"] = preview
     if not preview and rows:
         projected["preview_row_omitted"] = True
-        if len(_projection_json(projected)) > max_bytes:
+        if _projection_size(projected, csv_tool_results) > max_bytes:
             projected.pop("preview_row_omitted")
-    if len(_projection_json(projected)) > max_bytes:  # defensive hard bound
+    if (
+        _projection_size(projected, csv_tool_results) > max_bytes
+    ):  # defensive hard bound
         raise ValueError("Unable to build a bounded query result projection")
     return projected

--- a/src/sqlsaber/sdk/_runtime.py
+++ b/src/sqlsaber/sdk/_runtime.py
@@ -90,6 +90,7 @@ class _SQLSaberRuntime:
             model_name=options.model_name,
             api_key=options.api_key,
             allow_dangerous=options.allow_dangerous,
+            csv_tool_results=options.csv_tool_results,
             system_prompt=system_prompt_text,
             tool_overides=options.tool_overrides,
             extra_capabilities=options.extra_capabilities,

--- a/src/sqlsaber/sdk/client.py
+++ b/src/sqlsaber/sdk/client.py
@@ -269,6 +269,7 @@ class SQLSaber:
             dangerous_mode=agent.allow_dangerous,
             thread_id=str(thread_id) if thread_id is not None else None,
             is_new_thread=self._is_new_thread,
+            csv_tool_results=self._runtime.options.csv_tool_results,
         )
 
     @property

--- a/src/sqlsaber/sdk/options.py
+++ b/src/sqlsaber/sdk/options.py
@@ -50,3 +50,4 @@ class SQLSaberOptions:
     # Tool overrides
     tool_overrides: ToolOveridesInput | None = None
     allow_dangerous: bool = False
+    csv_tool_results: bool = False

--- a/src/sqlsaber/sdk/types.py
+++ b/src/sqlsaber/sdk/types.py
@@ -30,6 +30,7 @@ class SQLSaberInfo:
     dangerous_mode: bool
     thread_id: str | None
     is_new_thread: bool
+    csv_tool_results: bool = False
 
     @property
     def databases(self) -> tuple[str, ...]:

--- a/src/sqlsaber/tools/model_output.py
+++ b/src/sqlsaber/tools/model_output.py
@@ -1,0 +1,92 @@
+"""Compact model-facing SQL output; structured results remain available to clients."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections.abc import Awaitable, Callable, Mapping
+from functools import wraps
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pydantic_ai import ToolReturn
+
+from sqlsaber.utils.json_utils import json_dumps
+
+
+def _json(value: object) -> str:
+    return json_dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _csv(label: str, rows: list[dict[str, Any]]) -> str:
+    columns = list(dict.fromkeys(key for row in rows for key in row))
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\r\n")
+    writer.writerow(columns)
+    for row in rows:
+        cells = []
+        for column in columns:
+            value = row.get(column)
+            if value is None:
+                cells.append("\\N")
+            else:
+                text = value if isinstance(value, str) else _json(value)
+                cells.append(text.replace("\\", "\\\\"))
+        writer.writerow(cells)
+    return f"{label} (CSV; null=\\N; backslashes escaped):\n{output.getvalue()}"
+
+
+def format_sql_output(name: str, payload: Mapping[str, Any]) -> str:
+    """Use CSV for rows, JSON for metadata and nested cell values.
+
+    CSV is a model presentation, not a replacement for typed JSON storage.
+    Normalize database-specific values with the same encoder as retained results.
+    """
+    data = json.loads(_json(payload))
+    if "error" in data:
+        return _json(data)
+    if name == "introspect_schema":
+        sections = []
+        for name, info in data.items():
+            columns = info.pop("columns", {})
+            sections.append(_json({"table": name, **info}))
+            sections.append(
+                _csv(
+                    "columns",
+                    [{"name": key, **value} for key, value in columns.items()],
+                )
+            )
+        return "\n".join(sections) if sections else "{}"
+    for key in ("tables", "databases", "results", "preview_rows"):
+        if key in data:
+            if not data[key]:
+                return _json(data)
+            rows = data.pop(key)
+            rows = [row if isinstance(row, dict) else {"value": row} for row in rows]
+            return _json(data) + "\n" + _csv(key, rows)
+    return _json(data)
+
+
+def model_output_wrapper(
+    function: Callable[..., Awaitable[Any]], name: str
+) -> Callable[..., Awaitable[ToolReturn]]:
+    """Convert only the agent boundary, preserving signatures and UI metadata."""
+
+    from pydantic_ai import ToolReturn
+
+    @wraps(function)
+    async def wrapped(*args: Any, **kwargs: Any) -> ToolReturn:
+        result = await function(*args, **kwargs)
+        returned = result if isinstance(result, ToolReturn) else ToolReturn(result)
+        payload = json.loads(cast(str, returned.return_value))
+        return ToolReturn(
+            return_value=format_sql_output(name, payload),
+            content=returned.content,
+            metadata={
+                **(returned.metadata or {}),
+                "sqlsaber_structured_result": payload,
+            },
+        )
+
+    return wrapped

--- a/src/sqlsaber/tools/renderer.py
+++ b/src/sqlsaber/tools/renderer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -97,6 +98,13 @@ class ToolRenderer:
             Blocks from the tool override, the display spec, or a JSON fallback.
         """
         ctx = context or ToolRenderContext()
+        if isinstance(result, str) and isinstance(ctx.metadata, dict):
+            structured = ctx.metadata.get("sqlsaber_structured_result")
+            if isinstance(structured, dict):
+                try:
+                    json.loads(result)
+                except json.JSONDecodeError:
+                    result = structured
         tool = self._registry.get(tool_name)
         if tool is not None:
             setter = getattr(tool, "set_replay_messages", None)

--- a/src/sqlsaber/tools/sql_tools.py
+++ b/src/sqlsaber/tools/sql_tools.py
@@ -334,9 +334,11 @@ class ExecuteSQLTool(SQLTool):
         schema_manager: SchemaManager | None = None,
         *,
         query_result_store: QueryResultStore | None = None,
+        csv_tool_results: bool = False,
     ) -> None:
         super().__init__(db_connection, schema_manager)
         self.query_result_store = query_result_store
+        self.csv_tool_results = csv_tool_results
 
     display_spec = ToolDisplaySpec(
         metadata=DisplayMetadata(display_name="Execute SQL"),
@@ -531,7 +533,11 @@ class ExecuteSQLTool(SQLTool):
                         metadata=getattr(ctx, "metadata", None) or {},
                     ),
                 )
-                projection = build_model_projection(canonical_payload, descriptor)
+                projection = build_model_projection(
+                    canonical_payload,
+                    descriptor,
+                    csv_tool_results=self.csv_tool_results,
+                )
             except Exception:
                 return json_dumps(
                     {

--- a/tests/test_api/test_options.py
+++ b/tests/test_api/test_options.py
@@ -32,6 +32,32 @@ def test_capabilities_are_exported_from_top_level() -> None:
     assert WorkspaceResolutionContext.__name__ == "WorkspaceResolutionContext"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("csv_tool_results", [None, False, True])
+async def test_csv_tool_results_is_opt_in_and_survives_agent_rebuild(csv_tool_results):
+    options = SQLSaberOptions(
+        database="sqlite:///:memory:",
+        settings=Config.in_memory(
+            model_name="anthropic:claude-3-5-sonnet",
+            api_keys={"anthropic": "test-key"},
+        ),
+    )
+    if csv_tool_results is not None:
+        options.csv_tool_results = csv_tool_results
+    expected = csv_tool_results is True
+    saber = SQLSaber(options=options)
+    try:
+        assert saber.info.csv_tool_results is expected
+        for rebuild in (False, True):
+            if rebuild:
+                saber.set_thinking(enabled=True)
+            sql = next(c for c in saber.agent.capabilities if isinstance(c, SqlTools))
+            assert sql.csv_tool_results is expected
+            assert sql.display_specs["execute_sql"].csv_tool_results is expected
+    finally:
+        await saber.close()
+
+
 def test_invalid_artifact_failure_mode_is_rejected() -> None:
     with pytest.raises(ValueError, match="artifact_failure_mode"):
         SQLSaber(

--- a/tests/test_cli/test_artifacts.py
+++ b/tests/test_cli/test_artifacts.py
@@ -83,6 +83,8 @@ def test_html_export_links_artifacts_without_embedding_bytes() -> None:
     assert "report.csv" in html
     assert publication.artifacts[0].uri in html
     assert "secret-data" not in html
+    assert html.count("Artifacts (report)") == 1
+    assert html.count(f'href="{publication.artifacts[0].uri}"') == 1
 
 
 def test_threads_artifacts_lists_retained_publication(

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -18,6 +18,43 @@ class TestCLICommands:
         assert "SQLsaber" in captured.out
         assert "SQL assistant for your database" in captured.out
         assert "--system-prompt" in captured.out
+        assert "--csv-tool-results" in captured.out
+
+    @pytest.mark.parametrize("prefix", [[], ["threads", "resume", "test-thread"]])
+    @pytest.mark.parametrize(
+        "flag,expected",
+        [(None, False), ("--csv-tool-results", True), ("--no-csv-tool-results", False)],
+    )
+    def test_csv_flag_parsing(self, prefix, flag, expected):
+        _, bound, _ = app.parse_args([*prefix, *([flag] if flag else [])])
+        bound.apply_defaults()
+        assert bound.arguments["csv_tool_results"] is expected
+
+    @pytest.mark.parametrize("interactive", [False, True])
+    @pytest.mark.parametrize("csv_tool_results", [False, True])
+    def test_query_passes_csv_choice_to_session(
+        self, monkeypatch, interactive, csv_tool_results
+    ):
+        from unittest.mock import AsyncMock, MagicMock
+        from sqlsaber.cli import commands
+        from sqlsaber.cli.interactive import InteractiveSession
+
+        class SessionReached(Exception):
+            pass
+
+        create = AsyncMock(side_effect=SessionReached)
+        monkeypatch.setattr(commands, "_create_cli_saber", create)
+        monkeypatch.setattr(commands, "needs_onboarding", lambda _: False)
+        monkeypatch.setattr(commands, "schedule_update_check", lambda: None)
+        monkeypatch.setattr(commands, "_ensure_logging", MagicMock())
+        monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(InteractiveSession, "start_unbound_shell", MagicMock())
+        with pytest.raises(SessionReached):
+            commands.query(
+                None if interactive else "Show tables",
+                csv_tool_results=csv_tool_results,
+            )
+        assert create.await_args.kwargs["csv_tool_results"] is csv_tool_results
 
     def test_query_specific_database_not_found(self, capsys, temp_dir, monkeypatch):
         """Test query with non-existent database name."""

--- a/tests/test_cli/test_slash_management.py
+++ b/tests/test_cli/test_slash_management.py
@@ -314,9 +314,14 @@ async def test_resume_of_active_thread_does_not_prepare_duplicate() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
+@pytest.mark.parametrize("csv_tool_results", [False, True])
+async def test_resume_swaps_after_preparation_and_refreshes_session(
+    csv_tool_results,
+) -> None:
     old = MagicMock()
-    old.info = SimpleNamespace(thread_id="thread-old")
+    old.info = SimpleNamespace(
+        thread_id="thread-old", csv_tool_results=csv_tool_results
+    )
     old.end_thread = AsyncMock(return_value="thread-old")
     old.close = AsyncMock()
     new = MagicMock()
@@ -347,11 +352,14 @@ async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
         patch(
             "sqlsaber.cli.threads.prepare_thread_resume",
             AsyncMock(return_value=_prepared(new)),
-        ),
+        ) as prepare,
         patch("sqlsaber.cli.threads.render_prepared_thread") as render,
     ):
         await session._resume_thread(app, surface, ThreadResumeRequest("thread-new"))
 
+    prepare.assert_awaited_once_with(
+        "thread-new", None, csv_tool_results=csv_tool_results
+    )
     old.end_thread.assert_awaited_once_with()
     old.close.assert_awaited_once_with()
     assert session.saber is new
@@ -366,7 +374,7 @@ async def test_resume_swaps_after_preparation_and_refreshes_session() -> None:
 @pytest.mark.asyncio
 async def test_resume_keeps_new_session_when_old_cleanup_fails() -> None:
     old = MagicMock()
-    old.info = SimpleNamespace(thread_id="thread-old")
+    old.info = SimpleNamespace(thread_id="thread-old", csv_tool_results=False)
     old.end_thread = AsyncMock(return_value="thread-old")
     old.close = AsyncMock(side_effect=RuntimeError("cleanup broke"))
     new = MagicMock()
@@ -411,7 +419,7 @@ async def test_resume_keeps_new_session_when_old_cleanup_fails() -> None:
 @pytest.mark.asyncio
 async def test_resume_preparation_failure_keeps_old_session() -> None:
     old = MagicMock()
-    old.info = SimpleNamespace(thread_id="thread-old")
+    old.info = SimpleNamespace(thread_id="thread-old", csv_tool_results=False)
     old.end_thread = AsyncMock()
     old.close = AsyncMock()
     session = InteractiveSession.__new__(InteractiveSession)

--- a/tests/test_cli/test_threads.py
+++ b/tests/test_cli/test_threads.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -24,6 +25,7 @@ from sqlsaber.cli.threads import (
 from sqlsaber.config.database import DatabaseConfigManager
 from sqlsaber.render.markdown_text import md_of
 from sqlsaber.threads.storage import Thread, ThreadStorage
+from sqlsaber.tools.model_output import format_sql_output
 
 
 class TestThreadsCLI:
@@ -328,7 +330,10 @@ class TestThreadsCLI:
 
         await mock_resume_run()
 
-    def test_resume_uses_public_sdk_and_passes_saber_to_tui(self, sample_messages):
+    @pytest.mark.parametrize("csv_tool_results", [False, True])
+    def test_resume_uses_public_sdk_and_passes_saber_to_tui(
+        self, sample_messages, csv_tool_results
+    ):
         from sqlsaber.cli.threads import resume
 
         store = MagicMock()
@@ -381,11 +386,12 @@ class TestThreadsCLI:
             patch("sqlsaber.cli.retention.run_cli_retention", retention),
             patch("sqlsaber.cli.threads._render_transcript"),
         ):
-            resume("thread-multi")
+            resume("thread-multi", csv_tool_results=csv_tool_results)
 
         thread_id, options, storage = captured["resume"]
         assert thread_id == "thread-multi"
         assert options.database is None
+        assert options.csv_tool_results is csv_tool_results
         assert storage is store
         assert captured["interactive_saber"] is captured["saber"]
         assert captured["ran"] is True
@@ -472,6 +478,109 @@ class TestThreadsCLI:
         assert "User" in html
         assert "Assistant" in html
         assert "Show me all tables" in html
+
+    @pytest.mark.parametrize(
+        "tool_name,payload",
+        [
+            (
+                "introspect_schema",
+                {
+                    "main.users": {
+                        "columns": {
+                            "id": {
+                                "type": "INTEGER",
+                                "nullable": False,
+                                "default": None,
+                            }
+                        },
+                        "primary_keys": ["id"],
+                        "foreign_keys": [],
+                        "indexes": [],
+                    }
+                },
+            ),
+            (
+                "list_tables",
+                {
+                    "tables": [{"schema": "main", "name": "users", "type": "TABLE"}],
+                    "total_tables": 1,
+                },
+            ),
+            (
+                "list_dbs",
+                {
+                    "databases": [
+                        {
+                            "name": "analytics",
+                            "dialect": "sqlite",
+                            "description": "Reports",
+                        }
+                    ],
+                    "total_databases": 1,
+                },
+            ),
+            ("execute_sql", {"success": True, "results": [{"id": 1, "name": "Ada"}]}),
+        ],
+    )
+    def test_html_csv_results_match_json(self, sample_threads, tool_name, payload):
+        def messages(content, metadata=None):
+            return [
+                ModelRequest(parts=[UserPromptPart("Inspect users")]),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name=tool_name,
+                            tool_call_id="csv-call",
+                            content=content,
+                            metadata=metadata,
+                        )
+                    ]
+                ),
+            ]
+
+        expected = render_thread_html(sample_threads[0], messages(json.dumps(payload)))
+        actual = render_thread_html(
+            sample_threads[0],
+            messages(
+                format_sql_output(tool_name, payload),
+                {"sqlsaber_structured_result": payload},
+            ),
+        )
+        assert "<table" in expected
+        assert actual == expected
+
+    @pytest.mark.parametrize("hydrated", [False, True])
+    def test_html_csv_preview_and_hydrated_result(self, sample_threads, hydrated):
+        preview = {
+            "success": True,
+            "preview_rows": [{"name": "Ada"}],
+            "results_truncated": True,
+        }
+        complete = {"success": True, "results": [{"name": "Ada"}, {"name": "Grace"}]}
+        messages = [
+            ModelRequest(parts=[UserPromptPart("List users")]),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="execute_sql",
+                        tool_call_id="csv-call",
+                        content=format_sql_output("execute_sql", preview),
+                        metadata={"sqlsaber_structured_result": preview},
+                    )
+                ]
+            ),
+        ]
+        kwargs = (
+            {"hydrated_results": {"csv-call": json.dumps(complete)}}
+            if hydrated
+            else {"unavailable_results": {"csv-call"}}
+        )
+        actual = render_thread_html(sample_threads[0], messages, **kwargs)
+        messages[1].parts[0].content = json.dumps(preview)
+        expected = render_thread_html(sample_threads[0], messages, **kwargs)
+        assert actual == expected
+        assert ("Complete query result unavailable" in actual) is not hydrated
+        assert ("Grace" in actual) is hydrated
 
     def test_render_thread_html_empty_messages(self, sample_threads):
         """Test render_thread_html with empty messages."""

--- a/tests/test_tools/test_model_output.py
+++ b/tests/test_tools/test_model_output.py
@@ -1,0 +1,185 @@
+"""Model CSV presentation stays separate from structured storage and rendering."""
+
+import csv
+import datetime
+import io
+import json
+from decimal import Decimal
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import FunctionModel
+
+from sqlsaber.capabilities import SqlTools
+from sqlsaber.database.registry import DatabaseEntry, DatabaseRegistry
+from sqlsaber.database.sqlite import SQLiteConnection
+from sqlsaber.query_result_resolution import query_result_references_from_messages
+from sqlsaber.query_results import (
+    QueryResultContext,
+    build_model_projection,
+    descriptor_for_data,
+)
+from sqlsaber.tools.model_output import format_sql_output
+from sqlsaber.tools.renderer import ToolRenderContext, ToolRenderer
+
+
+def test_csv_cells_and_database_types() -> None:
+    payload = {
+        "results": [
+            {"value": None},
+            {"value": ""},
+            {"value": r"\N"},
+            {"value": 'a,b"c\r\nd\re'},
+            {"value": "東京"},
+            {"value": Decimal("12.5")},
+            {"value": datetime.date(2026, 9, 6)},
+            {"value": b"abc"},
+            {"value": {"nested": [True, None]}},
+            {"other": 42},
+        ]
+    }
+    output = format_sql_output("execute_sql", payload)
+    rows = list(csv.reader(io.StringIO(output.split("\n", 2)[2], newline="")))
+    assert rows[0] == ["value", "other"]
+    assert [row[0] for row in rows[1:]] == [
+        r"\N",
+        "",
+        r"\\N",
+        'a,b"c\r\nd\re',
+        "東京",
+        "12.5",
+        "2026-09-06",
+        "YWJj",
+        '{"nested":[true,null]}',
+        r"\N",
+    ]
+    assert rows[-1][1] == "42"
+
+
+def test_schema_keeps_constraints_comments_and_input() -> None:
+    payload = {
+        "main.users": {
+            "comment": "Users, including archived",
+            "columns": {"id": {"type": "INTEGER", "nullable": False, "default": None}},
+            "primary_keys": ["id"],
+            "foreign_keys": ["id -> accounts.id"],
+            "indexes": ["users_pk (id) UNIQUE"],
+        }
+    }
+    before = json.dumps(payload)
+    output = format_sql_output("introspect_schema", payload)
+    metadata = json.loads(output.splitlines()[0])
+    assert metadata == {
+        "table": "main.users",
+        **{k: v for k, v in payload["main.users"].items() if k != "columns"},
+    }
+    assert "name,type,nullable,default\r\nid,INTEGER,false,\\N" in output
+    assert json.dumps(payload) == before
+
+
+@pytest.mark.parametrize(
+    "payload", [{"error": "bad query"}, {"success": True}, {}, {"results": []}]
+)
+def test_non_tabular_output_stays_json(payload) -> None:
+    assert json.loads(format_sql_output("execute_sql", payload)) == payload
+
+
+def test_csv_preview_obeys_byte_budget() -> None:
+    payload = {"results": [{'"' * 80: "東京," * 100}] * 20}
+    descriptor = descriptor_for_data(
+        b"{}",
+        result_id="qr_" + "a" * 32,
+        file="result_test.json",
+        row_count=20,
+        columns=('"' * 80,),
+    )
+    projection = build_model_projection(
+        payload, descriptor, max_bytes=1024, csv_tool_results=True
+    )
+    assert projection["results_truncated"] is True
+    assert len(format_sql_output("execute_sql", projection).encode()) <= 1024
+    assert projection["result_id"] == descriptor.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name", ["list_tables", "introspect_schema", "execute_sql", "list_dbs"]
+)
+@pytest.mark.parametrize("csv_tool_results", [None, False, True])
+async def test_agent_output_format_and_replay_preserve_structured_results(
+    name, tmp_path, csv_tool_results
+) -> None:
+    connection = SQLiteConnection(f"sqlite:///{tmp_path / 'test.db'}")
+    registry = DatabaseRegistry(
+        [
+            DatabaseEntry.from_connection(
+                name="test",
+                connection=connection,
+                description=None,
+                excluded_schemas=[],
+            )
+        ]
+    )
+    if name == "list_dbs":
+        registry = DatabaseRegistry(
+            [
+                *registry,
+                DatabaseEntry.from_connection(
+                    name="second",
+                    connection=connection,
+                    description="Another DB",
+                    excluded_schemas=[],
+                ),
+            ]
+        )
+    options = {} if csv_tool_results is None else {"csv_tool_results": csv_tool_results}
+    capability = SqlTools(registry=registry, **options)
+    await connection.execute_query(
+        "CREATE TABLE users (id INTEGER, name TEXT)", commit=True
+    )
+    await connection.execute_query("INSERT INTO users VALUES (1, 'Ada')", commit=True)
+
+    def respond(messages, info):
+        if any(isinstance(p, ToolReturnPart) for m in messages for p in m.parts):
+            return ModelResponse(parts=[TextPart("Done")])
+        args = {"query": "SELECT * FROM users"} if name == "execute_sql" else {}
+        return ModelResponse(parts=[ToolCallPart(name, args, tool_call_id="test_call")])
+
+    model = FunctionModel(respond)
+    try:
+        agent = Agent(model, capabilities=[capability])
+        result = await agent.run("Inspect users")
+        messages = ModelMessagesTypeAdapter.validate_json(
+            ModelMessagesTypeAdapter.dump_json(result.all_messages())
+        )
+        part = next(
+            p for m in messages for p in m.parts if isinstance(p, ToolReturnPart)
+        )
+        if csv_tool_results:
+            assert "CSV;" in part.content
+            assert isinstance(part.metadata, dict)
+            payload = part.metadata["sqlsaber_structured_result"]
+        else:
+            payload = json.loads(part.content)
+            assert "sqlsaber_structured_result" not in (part.metadata or {})
+        renderer = ToolRenderer(capability.display_specs)
+        assert renderer.result(
+            name, part.content, context=ToolRenderContext(metadata=part.metadata)
+        ) == renderer.result(name, payload)
+        if name == "execute_sql":
+            references = query_result_references_from_messages(messages)
+            assert len(references) == 1
+            stored = await capability.query_result_store.get(
+                references[0].descriptor.id,
+                context=QueryResultContext(),
+            )
+            assert stored.rows() == [{"id": 1, "name": "Ada"}]
+    finally:
+        await registry.close()


### PR DESCRIPTION
## Summary
- Keep JSON as the default; opt in with `SQLSaberOptions(csv_tool_results=True)`, standalone `SqlTools(csv_tool_results=True)`, or `--csv-tool-results` for CLI queries, interactive sessions, and thread resume.
- Format tabular SQL tool output as CSV while preserving JSON metadata/errors/empty results, complete typed JSON storage, plugin result handles, and the 12 KiB preview limit.
- Preserve the session choice through agent rebuilds and interactive thread switches, without rewriting historical messages or persisting a global preference.
- Document usage, format boundaries, and the experimental status.
- Fix the HTML export metadata handoff identified during oracle review and reproduced with five failing checks. CSV exports now match JSON rendering without duplicating artifact links.

## Motivation and limitations
Measurements using actual `legislators.db` tool outputs and the `cl100k_base`/`o200k_base` tokenizers showed roughly 35–37% savings for table listings and full schema, and 29–37% for sampled 10–100-row SQL results versus compact JSON. Small results can be larger. Token savings do not establish equivalent answer quality, so CSV remains opt-in. Live-provider answer quality has not been evaluated.

## Verification
- `env -u FORCE_COLOR uv run pytest -q`: **1,547 passed, 6 skipped**.
- `uv run ruff check .`: passed.
- `uvx ty check src/`: passed.
- Documentation `npm run build`: passed.
- CLI root and thread-resume help verified; root help startup: **0.19s**.
- Rendered HTML inspected in Chromium: populated schema/table/database tables, complete hydrated SQL rows, and retained availability warning.

[Implementation and review thread](https://ampcode.com/threads/T-01a0780e-b8c2-77c9-a73e-58c615d2d227)