### PR TITLE
fix: live model settings and display thinking level in footer

### DIFF
--- a/src/sqlsaber/agents/pydantic_ai_agent.py
+++ b/src/sqlsaber/agents/pydantic_ai_agent.py
@@ -218,6 +218,34 @@ class SQLSaberAgent:
             self.thinking_level = level
         self.agent = self._build_agent()
 
+    def reload_model_settings(self) -> None:
+        """Apply saved model settings without replacing conversation resources."""
+        previous = (
+            self._model_name_override,
+            self._api_key_override,
+            self.thinking_enabled,
+            self.thinking_level,
+            self.capabilities,
+            self._tools,
+        )
+        try:
+            self._model_name_override = None
+            self._api_key_override = None
+            self.thinking_enabled = self.config.model.thinking_enabled
+            self.thinking_level = self.config.model.thinking_level
+            agent = self._build_agent()
+        except Exception:
+            (
+                self._model_name_override,
+                self._api_key_override,
+                self.thinking_enabled,
+                self.thinking_level,
+                self.capabilities,
+                self._tools,
+            ) = previous
+            raise
+        self.agent = agent
+
     async def run(
         self,
         prompt: str,

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -249,7 +249,12 @@ class InteractiveSession:
         return f"DB: {db_name} ({info.primary_database_type})"
 
     def _footer_text(self) -> str:
-        parts = [self._database_footer_text(), f"Model: {self._model_name()}"]
+        thinking = self.saber.info.thinking
+        parts = [
+            self._database_footer_text(),
+            f"Model: {self._model_name()}",
+            f"Thinking: {thinking.level.value if thinking.enabled else 'off'}",
+        ]
         if dangerous_mode := self._dangerous_mode_footer_text():
             parts.append(dangerous_mode)
         parts.append(self._usage_footer_text())
@@ -508,6 +513,7 @@ class InteractiveSession:
                 return
 
             if cmd_result.handled:
+                self._refresh_footer()
                 return
 
             await self._execute_query_with_cancellation(user_query)

--- a/src/sqlsaber/cli/slash_commands.py
+++ b/src/sqlsaber/cli/slash_commands.py
@@ -281,11 +281,61 @@ class SlashCommandProcessor:
         def invoke() -> None:
             command(*bound.args, **bound.kwargs)
 
+        model_config = None
+        before = None
+        if spec.path in {("models", "set"), ("models", "reset")}:
+            from sqlsaber.config.settings import ModelConfigManager
+
+            model_config = ModelConfigManager()
+            # A write (even of the same value) is an explicit apply; a cancelled
+            # picker or invalid command must not reset session-only thinking.
+            before = (
+                model_config.config_file.stat().st_mtime_ns
+                if model_config.config_file.exists()
+                else None
+            )
+
+        completed = True
         try:
             with bind_cli_surfaces(context.surface):
                 await asyncio.to_thread(invoke)
         except SystemExit:
-            pass
+            completed = False
+        if model_config is not None:
+            after = (
+                model_config.config_file.stat().st_mtime_ns
+                if model_config.config_file.exists()
+                else None
+            )
+            explicit_model = spec.path == ("models", "set") and bound.arguments.get(
+                "model"
+            )
+            if before != after or (completed and explicit_model):
+                try:
+                    with bind_cli_surfaces(context.surface):
+                        await asyncio.to_thread(context.saber.reload_model_settings)
+                except Exception as exc:
+                    context.surface.emit(
+                        b.error(
+                            f"Settings saved, but could not apply them to this session: {exc}"
+                        ),
+                        b.warn(
+                            "The active model is unchanged. Check authentication and retry, or restart."
+                        ),
+                    )
+        if spec.path in {("theme", "set"), ("theme", "reset")}:
+            context.surface.emit(
+                b.md(
+                    "Theme changes take effect after restarting SQLsaber.", role="muted"
+                )
+            )
+        if spec.path == ("db", "set-default"):
+            context.surface.emit(
+                b.md(
+                    "The default is used by new sessions; this session's active database is unchanged.",
+                    role="muted",
+                )
+            )
         return CommandResult(handled=True)
 
     @staticmethod

--- a/src/sqlsaber/sdk/client.py
+++ b/src/sqlsaber/sdk/client.py
@@ -380,6 +380,11 @@ class SQLSaber:
             level=agent.thinking_level,
         )
 
+    def reload_model_settings(self) -> None:
+        """Apply configured models and thinking to subsequent queries, retaining history."""
+        self._ensure_not_running()
+        self._runtime.agent.reload_model_settings()
+
     async def list_tables(self) -> tuple[TableInfo, ...]:
         """List tables across all managed databases in registry order."""
         self._ensure_open()

--- a/tests/test_api/test_sdk_conversation.py
+++ b/tests/test_api/test_sdk_conversation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import FrozenInstanceError, dataclass
 from typing import Any
+from unittest.mock import MagicMock
 
 import aiosqlite
 import pytest
@@ -19,6 +20,7 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 from sqlsaber import (
     RunInProgressError,
     SQLSaber,
+    SQLSaberClosedError,
     SQLSaberInfo,
     SQLSaberOptions,
     SQLSaberResult,
@@ -48,6 +50,54 @@ def _options(**overrides: Any) -> SQLSaberOptions:
     }
     values.update(overrides)
     return SQLSaberOptions(**values)
+
+
+@pytest.mark.asyncio
+async def test_reload_model_settings_preserves_session_and_rolls_back_failure(
+    monkeypatch,
+):
+    settings = Config.in_memory(
+        model_name="openai:gpt-5",
+        api_keys={"openai": "test-key"},
+    )
+    saber = SQLSaber(options=_options(settings=settings))
+    history = _turn("previous question", "previous answer")
+    saber._message_history = history.copy()
+    registry = saber.registry
+    store = saber.query_result_store
+    try:
+        settings.model.name = "openai:gpt-6-astra"
+        settings.model.set_thinking(False, ThinkingLevel.HIGH)
+        saber.reload_model_settings()
+        assert saber.info.model_name == "gpt-6-astra"
+        assert saber.info.thinking == ThinkingState(
+            enabled=False, level=ThinkingLevel.HIGH
+        )
+        assert saber._message_history == history
+        assert saber.registry is registry
+        assert saber.query_result_store is store
+
+        active_agent = saber.agent.agent
+        settings.model.set_thinking(True, ThinkingLevel.LOW)
+        with monkeypatch.context() as patcher:
+            patcher.setattr(
+                saber.agent, "_build_agent", MagicMock(side_effect=ValueError("no key"))
+            )
+            with pytest.raises(ValueError, match="no key"):
+                saber.reload_model_settings()
+        assert saber.agent.agent is active_agent
+        assert saber.info.thinking == ThinkingState(
+            enabled=False, level=ThinkingLevel.HIGH
+        )
+
+        saber._query_in_progress = True
+        with pytest.raises(RunInProgressError):
+            saber.reload_model_settings()
+        saber._query_in_progress = False
+    finally:
+        await saber.close()
+    with pytest.raises(SQLSaberClosedError):
+        saber.reload_model_settings()
 
 
 def _turn(

--- a/tests/test_cli/test_slash_management.py
+++ b/tests/test_cli/test_slash_management.py
@@ -74,6 +74,54 @@ def _output(context: CommandContext) -> str:
     return "\n\n".join(md_of(call.args) for call in context.surface.emit.call_args_list)
 
 
+@pytest.mark.asyncio
+async def test_model_commands_update_live_session_and_footer(tmp_path, monkeypatch):
+    from sqlsaber import SQLSaber, SQLSaberOptions
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    saber = SQLSaber(options=SQLSaberOptions(database="sqlite:///:memory:"))
+    session = InteractiveSession(saber)
+    app = MagicMock()
+    session.streaming_handler = MagicMock(app=app)
+    surface = MagicMock()
+    surface.ask = AsyncMock(return_value=True)
+    try:
+        for command, expected in [
+            ("/models set openai:gpt-6-astra --thinking-level off", "gpt-6-astra"),
+            ("/models set openai:gpt-6-astra --thinking-level off", "gpt-6-astra"),
+            ("/models reset --yes", "gpt-5.6-sol"),
+        ]:
+            await session._handle_submit(app, surface, command)
+            assert saber.info.model_name == expected
+            assert not saber.info.thinking.enabled
+            assert f"Model: {expected}" in app.set_footer.call_args.args[0]
+            assert "Thinking: off" in app.set_footer.call_args.args[0]
+        await session._handle_submit(app, surface, "/thinking high")
+        assert saber.info.thinking.level == ThinkingLevel.HIGH
+        assert saber.info.thinking.enabled
+        assert "Thinking: high" in app.set_footer.call_args.args[0]
+        with patch.object(saber, "reload_model_settings") as reload:
+            await session._handle_submit(app, surface, "/models set invalid")
+            await session._handle_submit(app, surface, "/models current")
+            reload.assert_not_called()
+        assert saber.info.thinking.enabled
+        with patch.object(
+            saber, "reload_model_settings", side_effect=ValueError("no key")
+        ):
+            await session._handle_submit(app, surface, "/models set openai:gpt-6-astra")
+        assert saber.info.model_name == "gpt-5.6-sol"
+        assert "Model: gpt-5.6-sol" in app.set_footer.call_args.args[0]
+        assert "could not apply" in "\n".join(
+            md_of(call.args) for call in surface.emit.call_args_list
+        )
+        # Retrying the same saved value must attempt live application again.
+        await session._handle_submit(app, surface, "/models set openai:gpt-6-astra")
+        assert saber.info.model_name == "gpt-6-astra"
+    finally:
+        await saber.close()
+
+
 def test_registry_has_exact_management_parity() -> None:
     assert management_paths() == EXPECTED_MANAGEMENT_PATHS
     assert len(management_paths()) == 27
@@ -331,6 +379,7 @@ async def test_resume_swaps_after_preparation_and_refreshes_session(
         primary_database_name="Analytics",
         primary_database_type="SQLite",
         model_name="test-model",
+        thinking=SimpleNamespace(enabled=False, level=ThinkingLevel.MEDIUM),
         dangerous_mode=False,
     )
     new.close = AsyncMock()
@@ -384,6 +433,7 @@ async def test_resume_keeps_new_session_when_old_cleanup_fails() -> None:
         primary_database_name="Analytics",
         primary_database_type="SQLite",
         model_name="test-model",
+        thinking=SimpleNamespace(enabled=False, level=ThinkingLevel.MEDIUM),
         dangerous_mode=False,
     )
     new.display_registry = {}

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -636,6 +636,18 @@ def test_interactive_footer_includes_usage_cost_and_context() -> None:
     assert "Cost: $0.0123" in footer
 
 
+@pytest.mark.parametrize("level", list(ThinkingLevel))
+@pytest.mark.parametrize("enabled", [False, True])
+def test_interactive_footer_shows_thinking(level, enabled) -> None:
+    session = InteractiveSession(_fake_saber())
+    session.saber.info.thinking = SimpleNamespace(enabled=enabled, level=level)
+
+    footer = session._footer_text()
+
+    expected = level.value if enabled else "off"
+    assert f"Model: gpt-test | Thinking: {expected} |" in footer
+
+
 def test_welcome_message_uses_compact_greeting() -> None:
     terminal = FakeTerminal(columns=100, rows=24)
     session = InteractiveSession(_fake_saber())


### PR DESCRIPTION
## Summary
- Apply interactive model selections and resets to the running agent, preserving conversation history and session resources.
- Refresh the footer after slash commands and show the active thinking level (or off) beside the model.
- Preserve the active agent on application failure and explain that database defaults and themes apply to later sessions.

## Verification
- `env -u FORCE_COLOR uv run pytest -q`: 1,559 passed, 6 skipped.
- `uv run ruff check .`, formatting checks, and `uvx ty check src/`: passed.
- Real isolated CLI sessions verified model picker changes, model reset, and thinking transitions medium → off → high → maximum without restarting.
- Terminal captures were replayed and visually inspected for the updated footer and disabled state. Local controls used a placeholder provider key; no authenticated model query was used as proof.

[Implementation and terminal verification screenshots](https://ampcode.com/threads/T-01a07cb2-cf5a-76ed-bd11-df3702ec555d)