### PR TITLE
feat: Add Parquet file support using DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > SQLsaber is an open-source agentic SQL assistant. Think Claude Code but for SQL.
 
-Ask questions about databases, SQLite/DuckDB files, and CSVs in plain English from your terminal or Python code. SQLsaber reads your schema, writes SQL, executes read-only queries by default, and explains the results.
+Ask questions about databases, SQLite/DuckDB files, CSVs, and Parquet files in plain English from your terminal or Python code. SQLsaber reads your schema, writes SQL, executes read-only queries by default, and explains the results.
 
 `SQLSaber` is the canonical conversation lifecycle used by the CLI and TUI. Clients own input and presentation, while `SQLSaber` owns agent behavior, completed history, and thread lifecycle.
 
@@ -57,7 +57,11 @@ saber -d "postgresql://user:pass@localhost:5432/mydb" "count users"
 
 # Query local files
 saber -d ./customers.csv "How many customers are from each state?"
+saber -d ./orders.parquet "What is total revenue?"
 saber -d ./warehouse.duckdb "Show me the latest partition"
+
+# Join CSV and Parquet files using DuckDB
+saber -d ./customers.csv -d ./orders.parquet "Revenue by customer"
 
 # Connect multiple databases in one session
 saber -d sales -d analytics "Compare last month's revenue to web sessions"
@@ -68,7 +72,7 @@ saber -d sales -d analytics "Compare last month's revenue to web sessions"
 - **No context switching** — Stay in your terminal, ask questions, get answers.
 - **Schema-aware** — Automatically discovers tables, columns, indexes, comments, and relationships.
 - **Safe by default** — Runs read-only queries unless you explicitly enable dangerous mode.
-- **Works with your stack** — PostgreSQL, MySQL, SQLite, DuckDB, and CSV files.
+- **Works with your stack** — PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet files.
 - **Remembers your work** — Resume previous analysis with conversation threads.
 - **Learns your business context** — Store KPI definitions, SQL patterns, and domain notes in a searchable knowledge base.
 - **Flexible model support** — Use Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, Hugging Face, and other supported providers.

--- a/docs/src/content/docs/guides/database-setup.mdx
+++ b/docs/src/content/docs/guides/database-setup.mdx
@@ -1,11 +1,11 @@
 ---
 title: Database Setup
-description: "Connect SQLsaber to PostgreSQL, MySQL, SQLite, DuckDB, or CSV files. Configure connection strings, SSL certificates, and schema exclusions."
+description: "Connect SQLsaber to PostgreSQL, MySQL, SQLite, DuckDB, CSV, or Parquet files. Configure connection strings, SSL certificates, and schema exclusions."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber supports PostgreSQL, MySQL, SQLite, DuckDB, and CSV data sources. This guide covers all the ways to configure database connections.
+SQLsaber supports PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet data sources. This guide covers all the ways to configure database connections.
 
 ### Supported Database Types
 
@@ -14,6 +14,7 @@ SQLsaber supports PostgreSQL, MySQL, SQLite, DuckDB, and CSV data sources. This 
 - **SQLite** - Local database files
 - **DuckDB** - Local DuckDB files or in-memory analytics
 - **CSV** - Local CSV files
+- **Parquet** - Local Parquet files, queried using DuckDB
 
 ### Adding Database
 
@@ -88,6 +89,27 @@ saber -d "./customers.csv" "How many customers are from each state?"
   For CSV files, first row should contain column headers. SQLsaber will infer
   data types automatically.
 </Aside>
+
+#### Parquet
+
+Query a local `.parquet` file directly, or use a `parquet:///` URL:
+
+```bash
+saber -d "./orders.parquet" "What is total revenue?"
+saber -d "parquet:///orders.parquet" "Describe the columns"
+saber -d "./customers.csv" -d "./orders.parquet" "Revenue by customer"
+```
+
+DuckDB reads column names and types from the Parquet schema; no CSV delimiter or
+header options are needed. Each file becomes a table named after its filename
+without the extension (for example, `orders`). Repeated CSV/Parquet inputs share
+one database, so SQL joins work across them.
+
+Like CSV inputs, files are materialized into in-memory tables on every query,
+then external file access is disabled for read-only execution. This preserves
+the existing safety boundary, but is not a lazy, large-file Parquet scan: allow
+enough memory for the loaded data. Use explicit local files, not remote URLs or
+partition-directory inputs.
 
 ### Managing Connections
 
@@ -176,7 +198,7 @@ Default exclusions:
 
 - **PostgreSQL:** `pg_catalog`, `information_schema`, `_timescaledb_internal`, `_timescaledb_cache`, `_timescaledb_config`, `_timescaledb_catalog`
 - **MySQL:** `information_schema`, `performance_schema`, `mysql`, `sys`
-- **DuckDB / CSV:** `information_schema`, `pg_catalog`, `duckdb_catalog`
+- **DuckDB / CSV / Parquet:** `information_schema`, `pg_catalog`, `duckdb_catalog`
 
 When you run `saber db add`, the interactive flow prompts for extra schemas to ignore (or pass `--exclude-schemas schema1,schema2` in non-interactive mode). You can revisit an existing connection at any time:
 

--- a/docs/src/content/docs/guides/multi-database.mdx
+++ b/docs/src/content/docs/guides/multi-database.mdx
@@ -47,18 +47,20 @@ DBs: sales, analytics, inventory | Model: ... | ...
   derived from the database/file name for ad-hoc connection strings and paths.
 </Aside>
 
-#### CSV files are different
+#### CSV and Parquet files are different
 
-Passing **multiple CSV files** does not create a multi-database session. Instead,
-all CSVs are merged into a single in-memory database with one table (view) per
+Passing **multiple CSV/Parquet files** does not create a multi-database session. Instead,
+all files are loaded into a single in-memory DuckDB database with one table per
 file, so you can join across them:
 
 ```bash
 saber -d users.csv -d orders.csv "Join users and orders"
+saber -d users.csv -d orders.parquet "Revenue by user"
+saber -d users.parquet -d orders.parquet "Join users and orders"
 ```
 
-Multi-database mode kicks in only when more than one **non-CSV** target is
-provided (or a CSV combined with another database type).
+When repeated targets include another database type or a configured connection,
+each target instead resolves independently into a multi-database session.
 
 ### Describing connections
 

--- a/docs/src/content/docs/guides/queries.mdx
+++ b/docs/src/content/docs/guides/queries.mdx
@@ -245,7 +245,7 @@ saber -d prod-db "What's our revenue this month?"
 
 #### Using Files Directly
 
-Work with SQLite, DuckDB, or CSV files directly:
+Work with SQLite, DuckDB, CSV, or Parquet files directly:
 
 ```bash
 # SQLite file
@@ -256,6 +256,9 @@ saber -d "./data/warehouse.duckdb" "Latest partitions"
 
 # CSV file
 saber -d "./customers.csv" "How many customers per state?"
+
+# Parquet file
+saber -d "./orders.parquet" "What is total revenue?"
 ```
 
 #### Connection Strings

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -34,7 +34,7 @@ saber --thread a1b2c3d4 "Now compare that with last quarter"
 **Parameters:**
 
 - `QUERY-TEXT` - SQL query in natural language (optional, starts interactive mode if not provided)
-- `-d, --database` - Database connection name, file path (CSV/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://). Repeat the flag to connect to [multiple databases](/guides/multi-database) at once (or to merge multiple CSV files into one session).
+- `-d, --database` - Database connection name, file path (CSV/Parquet/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://, csv:///, parquet:///). Repeat the flag to connect to [multiple databases](/guides/multi-database) at once (or to load multiple CSV/Parquet files into one DuckDB session with one table per file).
 - `--thinking` / `--no-thinking` - Enable/disable extended thinking/reasoning mode
 - `--csv-tool-results` / `--no-csv-tool-results` - Opt in to experimental CSV tables in model-facing SQL tool results. Defaults to JSON; applies to both single-shot queries and interactive mode.
 - `--allow-dangerous` - Allow INSERT/UPDATE/DELETE and restricted DDL (CREATE TABLE/VIEW/INDEX, ALTER TABLE). DROP/TRUNCATE and admin/security operations remain blocked; UPDATE/DELETE require WHERE.

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -22,7 +22,7 @@ options = SQLSaberOptions(
 
 | Field               | Type                                          | Default | Description                                                                                  |
 | ------------------- | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, a list of CSV paths, or a list of targets for a [multi-database](/guides/multi-database) session. |
+| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, a list of CSV/Parquet paths, or a list of targets for a [multi-database](/guides/multi-database) session. |
 | `model_name`        | `str \| None`                                 | `None`  | Model in `"provider:model"` form. Falls back to your configured/default model.               |
 | `api_key`           | `str \| None`                                 | `None`  | API key for the model's provider. Usually unnecessary — see [Credentials](/sdk/credentials-and-models). |
 | `thinking_enabled`  | `bool \| None`                                | `None`  | Toggle extended thinking on supported reasoning models.                                      |
@@ -130,25 +130,27 @@ SQLSaberOptions(database="duckdb:///path/to/warehouse.duckdb")
 
 ### File paths
 
-Point directly at a SQLite, DuckDB, or CSV file:
+Point directly at a SQLite, DuckDB, CSV, or Parquet file:
 
 ```python
 SQLSaberOptions(database="./data/sales.db")
 SQLSaberOptions(database="./customers.csv")
+SQLSaberOptions(database="./orders.parquet")
 ```
 
-### Multiple CSV files
+### Multiple CSV or Parquet files
 
-Pass a list (or tuple) of CSV paths to query across them together. All CSVs are
+Pass a list (or tuple) of CSV/Parquet paths to query across them together. All files are
 merged into a single in-memory database with one table per file:
 
 ```python
 SQLSaberOptions(database=["users.csv", "orders.csv"])
+SQLSaberOptions(database=["users.csv", "orders.parquet"])
 ```
 
 ### Multiple databases
 
-Pass a list of non-CSV targets (configured names, connection strings, or file
+Pass a list including other targets (configured names, connection strings, or database file
 paths) to connect to [several databases](/guides/multi-database) in one session.
 The agent queries each one separately and combines the results:
 

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -22,9 +22,9 @@ DANGEROUS_MODE_SCOPE = (
 DANGEROUS_MODE_WARNING = f"The assistant can execute {DANGEROUS_MODE_SCOPE}"
 DANGEROUS_MODE_HELP = f"Allow {DANGEROUS_MODE_SCOPE}"
 DATABASE_OPTION_HELP = (
-    "Database connection name, file path (CSV/SQLite/DuckDB), or connection "
+    "Database connection name, file path (CSV/Parquet/SQLite/DuckDB), or connection "
     "string (postgresql://, mysql://, duckdb://). Repeat -d for multiple saved "
-    "names, files, or DSNs. Repeated CSV files merge into one session. Uses "
+    "names, files, or DSNs. Repeated CSV/Parquet files merge into one session. Uses "
     "the default if omitted"
 )
 

--- a/src/sqlsaber/database/__init__.py
+++ b/src/sqlsaber/database/__init__.py
@@ -31,7 +31,7 @@ def DatabaseConnection(
         conn = SQLiteConnection(connection_string)
     elif connection_string.startswith("duckdb://"):
         conn = DuckDBConnection(connection_string)
-    elif connection_string.startswith("csv:///"):
+    elif connection_string.startswith(("csv:///", "parquet:///")):
         from .csv import CSVConnection
 
         conn = CSVConnection(connection_string)

--- a/src/sqlsaber/database/csv.py
+++ b/src/sqlsaber/database/csv.py
@@ -1,4 +1,4 @@
-"""CSV database connection using DuckDB backend."""
+"""CSV and Parquet file connections using the same DuckDB backend."""
 
 import asyncio
 from pathlib import Path
@@ -18,12 +18,18 @@ __all__ = ["CSVConnection"]
 
 
 class CSVConnection(BaseDatabaseConnection):
-    """CSV file connection using DuckDB per query."""
+    """Local CSV or Parquet connection using DuckDB per query.
+
+    The historical class and attribute names are retained for compatibility.
+    """
 
     def __init__(self, connection_string: str):
         super().__init__(connection_string)
 
-        raw_path = connection_string.replace("csv:///", "", 1)
+        self.file_format = urlparse(connection_string).scheme
+        if self.file_format not in {"csv", "parquet"}:
+            raise ValueError("Expected a csv:/// or parquet:/// connection string")
+        raw_path = connection_string.removeprefix(f"{self.file_format}:///")
         self.csv_path = raw_path.split("?", 1)[0]
 
         self.delimiter = ","
@@ -72,13 +78,20 @@ class CSVConnection(BaseDatabaseConnection):
         return encoding.replace("-", "").replace("_", "").upper()
 
     def _create_table(self, conn: duckdb.DuckDBPyConnection) -> None:
-        """Materialize the CSV into a real table.
+        """Materialize the source file into a real table.
 
-        A materialized table (rather than a view over read_csv_auto) lets the
+        A materialized table (rather than a view over a file reader) lets the
         session lock down external file access afterwards while still serving the
         intended data — a view would re-read the file on every query and break
         under the lockdown.
         """
+        if self.file_format == "parquet":
+            conn.execute(
+                f"CREATE TABLE {self._quote_identifier(self.table_name)} AS "
+                f"SELECT * FROM read_parquet({self._quote_literal(self.csv_path)})"
+            )
+            return
+
         header_literal = "TRUE" if self.has_header else "FALSE"
         option_parts: list[str] = [f"HEADER={header_literal}"]
 

--- a/src/sqlsaber/database/csvs.py
+++ b/src/sqlsaber/database/csvs.py
@@ -1,6 +1,6 @@
-"""Multiple-CSV database connection using DuckDB backend.
+"""Multiple CSV/Parquet database connection using DuckDB backend.
 
-This connection creates one DuckDB view per CSV file for each query.
+This connection materializes one DuckDB table per file for each query.
 """
 
 import asyncio
@@ -20,7 +20,7 @@ from .duckdb import (
 
 
 class CSVsConnection(BaseDatabaseConnection):
-    """Connection that exposes multiple CSV files as DuckDB views."""
+    """Connection that exposes multiple CSV/Parquet files as DuckDB tables."""
 
     def __init__(self, connection_string: str):
         super().__init__(connection_string)

--- a/src/sqlsaber/database/resolver.py
+++ b/src/sqlsaber/database/resolver.py
@@ -21,7 +21,15 @@ class ResolvedDatabase:
     description: str | None = None
 
 
-SUPPORTED_SCHEMES = {"postgresql", "mysql", "sqlite", "duckdb", "csv", "csvs"}
+SUPPORTED_SCHEMES = {
+    "postgresql",
+    "mysql",
+    "sqlite",
+    "duckdb",
+    "csv",
+    "csvs",
+    "parquet",
+}
 
 
 def _is_connection_string(s: str) -> bool:
@@ -46,9 +54,9 @@ def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
     for spec in specs:
         if _is_connection_string(spec):
             scheme = urlparse(spec).scheme
-            if scheme != "csv":
+            if scheme not in {"csv", "parquet"}:
                 raise DatabaseResolutionError(
-                    "Multiple database arguments are only supported for CSV files. "
+                    "Multiple database arguments are only supported for CSV/Parquet files. "
                     f"Got connection string with scheme '{scheme}': {spec}"
                 )
             csv_specs.append(spec)
@@ -56,19 +64,22 @@ def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
             continue
 
         path = Path(spec).expanduser().resolve()
-        if path.suffix.lower() != ".csv":
+        file_format = path.suffix.lower().lstrip(".")
+        if file_format not in {"csv", "parquet"}:
             raise DatabaseResolutionError(
-                "Multiple database arguments are only supported for CSV files. "
-                f"Got non-CSV path: {spec}"
+                "Multiple database arguments are only supported for CSV/Parquet files. "
+                f"Got unsupported file path: {spec}"
             )
         if not path.exists():
-            raise DatabaseResolutionError(f"CSV file '{spec}' not found.")
-        csv_specs.append(f"csv:///{path}")
+            raise DatabaseResolutionError(
+                f"{file_format.upper()} file '{spec}' not found."
+            )
+        csv_specs.append(f"{file_format}:///{path}")
         stems.append(path.stem or "csv")
 
     if not csv_specs:
         raise DatabaseResolutionError(
-            "Multiple database arguments were provided, but no CSV files were found."
+            "Multiple database arguments were provided, but no CSV/Parquet files were found."
         )
 
     query = urlencode({"spec": csv_specs}, doseq=True)
@@ -84,13 +95,13 @@ def _resolve_multiple_csvs(specs: list[str]) -> ResolvedDatabase:
 
 
 def _all_csv_specs(specs: list[str]) -> bool:
-    """Return True iff every spec resolves to a CSV file (path or csv:// URL)."""
+    """Return True iff every spec is a CSV/Parquet file path or URL."""
     for spec in specs:
         if _is_connection_string(spec):
-            if urlparse(spec).scheme != "csv":
+            if urlparse(spec).scheme not in {"csv", "parquet"}:
                 return False
         else:
-            if Path(spec).suffix.lower() != ".csv":
+            if Path(spec).suffix.lower() not in {".csv", ".parquet"}:
                 return False
     return True
 
@@ -103,8 +114,8 @@ def resolve_databases(
 
     - `None`, single string, or single-element list → returns 1 entry (matches
       `resolve_database` semantics).
-    - All-CSV list → returns 1 entry (CSVs merger, today's behavior).
-    - Mixed/non-CSV list with N > 1 → returns N entries, each resolved
+    - All CSV/Parquet list → returns 1 entry with one table per file.
+    - Other lists with N > 1 → returns N entries, each resolved
       independently. Duplicate names raise `DatabaseResolutionError`.
     """
     if spec is None or isinstance(spec, str):
@@ -143,7 +154,7 @@ def resolve_database(
 
     Args:
         spec: User input - None (default), configured name, connection string, file path,
-            or a list of CSV file paths/CSV connection strings.
+            or a list of CSV/Parquet file paths or connection strings.
         config_mgr: Optional database configuration manager for looking up configured
             connections. If omitted, one is created only when needed for configured
             name/default lookup.
@@ -181,7 +192,7 @@ def resolve_database(
         scheme = urlparse(spec).scheme
         if scheme in {"postgresql", "mysql"}:
             db_name = urlparse(spec).path.lstrip("/") or "database"
-        elif scheme in {"sqlite", "duckdb", "csv", "csvs"}:
+        elif scheme in {"sqlite", "duckdb", "csv", "csvs", "parquet"}:
             db_name = Path(urlparse(spec).path).stem or "database"
         else:  # should not happen because of SUPPORTED_SCHEMES
             db_name = "database"
@@ -191,11 +202,16 @@ def resolve_database(
 
     # 2. Raw file path?
     path = Path(spec).expanduser().resolve()
-    if path.suffix.lower() == ".csv":
+    if path.suffix.lower() in {".csv", ".parquet"}:
+        file_format = path.suffix.lower().lstrip(".")
         if not path.exists():
-            raise DatabaseResolutionError(f"CSV file '{spec}' not found.")
+            raise DatabaseResolutionError(
+                f"{file_format.upper()} file '{spec}' not found."
+            )
         return ResolvedDatabase(
-            name=path.stem, connection_string=f"csv:///{path}", excluded_schemas=[]
+            name=path.stem,
+            connection_string=f"{file_format}:///{path}",
+            excluded_schemas=[],
         )
     if path.suffix.lower() in {".db", ".sqlite", ".sqlite3"}:
         if not path.exists():

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -98,5 +98,5 @@ class TestCLICommands:
         text = self._help_text(capsys, ["--help"])
         assert "one/more CSV files via repeated -d" not in text
         assert "multiple saved names" in text
-        assert "CSV files merge" in text
+        assert "CSV/Parquet files merge" in text
         assert "-d sales -d analytics" in text

--- a/tests/test_database/test_parquet_connection.py
+++ b/tests/test_database/test_parquet_connection.py
@@ -1,0 +1,154 @@
+"""Parquet inputs use the CSV DuckDB lifecycle, including its lockdown."""
+
+from datetime import date
+from decimal import Decimal
+
+import duckdb
+import pytest
+
+from sqlsaber.database import DatabaseConnection, QueryTimeoutError, SchemaManager
+from sqlsaber.database.resolver import (
+    DatabaseResolutionError,
+    resolve_database,
+    resolve_databases,
+)
+
+
+@pytest.fixture
+def parquet_path(tmp_path):
+    path = tmp_path / "orders.parquet"
+    with duckdb.connect() as db:
+        db.execute(
+            "COPY (SELECT 1 AS id, 12.50::DECIMAL(10,2) AS total, "
+            "DATE '2026-01-02' AS placed, NULL::VARCHAR AS note) "
+            "TO ? (FORMAT PARQUET)",
+            [str(path)],
+        )
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("as_url", [False, True])
+async def test_parquet_types_and_schema(parquet_path, as_url):
+    spec = f"parquet:///{parquet_path}" if as_url else str(parquet_path)
+    resolved = resolve_database(spec)
+    assert resolved.name == "orders"
+    conn = DatabaseConnection(resolved.connection_string)
+    assert conn.sqlglot_dialect == "duckdb"
+    try:
+        assert await conn.execute_query("SELECT * FROM orders", read_only=True) == [
+            {
+                "id": 1,
+                "total": Decimal("12.50"),
+                "placed": date(2026, 1, 2),
+                "note": None,
+            }
+        ]
+        schema = await SchemaManager(conn).get_schema_info()
+        assert schema["main.orders"]["columns"]["total"]["data_type"] == "DECIMAL(10,2)"
+        assert schema["main.orders"]["columns"]["placed"]["data_type"] == "DATE"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("other_format", ["csv", "parquet"])
+async def test_join_files(parquet_path, other_format):
+    other = parquet_path.with_name(f"customers.{other_format}")
+    with duckdb.connect() as db:
+        db.execute(
+            f"COPY (SELECT 1 AS id, 'Alice' AS name) TO ? (FORMAT {other_format})",
+            [str(other)],
+        )
+    resolved = resolve_databases([str(parquet_path), f"{other_format}:///{other}"])
+    assert len(resolved) == 1
+    conn = DatabaseConnection(resolved[0].connection_string)
+    try:
+        assert await conn.execute_query(
+            "SELECT name, total FROM customers JOIN orders USING (id)", read_only=True
+        ) == [{"name": "Alice", "total": Decimal("12.50")}]
+        tables = await SchemaManager(conn).list_tables()
+        assert {t["name"] for t in tables["tables"]} == {"customers", "orders"}
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_same_stem_across_formats(parquet_path):
+    csv = parquet_path.with_suffix(".csv")
+    csv.write_text("id\n2\n")
+    conn = DatabaseConnection(
+        resolve_database([str(parquet_path), str(csv)]).connection_string
+    )
+    assert await conn.execute_query(
+        "SELECT id FROM orders UNION ALL SELECT id FROM orders_2 ORDER BY id",
+        read_only=True,
+    ) == [{"id": 1}, {"id": 2}]
+
+
+def test_parquet_paths_and_missing_files(parquet_path, monkeypatch):
+    monkeypatch.chdir(parquet_path.parent)
+    uppercase = parquet_path.rename(parquet_path.with_suffix(".PARQUET"))
+    assert resolve_database(uppercase.name).name == "orders"
+    for spec in ["missing.parquet", [uppercase.name, "missing.parquet"]]:
+        with pytest.raises(DatabaseResolutionError, match="PARQUET file .* not found"):
+            resolve_database(spec)
+    assert len(resolve_databases([str(uppercase), "sqlite:///other.db"])) == 2
+
+
+@pytest.mark.asyncio
+async def test_quoted_file_and_table_name(parquet_path):
+    path = parquet_path.rename(parquet_path.with_name('order\'s "data".parquet'))
+    conn = DatabaseConnection(resolve_database(str(path)).connection_string)
+    assert await conn.execute_query(
+        'SELECT id FROM "order\'s ""data"""', read_only=True
+    ) == [{"id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_invalid_parquet(tmp_path):
+    path = tmp_path / "bad.parquet"
+    path.write_text("not a parquet file")
+    conn = DatabaseConnection(resolve_database(str(path)).connection_string)
+    with pytest.raises(duckdb.InvalidInputException):
+        await conn.execute_query("SELECT * FROM bad", read_only=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reader", ["read_parquet", "read_blob", "replacement"])
+@pytest.mark.parametrize("selected", [True, False])
+async def test_lockdown_blocks_file_reads(parquet_path, reader, selected):
+    target = parquet_path
+    if not selected:
+        target = parquet_path.with_name("sibling.parquet")
+        target.write_bytes(parquet_path.read_bytes())
+    relation = f"'{target}'" if reader == "replacement" else f"{reader}('{target}')"
+    conn = DatabaseConnection(resolve_database(str(parquet_path)).connection_string)
+    with pytest.raises(duckdb.PermissionException, match="disabled|permission"):
+        await conn.execute_query(f"SELECT * FROM {relation}", read_only=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("overwrite", [True, False])
+async def test_lockdown_blocks_file_writes(parquet_path, overwrite):
+    before = parquet_path.read_bytes()
+    target = parquet_path if overwrite else parquet_path.with_name("output.parquet")
+    conn = DatabaseConnection(resolve_database(str(parquet_path)).connection_string)
+    with pytest.raises(duckdb.PermissionException, match="disabled|permission"):
+        await conn.execute_query(
+            f"COPY orders TO '{target}' (FORMAT PARQUET)", read_only=True
+        )
+    assert parquet_path.read_bytes() == before
+    if not overwrite:
+        assert not target.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("during_load", [False, True])
+async def test_parquet_timeout(parquet_path, monkeypatch, during_load):
+    conn = DatabaseConnection(resolve_database(str(parquet_path)).connection_string)
+    query = "SELECT sum(a.i * b.i) FROM range(10000000) a(i), range(10000000) b(i)"
+    if during_load:
+        monkeypatch.setattr(conn, "_create_table", lambda db: db.execute(query))
+    with pytest.raises(QueryTimeoutError):
+        await conn.execute_query(query, timeout=0.2, read_only=True)

--- a/tests/test_database/test_parquet_connection.py
+++ b/tests/test_database/test_parquet_connection.py
@@ -97,9 +97,15 @@ def test_parquet_paths_and_missing_files(parquet_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_quoted_file_and_table_name(parquet_path):
-    path = parquet_path.rename(parquet_path.with_name('order\'s "data".parquet'))
+async def test_quoted_file_and_table_name(parquet_path, monkeypatch):
+    path = parquet_path.rename(parquet_path.with_name("order's data.parquet"))
     conn = DatabaseConnection(resolve_database(str(path)).connection_string)
+    assert await conn.execute_query(
+        'SELECT id FROM "order\'s data"', read_only=True
+    ) == [{"id": 1}]
+
+    # Double quotes are valid SQL identifiers, but not Windows filenames.
+    monkeypatch.setattr(conn, "table_name", 'order\'s "data"')
     assert await conn.execute_query(
         'SELECT id FROM "order\'s ""data"""', read_only=True
     ) == [{"id": 1}]


### PR DESCRIPTION
## Summary
- Accept `.parquet` paths and `parquet:///` URLs using the existing DuckDB file execution path.
- Support joins across repeated Parquet and mixed CSV/Parquet inputs, with typed schema introspection.
- Update CLI help, README, and database/query/SDK documentation.
- Preserve materialization-before-lockdown following Oracle input: DuckDB file allowlists also grant write access, so lazy views would weaken the existing safety boundary. Files reload per query; this is not a lazy large-file scan.

## Verification
- Rebased onto latest origin/main without conflicts.
- Full suite: 1,577 passed, 6 skipped.
- Ruff and source type checks pass.
- Documentation build passes.
- Real file queries through SQLsaber database layer returned 3 orders / 50.00 revenue and a CSV/Parquet join returned Alice 20.00 / Bob 30.00.
- Added coverage for typed values, schema introspection, joins, filename collisions/quoting, invalid files, filesystem lockdown, and cancellation.

## Limitation
Natural-language CLI verification was attempted but blocked by missing model credentials in the orb; database-layer verification used real files and queries, not mocks.