### PR TITLE
feat: Keep interactive prompts inline with themed backgrounds

### DIFF
--- a/src/sqlsaber/cli/chat_surface.py
+++ b/src/sqlsaber/cli/chat_surface.py
@@ -125,9 +125,7 @@ class ChatSurface:
         """
         if isinstance(prompt, AskConfirm) and prompt.assume_yes:
             return cast(T, True)
-        from sqlsaber.render.prompts import ask_in_overlay
-
-        return await ask_in_overlay(self.app.tui, prompt, get_styles())
+        return await self.app.ask(prompt)
 
     def _paint(self) -> None:
         self.app.tui.request_render()

--- a/src/sqlsaber/cli/database.py
+++ b/src/sqlsaber/cli/database.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import cyclopts
 
-from sqlsaber.cli.output import fail, fail_usage, out
+from sqlsaber.cli.output import fail, fail_usage, out, status
 from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config.database import DatabaseConfig, DatabaseConfigManager
 from sqlsaber.config.logging import get_logger
@@ -581,16 +581,15 @@ def test(
                     "  Add one with: saber db add <name>"
                 )
 
-        out(b.md(f"Testing connection to '{db_config.name}'..."))
-
         try:
-            connection_string = db_config.to_connection_string()
-            db_conn = DatabaseConnection(
-                connection_string, excluded_schemas=db_config.exclude_schemas
-            )
+            with status(f"Testing connection to '{db_config.name}'..."):
+                connection_string = db_config.to_connection_string()
+                db_conn = DatabaseConnection(
+                    connection_string, excluded_schemas=db_config.exclude_schemas
+                )
 
-            await db_conn.execute_query("SELECT 1 as test")
-            await db_conn.close()
+                await db_conn.execute_query("SELECT 1 as test")
+                await db_conn.close()
 
             out(b.success(f"Connection to '{db_config.name}' successful"))
             logger.info("db.test.success", name=db_config.name)

--- a/src/sqlsaber/cli/models.py
+++ b/src/sqlsaber/cli/models.py
@@ -10,7 +10,7 @@ import cyclopts
 import httpx
 
 from sqlsaber.cli.prompts import Choice
-from sqlsaber.cli.output import err, fail, fail_usage, out
+from sqlsaber.cli.output import err, fail, fail_usage, out, status
 from sqlsaber.cli.safety import confirm_action
 from sqlsaber.config import providers
 from sqlsaber.config.logging import get_logger
@@ -248,8 +248,8 @@ def list_models() -> None:
     logger.info("models.list.start")
 
     async def fetch_and_display() -> None:
-        out(b.md("Fetching available models..."))
-        models = await model_manager.fetch_available_models()
+        with status("Fetching available models..."):
+            models = await model_manager.fetch_available_models()
 
         if not models:
             logger.info("models.list.empty")
@@ -459,8 +459,8 @@ def set_model_command(
         from sqlsaber.cli.prompts import AsyncPrompter
         from sqlsaber.cli.workflows.model_selection import choose_model, fetch_models
 
-        out(b.md("Fetching available models..."))
-        models = await fetch_models(model_manager)
+        with status("Fetching available models..."):
+            models = await fetch_models(model_manager)
 
         if not models:
             logger.error("models.set.no_models")

--- a/src/sqlsaber/cli/onboarding.py
+++ b/src/sqlsaber/cli/onboarding.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from sqlsaber.cli.output import err, out
+from sqlsaber.cli.output import err, out, status
 from sqlsaber.render import blocks as b
 
 
@@ -88,8 +88,8 @@ async def setup_database_guided() -> str | None:
 
         db_config = build_config(db_input)
 
-        out(b.md(f"Testing connection to '{name}'...", role="muted"))
-        connection_success = await test_connection(db_config, db_input.password)
+        with status(f"Testing connection to '{name}'..."):
+            connection_success = await test_connection(db_config, db_input.password)
 
         if not connection_success:
             retry = await prompter.confirm(
@@ -128,10 +128,9 @@ async def select_model_for_provider(provider: str) -> str | None:
     from sqlsaber.cli.workflows.model_selection import choose_model, fetch_models
 
     try:
-        out(b.md(f"Fetching available {provider.title()} models...", role="muted"))
-
         model_manager = ModelManager()
-        models = await fetch_models(model_manager, providers=[provider])
+        with status(f"Fetching available {provider.title()} models..."):
+            models = await fetch_models(model_manager, providers=[provider])
 
         if not models:
             out(b.warn(f"Could not fetch models for {provider}. Using default."))

--- a/src/sqlsaber/cli/output.py
+++ b/src/sqlsaber/cli/output.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import NoReturn
 
 from sqlsaber.render import PromptUnavailable, blocks as b, cli_err, cli_out
@@ -16,6 +18,17 @@ def out(*blocks: b.Block) -> None:
 def err(*blocks: b.Block) -> None:
     """Emit finished blocks on stderr."""
     cli_err().emit(*blocks)
+
+
+@contextmanager
+def status(message: str) -> Iterator[None]:
+    """Show progress only while the operation is running."""
+    surface = cli_out()
+    surface.status(message)
+    try:
+        yield
+    finally:
+        surface.status(None)
 
 
 def fail(message: str, code: int = 1) -> NoReturn:

--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import platform
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import cast
 
 import saber_tui.utils as tui_utils
 from saber_tui import (
@@ -40,6 +42,9 @@ from saber_tui.utils import (
 
 from sqlsaber.cli.command_catalog import PaletteCommand, PaletteMode, palette_commands
 from sqlsaber.config.settings import ThinkingLevel
+from sqlsaber.render.prompts import PromptForm
+from sqlsaber.render.surface import Ask
+from sqlsaber.theme.styles import get_styles
 
 type SubmitHandler = Callable[[str], bool | None]
 
@@ -396,6 +401,7 @@ class ChatApp:
         self.should_submit_empty = should_submit_empty
         self.on_open_command_palette = on_open_command_palette
         self._command_palette_component: _CommandPaletteComponent | None = None
+        self._prompt_form: PromptForm | None = None
         self._palette_fill_hint = False
 
     def submit(self, text: str) -> None:
@@ -662,6 +668,34 @@ class ChatApp:
         self.tui.set_focus(self.editor)
         self.tui.request_render()
 
+    async def ask[T](self, prompt: Ask[T]) -> T | None:
+        """Ask in the editor slot, where the command palette opens."""
+        self.close_command_palette()
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[T | None] = loop.create_future()
+
+        def resolve(value: object) -> None:
+            if not future.done():
+                future.set_result(cast(T | None, value))
+
+        def finish(value: object) -> None:
+            loop.call_soon_threadsafe(resolve, value)
+
+        form = PromptForm(
+            prompt, get_styles(), on_done=finish, on_cancel=lambda: finish(None)
+        )
+        self._prompt_form = form
+        self._replace_editor(form)
+        self.tui.set_focus(form)
+        self.tui.request_render()
+        try:
+            return await future
+        finally:
+            self.tui.children[self.tui.children.index(form)] = self.editor
+            self._prompt_form = None
+            self.tui.set_focus(self.editor)
+            self.tui.request_render()
+
     def _replace_editor(self, component) -> None:
         try:
             index = self.tui.children.index(self.editor)
@@ -755,6 +789,10 @@ def build_chat_app(
     editor.on_submit = app.submit
 
     def global_listener(data: str):
+        if app._prompt_form is not None:
+            if matches_key(data, "ctrl+c") or matches_key(data, "ctrl+d"):
+                return {"data": "\x1b"}
+            return None
         if app.is_command_palette_open() and (
             matches_key(data, "escape") or matches_key(data, "ctrl+c")
         ):

--- a/src/sqlsaber/render/prompts.py
+++ b/src/sqlsaber/render/prompts.py
@@ -1,4 +1,4 @@
-"""PromptForm widget plus overlay and transient-TUI hosts."""
+"""PromptForm widget and transient-TUI hosts."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from saber_tui import PosixProcessTerminal, TUI, WindowsProcessTerminal
 from saber_tui.components import Input
 from saber_tui.components.select_list import SelectItem, SelectList, SelectListTheme
 from saber_tui.fuzzy import fuzzy_filter
+from saber_tui.utils import apply_background_to_line, truncate_to_width
 
 from sqlsaber.render.surface import (
     Ask,
@@ -79,6 +80,7 @@ class PromptForm:
         Returns:
             One string per row.
         """
+        content_width = max(1, width - 2)
         lines: list[str] = []
         message = self._styles.assistant_fg(self._prompt.message)
         lines.append(message)
@@ -87,14 +89,21 @@ class PromptForm:
         if self._filter and self._select is not None:
             lines.append(self._styles.muted_fg(f"  filter: {self._filter}"))
         if self._input is not None:
-            lines.extend(self._input.render(width))
+            lines.extend(self._input.render(content_width))
         if self._select is not None:
-            lines.extend(self._select.render(width))
+            lines.extend(self._select.render(content_width))
         hint = "enter confirm · esc cancel"
         if isinstance(self._prompt, AskChoice) and self._prompt.searchable:
             hint = "type to filter · " + hint
         lines.append(self._styles.muted_fg(hint))
-        return lines or [""]
+        return [
+            apply_background_to_line(
+                truncate_to_width(f" {line}", width, "", pad=True),
+                width,
+                self._styles.panel_bg,
+            )
+            for line in ["", *lines, ""]
+        ]
 
     def handle_input(self, data: str) -> None:
         """Dispatch a key sequence to the active child widget.
@@ -205,38 +214,6 @@ def _is_filter_char(data: str) -> bool:
     if data in {"\x7f", "\x08"}:
         return True
     return len(data) == 1 and data.isprintable() and data not in {"\n", "\r", "\t"}
-
-
-async def ask_in_overlay[T](tui: TUI, prompt: Ask[T], styles: Styles) -> T | None:
-    """Host a PromptForm inside a running TUI via ``show_overlay``.
-
-    Args:
-        tui: The live TUI.
-        prompt: Prompt to ask.
-        styles: Resolved theme.
-
-    Returns:
-        The typed value, or None when the user cancelled.
-    """
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[T | None] = loop.create_future()
-
-    def finish(value: object) -> None:
-        if not future.done():
-            loop.call_soon_threadsafe(future.set_result, cast(T | None, value))
-
-    form = PromptForm(
-        prompt,
-        styles,
-        on_done=finish,
-        on_cancel=lambda: finish(None),
-    )
-    handle = tui.show_overlay(form, {"anchor": "center", "width": 72})
-    handle.focus()
-    try:
-        return await future
-    finally:
-        handle.hide()
 
 
 async def ask_in_transient_tui[T](prompt: Ask[T], styles: Styles) -> T | None:

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -34,11 +34,14 @@ import sqlsaber.cli.interactive as interactive
 from sqlsaber.cli import tui_chat
 from sqlsaber.cli.chat_surface import ChatSurface
 from sqlsaber.cli.interactive import InteractiveSession
+from sqlsaber.cli.output import status
 from sqlsaber.cli.tui_chat import ChatApp, build_chat_app
 from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
 from sqlsaber.config.settings import ThinkingLevel
 from sqlsaber.render import blocks as b
-from sqlsaber.render.surface import AskSecret, AskText
+from sqlsaber.render import bind_cli_surfaces
+from sqlsaber.render.prompts import PromptForm
+from sqlsaber.render.surface import AskChoice, AskSecret, AskText, Choice
 from sqlsaber.theme.manager import get_theme_manager
 from sqlsaber.theme.styles import get_styles
 
@@ -427,17 +430,81 @@ def test_bare_slash_opens_command_palette_without_editor_autocomplete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_secret_prompt_uses_masked_live_overlay() -> None:
+async def test_choice_prompt_replaces_palette_and_restores_editor() -> None:
+    terminal = FakeTerminal(columns=80, rows=24)
+    app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
+    app.tui.start()
+    app.append_markdown("Conversation remains above settings.")
+    app.show_command_palette(thinking_enabled=True, thinking_level=ThinkingLevel.MEDIUM)
+    slot = app.tui.children.index(app._command_palette_component)
+
+    prompt = asyncio.create_task(
+        ChatSurface(app).ask(
+            AskChoice(
+                "Select model:", choices=[Choice("First", "a"), Choice("Second", "b")]
+            )
+        )
+    )
+    await asyncio.sleep(0)
+    assert app.tui.children[slot] is app._prompt_form
+    assert not app.tui.has_overlay()
+    viewport = "\n".join(app.render_plain_viewport())
+    assert viewport.index("Conversation remains") < viewport.index("Select model:")
+    terminal.send_input("\x1b[B")
+    terminal.send_input("\r")
+    assert await asyncio.wait_for(prompt, timeout=1) == "b"
+    assert app.tui.children[slot] is app.editor
+    assert app.tui.focused_component is app.editor
+
+
+@pytest.mark.parametrize("width", [20, 80])
+def test_prompt_background_fills_padded_rows(width: int) -> None:
+    styles = get_styles()
+    form = PromptForm(
+        AskText("Name:"), styles, on_done=lambda value: None, on_cancel=lambda: None
+    )
+    lines = form.render(width)
+    assert all(visible_width(line) == width for line in lines)
+    background = styles.panel_bg("sample").partition("sample")[0]
+    assert background
+    assert all(background in line for line in lines)
+    assert strip_ansi(lines[0]) == " " * width
+    assert strip_ansi(lines[-1]) == " " * width
+    assert strip_ansi(lines[1]).startswith(" Name:")
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_temporary_status_is_cleared_without_chat_history(fail: bool) -> None:
+    app = build_chat_app(terminal=FakeTerminal(columns=80), on_submit=lambda text: None)
+    with bind_cli_surfaces(ChatSurface(app)):
+        try:
+            with status("Fetching available models..."):
+                assert "Fetching available models" in "\n".join(
+                    app.render_plain_viewport()
+                )
+                if fail:
+                    raise RuntimeError("fetch failed")
+        except RuntimeError:
+            pass
+    assert "Fetching available models" not in "\n".join(app.render_plain_viewport())
+    assert not app.chat_container.children
+    assert app.status.loader is None
+
+
+@pytest.mark.asyncio
+async def test_secret_prompt_uses_masked_editor_slot() -> None:
     terminal = FakeTerminal(columns=80, rows=18)
     app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
     app.tui.start()
 
     prompt = asyncio.create_task(ChatSurface(app).ask(AskSecret("API key:")))
     for _ in range(100):
-        if app.tui.has_overlay():
+        if app._prompt_form is not None:
             break
         await asyncio.sleep(0.001)
-    assert app.tui.has_overlay() is True
+    assert app._prompt_form is not None
+    assert app.tui.children[2] is app._prompt_form
+    assert app.tui.has_overlay() is False
     terminal.send_input("secret-value")
 
     assert "secret-value" not in "\n".join(app.render_plain_viewport())
@@ -447,8 +514,8 @@ async def test_secret_prompt_uses_masked_live_overlay() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("cancel_key", ["\x03", "\x04"])
-async def test_prompt_cancel_keys_resolve_live_overlay(cancel_key: str) -> None:
+@pytest.mark.parametrize("cancel_key", ["\x1b", "\x03", "\x04"])
+async def test_prompt_cancel_keys_restore_editor(cancel_key: str) -> None:
     terminal = FakeTerminal(columns=80, rows=18)
     app = build_chat_app(terminal=terminal, on_submit=lambda text: None)
     app.tui.start()
@@ -459,6 +526,8 @@ async def test_prompt_cancel_keys_resolve_live_overlay(cancel_key: str) -> None:
 
     assert await asyncio.wait_for(prompt, timeout=1) is None
     assert app.tui.has_overlay() is False
+    assert app.tui.children[2] is app.editor
+    assert app.tui.focused_component is app.editor
     assert terminal.stopped is False
 
 


### PR DESCRIPTION
## Summary
- Show follow-up forms in the chat input slot instead of a centered overlay, restoring editor focus on completion or cancellation.
- Apply the active theme panel background and padding to prompt forms.
- Clear temporary model-fetch and connection-check status messages before showing forms or results, including failure paths.

## Verification
- Rebased onto the latest origin/main without conflicts.
- `env -u FORCE_COLOR uv run pytest -q`: 1583 passed, 6 skipped.
- `uv run ruff check .` and `uvx ty check src/`: passed.
- Visually inspected live default and filtered model pickers before rebase. Confirmed themed backgrounds and removal of the fetching message. The live exit sequence reached a separate API-key setup prompt and timed out; isolated verification state was cleaned up.
- Regression coverage includes inline placement, selection, secret masking, cancellation, background padding, and status cleanup after success or failure.