### PR TITLE
feat: Render loading status in the editor border

### DIFF
--- a/src/sqlsaber/cli/tui_chat.py
+++ b/src/sqlsaber/cli/tui_chat.py
@@ -37,6 +37,7 @@ from saber_tui.utils import (
     apply_background_to_line,
     strip_ansi,
     truncate_to_width,
+    visible_width,
     wrap_text_with_ansi,
 )
 
@@ -230,12 +231,13 @@ class _StatusComponent:
             self.loader.on_cancel = self.on_cancel
 
     def render(self, width: int) -> list[str]:
-        loader = self.loader
-        if loader is not None:
-            return loader.render(width)
-        if not self.text:
+        if self.loader is not None or not self.text:
             return [" " * width]
-        return [self.theme.status_fg(_pad_to_width(f"  {self.text}", width))]
+        return [
+            " " * width,
+            self.theme.status_fg(_pad_to_width(f"  {self.text}", width)),
+            " " * width,
+        ]
 
     def invalidate(self) -> None:
         return None
@@ -255,6 +257,27 @@ class _StatusComponent:
         self.loader = None
         if loader is not None:
             loader.dispose()
+
+
+class _StatusEditor(Editor):
+    def __init__(self, tui: TUI, status: _StatusComponent, theme: EditorTheme) -> None:
+        super().__init__(tui, theme=theme)
+        self.status = status
+
+    def render(self, width: int) -> list[str]:
+        lines = super().render(width)
+        loader = self.status.loader
+        if loader is not None and width >= 8:
+            # Render without wrapping, then fit the label between border segments.
+            label_width = max(width, visible_width(loader.message) + 4)
+            label = loader.render(label_width)[1].strip()
+            label = truncate_to_width(label, width - 5, "…")
+            lines[0] = (
+                self.border_color("─ ")
+                + label
+                + self.border_color(" " + "─" * (width - visible_width(label) - 3))
+            )
+        return lines
 
 
 class _FooterComponent:
@@ -763,8 +786,9 @@ def build_chat_app(
     chat_container = Container()
     status = _StatusComponent(tui, theme, on_cancel)
     footer = _FooterComponent(footer_text, theme)
-    editor = Editor(
+    editor = _StatusEditor(
         tui,
+        status,
         theme=EditorTheme(
             border_color=theme.muted_fg,
             select_list=SelectListTheme(),

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -316,12 +316,72 @@ def test_status_uses_cancellable_loader_without_stealing_editor_focus() -> None:
     assert "Crunching data..." in viewport
     assert app.status.loader is not None
     assert app.editor.focused is True
+    assert viewport.count("Crunching data...") == 1
+    border = strip_ansi(app.editor.render(80)[0])
+    assert border.startswith("─ ")
+    assert "Crunching data... ─" in border
 
     terminal.send_input("\x03")
 
     assert cancelled == [True]
     assert app.editor.focused is True
     app.clear_status()
+
+
+@pytest.mark.parametrize("width", [0, 1, 7, 8, 24, 80])
+def test_loading_border_preserves_editor_and_fits_width(width: int) -> None:
+    app = build_chat_app(terminal=FakeTerminal(), on_submit=lambda text: None)
+    app.editor.set_text("SELECT name\nFROM employees")
+    idle = app.editor.render(width)
+    app.set_loading("Crunching data... 分析売上データ")
+    loader = app.status.loader
+    assert loader is not None
+    loader.stop()
+    try:
+        loading = app.editor.render(width)
+        assert loading[1:] == idle[1:]
+        assert all(visible_width(line) <= width for line in loading)
+        if width >= 8:
+            assert loading[0] != idle[0]
+            assert strip_ansi(loading[0]).endswith("──")
+            app.tui.request_render = MagicMock()
+            loader.tick()
+            assert app.editor.render(width)[0] != loading[0]
+            app.tui.request_render.assert_called_once()
+        else:
+            assert loading == idle
+    finally:
+        app.clear_status()
+    assert app.editor.render(width) == idle
+
+
+def test_replacing_loading_status_disposes_previous_animation() -> None:
+    app = build_chat_app(terminal=FakeTerminal(), on_submit=lambda text: None)
+    app.set_loading("Executing SQL...")
+    previous = app.status.loader
+    assert previous is not None
+    previous.dispose = MagicMock(wraps=previous.dispose)
+    app.set_loading("Crunching data...")
+    previous.dispose.assert_called_once()
+    assert "Crunching data..." in strip_ansi(app.editor.render(80)[0])
+    app.set_status("Type the handoff goal and press Enter.")
+    assert app.status.loader is None
+    assert strip_ansi(app.editor.render(80)[0]) == "─" * 80
+    assert "Type the handoff goal" in strip_ansi(app.status.render(80)[1])
+
+
+def test_cancelled_status_keeps_blank_lines_around_message() -> None:
+    app = build_chat_app(terminal=FakeTerminal(columns=80), on_submit=lambda text: None)
+    app.append_user_message("Show sales by region")
+    app.set_loading("Crunching data...")
+    app.set_status("Query cancelled.")
+
+    lines = app.render_plain_viewport()
+    index = next(i for i, line in enumerate(lines) if "Query cancelled." in line)
+    assert lines[index - 1] == " " * 80
+    assert lines[index + 1] == " " * 80
+    assert lines[index + 2] == "─" * 80
+    assert app.status.loader is None
 
 
 def test_status_and_footer_render_within_narrow_terminal_width() -> None:
@@ -535,9 +595,11 @@ def test_status_snapshots_loader_across_render_cancel_and_dispose() -> None:
     app = build_chat_app(terminal=FakeTerminal(columns=80), on_submit=lambda text: None)
 
     class RacingLoader:
+        message = "loading"
+
         def render(self, width: int) -> list[str]:
             app.status.loader = None
-            return ["loading".ljust(width)]
+            return ["", "loading".ljust(width)]
 
         def handle_input(self, data: str) -> None:
             assert data == "\x03"
@@ -548,7 +610,7 @@ def test_status_snapshots_loader_across_render_cancel_and_dispose() -> None:
 
     loader = RacingLoader()
     app.status.loader = loader
-    assert app.status.render(80)[0].startswith("loading")
+    assert strip_ansi(app.editor.render(80)[0]).startswith("─ loading ─")
 
     app.status.loader = loader
     assert app.status.cancel_loading() is True


### PR DESCRIPTION
## Changes
- Embed the existing animated spinner and busy status in the editor top border without upgrading saber-tui.
- Preserve editor content, focus, cancellation, and the plain border when loading ends.
- Fit long status labels to terminal width and add blank lines above and below non-loading status messages.

## Verification
- `env -u FORCE_COLOR uv run pytest -q`: 1,614 passed, 6 skipped.
- `uv run ruff check .`, formatting checks for changed files, and `uvx ty check src/`: passed.
- Inspected rendered normal-width, narrow, and cancellation states. Captured terminal animation and exercised Ctrl+C and Ctrl+D in a UI demonstration.
- Verified CLI startup and exit in an isolated environment. Warm `saber --help`: 0.23–0.24 seconds.
- No live model query was run because the orb has no model-provider credentials.