### PR TITLE
fix(cli): keep the TUI editor ready until SQLSaber binds

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -417,13 +417,13 @@ def query(
                         allow_dangerous=allow_dangerous,
                     )
                 )
+                schedule_update_check()
                 should_bind = await shell.wait_for_bind_or_exit()
                 if not should_bind:
                     shell.stop()
                     out(b.success("Goodbye!"))
                     return
                 log = _ensure_logging()
-                schedule_update_check()
                 log.info(
                     "cli.session.start",
                     argv=sys.argv[1:],

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -411,6 +411,17 @@ def query(
                     database=selected_database,
                     allow_dangerous=allow_dangerous,
                 )
+                shell.app.set_footer(
+                    InteractiveSession.preview_footer(
+                        selected_database,
+                        allow_dangerous=allow_dangerous,
+                    )
+                )
+                should_bind = await shell.wait_for_bind_or_exit()
+                if not should_bind:
+                    shell.stop()
+                    out(b.success("Goodbye!"))
+                    return
                 log = _ensure_logging()
                 schedule_update_check()
                 log.info(

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -42,6 +42,7 @@ def bind_update_notice(emit: Callable[..., None] | None) -> None:
 
 
 QUERY_CANCEL_GRACE_SECONDS = 0.1
+UNBOUND_EXIT_COMMANDS = frozenset({"/exit", "/quit", "exit", "quit"})
 
 
 def __getattr__(name: str):
@@ -61,6 +62,8 @@ class ChatShell:
     session_slot: dict[str, InteractiveSession]
     exit_event: asyncio.Event
     loop: asyncio.AbstractEventLoop
+    bind_event: asyncio.Event = field(default_factory=asyncio.Event)
+    queued: dict[str, str] = field(default_factory=dict)
     _stopped: bool = False
 
     def stop(self) -> None:
@@ -71,6 +74,23 @@ class ChatShell:
         if not self.app.tui.stopped:
             self.app.stop()
         self.exit_event.set()
+
+    async def wait_for_bind_or_exit(self) -> bool:
+        """True when SQLSaber should be constructed."""
+        if self.bind_event.is_set():
+            return True
+        if self.exit_event.is_set():
+            return False
+        bind_task = asyncio.create_task(self.bind_event.wait())
+        exit_task = asyncio.create_task(self.exit_event.wait())
+        _done, pending = await asyncio.wait(
+            {bind_task, exit_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        return self.bind_event.is_set()
 
 
 class InteractiveSession:
@@ -93,21 +113,59 @@ class InteractiveSession:
         self.log = get_logger(__name__)
 
     @staticmethod
+    def _named_database_footer(database: str | list[str] | None) -> str | None:
+        if isinstance(database, list) and len(database) > 1:
+            return f"DBs: {', '.join(database)}"
+        if isinstance(database, list) and database:
+            return f"DB: {Path(database[0]).stem}"
+        if isinstance(database, str) and database:
+            return f"DB: {Path(database).stem}"
+        return None
+
+    @staticmethod
     def boot_footer(
         database: str | list[str] | None,
         *,
         allow_dangerous: bool = False,
     ) -> str:
         """Footer shown before SQLSaber is constructed."""
-        if isinstance(database, list) and len(database) > 1:
-            db_part = f"DBs: {', '.join(database)}"
-        elif isinstance(database, list) and database:
-            db_part = f"DB: {Path(database[0]).stem}"
-        elif isinstance(database, str) and database:
-            db_part = f"DB: {Path(database).stem}"
-        else:
-            db_part = "DB: starting..."
+        db_part = (
+            InteractiveSession._named_database_footer(database) or "DB: starting..."
+        )
         parts = [db_part]
+        if allow_dangerous:
+            parts.append(DANGEROUS_MODE_FOOTER_LABEL)
+        return " | ".join(parts)
+
+    @staticmethod
+    def preview_footer(
+        database: str | list[str] | None,
+        *,
+        allow_dangerous: bool = False,
+    ) -> str:
+        """Footer from config files, without constructing SQLSaber."""
+        from sqlsaber.config.database import DatabaseConfigManager
+        from sqlsaber.config.settings import Config
+
+        db_part = InteractiveSession._named_database_footer(database)
+        if db_part is None:
+            default = DatabaseConfigManager().get_default_database()
+            db_part = (
+                "DB: starting..."
+                if default is None
+                else f"DB: {default.name} ({default.type})"
+            )
+        settings = Config.default()
+        thinking = (
+            settings.model.thinking_level.value
+            if settings.model.thinking_enabled
+            else "off"
+        )
+        parts = [
+            db_part,
+            f"Model: {settings.model.name}",
+            f"Thinking: {thinking}",
+        ]
         if allow_dangerous:
             parts.append(DANGEROUS_MODE_FOOTER_LABEL)
         return " | ".join(parts)
@@ -125,6 +183,8 @@ class InteractiveSession:
 
         loop = asyncio.get_running_loop()
         exit_event = asyncio.Event()
+        bind_event = asyncio.Event()
+        queued: dict[str, str] = {}
         session_slot: dict[str, InteractiveSession] = {}
         app_ref: dict[str, ChatApp] = {}
         surface_ref: dict[str, ChatSurface] = {}
@@ -134,7 +194,13 @@ class InteractiveSession:
             app = app_ref["app"]
             surface = surface_ref["surface"]
             if session is None:
-                surface.emit(b.warn("Still starting..."))
+                if user_query.strip().casefold() in UNBOUND_EXIT_COMMANDS:
+                    exit_event.set()
+                    app.stop()
+                    return False
+                queued["query"] = user_query
+                app.set_loading("Starting...")
+                bind_event.set()
                 app.tui.set_focus(app.editor)
                 return False
             return session._queue_submit(app, surface, user_query, loop=loop)
@@ -196,6 +262,8 @@ class InteractiveSession:
             session_slot=session_slot,
             exit_event=exit_event,
             loop=loop,
+            bind_event=bind_event,
+            queued=queued,
         )
 
     def _history_path(self) -> Path:
@@ -630,6 +698,10 @@ class InteractiveSession:
             bind_update_notice(surface.emit)
             self._refresh_footer()
             await self.before_prompt_loop()
+            queued_query = shell.queued.pop("query", None)
+            if queued_query is not None:
+                app.submit(queued_query)
+            app.clear_status()
             exit_event = shell.exit_event
 
         try:

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -45,6 +45,15 @@ QUERY_CANCEL_GRACE_SECONDS = 0.1
 UNBOUND_EXIT_COMMANDS = frozenset({"/exit", "/quit", "exit", "quit"})
 
 
+def _signal_loop_event(loop: asyncio.AbstractEventLoop, event: asyncio.Event) -> None:
+    """Set an asyncio event from the TUI thread or the loop thread."""
+    event.set()
+    try:
+        loop.call_soon_threadsafe(event.set)
+    except RuntimeError:
+        return
+
+
 def __getattr__(name: str):
     """Expose usage types without importing pydantic-ai at module load."""
     if name in {"UsageMeter", "SessionUsage", "format_cost_usd", "format_tokens"}:
@@ -77,10 +86,10 @@ class ChatShell:
 
     async def wait_for_bind_or_exit(self) -> bool:
         """True when SQLSaber should be constructed."""
-        if self.bind_event.is_set():
-            return True
         if self.exit_event.is_set():
             return False
+        if self.bind_event.is_set():
+            return True
         bind_task = asyncio.create_task(self.bind_event.wait())
         exit_task = asyncio.create_task(self.exit_event.wait())
         _done, pending = await asyncio.wait(
@@ -90,7 +99,7 @@ class ChatShell:
         for task in pending:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
-        return self.bind_event.is_set()
+        return self.bind_event.is_set() and not self.exit_event.is_set()
 
 
 class InteractiveSession:
@@ -194,13 +203,17 @@ class InteractiveSession:
             app = app_ref["app"]
             surface = surface_ref["surface"]
             if session is None:
-                if user_query.strip().casefold() in UNBOUND_EXIT_COMMANDS:
-                    exit_event.set()
+                folded = user_query.strip().casefold()
+                if folded in UNBOUND_EXIT_COMMANDS:
+                    _signal_loop_event(loop, exit_event)
                     app.stop()
                     return False
+                if folded == "/clear":
+                    surface.emit(b.success("Conversation history cleared."))
+                    return True
                 queued["query"] = user_query
                 app.set_loading("Starting...")
-                bind_event.set()
+                _signal_loop_event(loop, bind_event)
                 app.tui.set_focus(app.editor)
                 return False
             return session._queue_submit(app, surface, user_query, loop=loop)
@@ -230,13 +243,15 @@ class InteractiveSession:
             session = session_slot.get("session")
             app = app_ref["app"]
             if session is None:
+                _signal_loop_event(loop, exit_event)
+                app.stop()
                 return
             loop.call_soon_threadsafe(
                 lambda: asyncio.create_task(session._cancel_current_task(app))
             )
 
         def on_exit() -> None:
-            loop.call_soon_threadsafe(exit_event.set)
+            _signal_loop_event(loop, exit_event)
 
         app = build_chat_app(
             terminal=terminal,

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -84,6 +84,7 @@ class ChatShell:
         if self._stopped:
             return
         self._stopped = True
+        bind_update_notice(None)
         if not self.app.tui.stopped:
             self.app.stop()
         self.exit_event.set()
@@ -276,6 +277,7 @@ class InteractiveSession:
             b.md(cls._instructions()),
         )
         app.tui.start()
+        bind_update_notice(surface.emit)
         return ChatShell(
             app=app,
             session_slot=session_slot,

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -46,8 +46,12 @@ UNBOUND_EXIT_COMMANDS = frozenset({"/exit", "/quit", "exit", "quit"})
 
 
 def _signal_loop_event(loop: asyncio.AbstractEventLoop, event: asyncio.Event) -> None:
-    """Set an asyncio event from the TUI thread or the loop thread."""
-    event.set()
+    try:
+        if asyncio.get_running_loop() is loop:
+            event.set()
+            return
+    except RuntimeError:
+        pass
     try:
         loop.call_soon_threadsafe(event.set)
     except RuntimeError:

--- a/src/sqlsaber/cli/update_check.py
+++ b/src/sqlsaber/cli/update_check.py
@@ -11,7 +11,7 @@ from importlib import metadata
 
 import httpx
 
-from sqlsaber.config.logging import get_logger
+from sqlsaber.config.logging import get_logger, is_configured
 from sqlsaber.render import blocks as b
 from sqlsaber.render.blocks import Block
 
@@ -152,7 +152,8 @@ async def _check_and_notify() -> None:
         return
 
     if _is_newer(latest, current):
-        _LOG.info("update_check.available", current=current, latest=latest)
+        if is_configured():
+            _LOG.info("update_check.available", current=current, latest=latest)
         _emit_update_notice()
 
 

--- a/src/sqlsaber/config/logging.py
+++ b/src/sqlsaber/config/logging.py
@@ -57,6 +57,11 @@ def get_logger(name: Optional[str] = None) -> structlog.BoundLogger:
     return structlog.get_logger(name)
 
 
+def is_configured() -> bool:
+    """True after ``setup_logging()`` has run."""
+    return _CONFIGURED
+
+
 def _build_file_handler(log_path: Path, level: int) -> Handler:
     rotation = os.getenv("SQLSABER_LOG_ROTATION", "time").strip().lower()
 
@@ -189,6 +194,7 @@ def setup_logging(*, force: bool = False) -> None:
 
 __all__ = [
     "setup_logging",
+    "is_configured",
     "get_logger",
     "default_log_dir",
     "default_log_file",

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -403,11 +403,22 @@ def test_root_bare_mode_passes_public_sdk_to_tui():
             captured["shell_kwargs"] = kwargs
 
             class FakeShell:
+                def __init__(self):
+                    self.app = MagicMock()
+
                 def stop(self):
                     captured["shell_stopped"] = True
 
+                async def wait_for_bind_or_exit(self):
+                    return True
+
             captured["shell"] = FakeShell()
             return captured["shell"]
+
+        @staticmethod
+        def preview_footer(database, *, allow_dangerous=False):
+            captured["preview"] = (database, allow_dangerous)
+            return "DB: analytics (SQLite)"
 
         def __init__(self, saber):
             captured["interactive_saber"] = saber

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -56,6 +56,53 @@ class TestCLICommands:
             )
         assert create.await_args.kwargs["csv_tool_results"] is csv_tool_results
 
+    def test_interactive_immediate_exit_does_not_construct_sqlsaber(
+        self, monkeypatch
+    ) -> None:
+        """Ctrl+D after first paint must not import or construct SQLSaber."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from sqlsaber.cli import commands
+        from sqlsaber.cli.interactive import ChatShell, InteractiveSession
+
+        created = False
+
+        async def create(**kwargs):
+            nonlocal created
+            created = True
+            raise AssertionError(
+                "interactive exit before a query must not construct SQLSaber"
+            )
+
+        def start_unbound_shell(**kwargs):
+            loop = asyncio.get_running_loop()
+            exit_event = asyncio.Event()
+            exit_event.set()
+            app = MagicMock()
+            app.tui.stopped = True
+            return ChatShell(
+                app=app,
+                session_slot={},
+                exit_event=exit_event,
+                loop=loop,
+            )
+
+        monkeypatch.setattr(
+            commands, "_create_cli_saber", AsyncMock(side_effect=create)
+        )
+        monkeypatch.setattr(commands, "needs_onboarding", lambda _: False)
+        monkeypatch.setattr(commands, "schedule_update_check", lambda: None)
+        monkeypatch.setattr(commands, "_ensure_logging", MagicMock())
+        monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            InteractiveSession, "start_unbound_shell", start_unbound_shell
+        )
+
+        commands.query(None)
+
+        assert created is False
+
     def test_query_specific_database_not_found(self, capsys, temp_dir, monkeypatch):
         """Test query with non-existent database name."""
         config_dir = temp_dir / "config"

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -113,7 +113,10 @@ class TestCLICommands:
             commands, "_create_cli_saber", AsyncMock(side_effect=create)
         )
         monkeypatch.setattr(commands, "needs_onboarding", lambda _: False)
-        monkeypatch.setattr(commands, "schedule_update_check", lambda: None)
+        scheduled: list[bool] = []
+        monkeypatch.setattr(
+            commands, "schedule_update_check", lambda: scheduled.append(True)
+        )
         monkeypatch.setattr(commands, "_ensure_logging", MagicMock())
         monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(
@@ -126,6 +129,7 @@ class TestCLICommands:
         commands.query(None)
 
         assert created is False
+        assert scheduled == [True]
 
     def test_query_specific_database_not_found(self, capsys, temp_dir, monkeypatch):
         """Test query with non-existent database name."""

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -35,20 +35,42 @@ class TestCLICommands:
     def test_query_passes_csv_choice_to_session(
         self, monkeypatch, interactive, csv_tool_results
     ):
+        import asyncio
         from unittest.mock import AsyncMock, MagicMock
+
         from sqlsaber.cli import commands
-        from sqlsaber.cli.interactive import InteractiveSession
+        from sqlsaber.cli.interactive import ChatShell, InteractiveSession
 
         class SessionReached(Exception):
             pass
 
         create = AsyncMock(side_effect=SessionReached)
+
+        def start_unbound_shell(**kwargs):
+            loop = asyncio.get_running_loop()
+            bind_event = asyncio.Event()
+            bind_event.set()
+            app = MagicMock()
+            app.tui.stopped = True
+            return ChatShell(
+                app=app,
+                session_slot={},
+                exit_event=asyncio.Event(),
+                loop=loop,
+                bind_event=bind_event,
+            )
+
         monkeypatch.setattr(commands, "_create_cli_saber", create)
         monkeypatch.setattr(commands, "needs_onboarding", lambda _: False)
         monkeypatch.setattr(commands, "schedule_update_check", lambda: None)
         monkeypatch.setattr(commands, "_ensure_logging", MagicMock())
         monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
-        monkeypatch.setattr(InteractiveSession, "start_unbound_shell", MagicMock())
+        monkeypatch.setattr(
+            InteractiveSession, "start_unbound_shell", start_unbound_shell
+        )
+        monkeypatch.setattr(
+            InteractiveSession, "preview_footer", lambda *a, **k: "DB: test"
+        )
         with pytest.raises(SessionReached):
             commands.query(
                 None if interactive else "Show tables",
@@ -59,7 +81,6 @@ class TestCLICommands:
     def test_interactive_immediate_exit_does_not_construct_sqlsaber(
         self, monkeypatch
     ) -> None:
-        """Ctrl+D after first paint must not import or construct SQLSaber."""
         import asyncio
         from unittest.mock import AsyncMock, MagicMock
 
@@ -97,6 +118,9 @@ class TestCLICommands:
         monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(
             InteractiveSession, "start_unbound_shell", start_unbound_shell
+        )
+        monkeypatch.setattr(
+            InteractiveSession, "preview_footer", lambda *a, **k: "DB: test"
         )
 
         commands.query(None)

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -146,6 +146,26 @@ async def test_start_unbound_shell_paints_slash_hint_and_db_footer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unbound_editor_accepts_text_before_session_bind() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        for char in "hello":
+            terminal.send_input(char)
+        shell.app.tui.flush_render()
+        assert shell.app.editor.get_text() == "hello"
+        assert "session" not in shell.session_slot
+        text = "\n".join(shell.app.render_plain_viewport())
+        assert "hello" in text
+        assert "DB: starting..." in text
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
 async def test_unbound_shell_slash_opens_palette() -> None:
     terminal = FakeTerminal(columns=100, rows=24)
     shell = InteractiveSession.start_unbound_shell(

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -360,6 +360,26 @@ async def test_start_unbound_shell_paints_slash_hint_and_db_footer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unbound_shell_shows_update_notice_without_sqlsaber() -> None:
+    from sqlsaber.cli.update_check import _emit_update_notice
+
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        _emit_update_notice()
+        shell.app.tui.flush_render()
+        text = "\n".join(shell.app.render_plain_viewport())
+        assert "A new version is now available!" in text
+        assert "uv tool update sqlsaber" in text
+        assert "session" not in shell.session_slot
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
 async def test_unbound_editor_accepts_text_before_session_bind() -> None:
     terminal = FakeTerminal(columns=100, rows=24)
     shell = InteractiveSession.start_unbound_shell(

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
 
@@ -9,7 +10,7 @@ import pytest
 
 from sqlsaber.cli.interactive import InteractiveSession
 
-from tests.test_cli.test_tui_chat import FakeTerminal
+from tests.test_cli.test_tui_chat import FakeTerminal, _fake_saber
 
 
 def test_commands_import_does_not_load_structlog_or_httpx() -> None:
@@ -114,12 +115,165 @@ assert ChatShell.__name__ == "ChatShell"
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_boot_footer_includes_db_ready_needle() -> None:
+def test_preview_footer_does_not_import_pydantic_ai() -> None:
+    code = """
+import sys
+from unittest.mock import MagicMock
+
+from sqlsaber.cli.interactive import InteractiveSession
+
+shell = MagicMock()
+shell.app.set_footer(InteractiveSession.preview_footer(None))
+loaded = [
+    name
+    for name in (
+        "pydantic_ai",
+        "sqlsaber.sdk.client",
+        "sqlsaber.threads.storage",
+        "sqlsaber.cli.retention",
+    )
+    if name in sys.modules
+]
+assert not loaded, loaded
+shell.app.set_footer.assert_called_once()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_preview_footer_uses_saved_default_without_sqlsaber(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        "sqlsaber.config.database.DatabaseConfigManager.get_default_database",
+        lambda self: SimpleNamespace(name="verification", type="sqlite"),
+    )
+
+    def fake_default(cls=None):
+        return SimpleNamespace(
+            model=SimpleNamespace(
+                name="openai:gpt-test",
+                thinking_enabled=False,
+                thinking_level=SimpleNamespace(value="medium"),
+            )
+        )
+
+    monkeypatch.setattr(
+        "sqlsaber.config.settings.Config.default",
+        classmethod(fake_default),
+    )
+    text = InteractiveSession.preview_footer(None)
+    assert "DB: verification (sqlite)" in text
+    assert "Model: openai:gpt-test" in text
+    assert "Thinking: off" in text
+
+
+@pytest.mark.asyncio
+async def test_wait_for_bind_or_exit_skips_bind_when_already_exited() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        shell.exit_event.set()
+        assert await shell.wait_for_bind_or_exit() is False
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
+async def test_unbound_exit_command_does_not_request_bind() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        for char in "exit":
+            terminal.send_input(char)
+        terminal.send_input("\r")
+        shell.app.tui.flush_render()
+        assert shell.bind_event.is_set() is False
+        assert shell.exit_event.is_set() is True
+        assert await shell.wait_for_bind_or_exit() is False
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
+async def test_unbound_submit_requests_bind_and_keeps_text() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        for char in "count rows":
+            terminal.send_input(char)
+        terminal.send_input("\r")
+        shell.app.tui.flush_render()
+        assert shell.bind_event.is_set() is True
+        assert shell.queued["query"] == "count rows"
+        assert shell.app.editor.get_text() == "count rows"
+        assert await shell.wait_for_bind_or_exit() is True
+    finally:
+        shell.stop()
     assert "DB:" in InteractiveSession.boot_footer("verification.db")
     assert "verification" in InteractiveSession.boot_footer(
         "/tmp/fixtures/verification.db"
     )
     assert "DB:" in InteractiveSession.boot_footer(None)
+
+
+@pytest.mark.asyncio
+async def test_run_submits_queued_query_after_bind() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        for char in "count rows":
+            terminal.send_input(char)
+        terminal.send_input("\r")
+        shell.app.tui.flush_render()
+
+        submitted: list[str] = []
+        session = InteractiveSession.__new__(InteractiveSession)
+        session.log = type("FakeLog", (), {"info": lambda *a, **k: None})()
+        session.saber = _fake_saber()
+        session.autocomplete_provider = None
+        session._handoff_mode = False
+        session._submit_pending = False
+        session.current_task = None
+        session._exit_finalized = False
+        session.streaming_handler = None
+        session.before_prompt_loop = lambda: asyncio.sleep(0)
+        session._load_history = lambda: []
+        session._footer_text = lambda: "DB: test"
+        session._create_streaming_handler = lambda app: None
+        session._finalize_exit = lambda: asyncio.sleep(0)
+
+        def capture_queue(app, surface, user_query, *, loop):
+            del app, surface, loop
+            submitted.append(user_query)
+            shell.exit_event.set()
+            return True
+
+        session._queue_submit = capture_queue
+        await session.run(shell=shell)
+        assert submitted == ["count rows"]
+        text = "\n".join(shell.app.render_plain_viewport())
+        assert "count rows" in text
+        assert shell.app.editor.get_text() == ""
+    finally:
+        shell.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import subprocess
 import sys
+import threading
 
 import pytest
 
-from sqlsaber.cli.interactive import InteractiveSession
+from sqlsaber.cli.interactive import InteractiveSession, _signal_loop_event
 
 from tests.test_cli.test_tui_chat import FakeTerminal, _fake_saber
 
@@ -171,6 +172,26 @@ def test_preview_footer_uses_saved_default_without_sqlsaber(monkeypatch) -> None
     assert "DB: verification (sqlite)" in text
     assert "Model: openai:gpt-test" in text
     assert "Thinking: off" in text
+
+
+@pytest.mark.asyncio
+async def test_bind_signal_from_other_thread_wakes_wait() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        waiter = asyncio.create_task(shell.wait_for_bind_or_exit())
+        await asyncio.sleep(0)
+        threading.Thread(
+            target=_signal_loop_event,
+            args=(shell.loop, shell.bind_event),
+            daemon=True,
+        ).start()
+        assert await asyncio.wait_for(waiter, timeout=2) is True
+    finally:
+        shell.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -183,6 +183,8 @@ async def test_wait_for_bind_or_exit_skips_bind_when_already_exited() -> None:
     try:
         shell.exit_event.set()
         assert await shell.wait_for_bind_or_exit() is False
+        shell.bind_event.set()
+        assert await shell.wait_for_bind_or_exit() is False
     finally:
         shell.stop()
 
@@ -202,6 +204,43 @@ async def test_unbound_exit_command_does_not_request_bind() -> None:
         assert shell.bind_event.is_set() is False
         assert shell.exit_event.is_set() is True
         assert await shell.wait_for_bind_or_exit() is False
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
+async def test_unbound_ctrl_c_during_starting_exits_without_bind() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        shell.app.submit("count rows")
+        shell.app.tui.flush_render()
+        assert shell.bind_event.is_set() is True
+        terminal.send_input("\x03")
+        shell.app.tui.flush_render()
+        assert shell.exit_event.is_set() is True
+        assert await shell.wait_for_bind_or_exit() is False
+    finally:
+        shell.stop()
+
+
+@pytest.mark.asyncio
+async def test_unbound_clear_does_not_request_bind() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database=None,
+        terminal=terminal,
+    )
+    try:
+        shell.app.submit("/clear")
+        shell.app.tui.flush_render()
+        assert shell.bind_event.is_set() is False
+        assert shell.exit_event.is_set() is False
+        text = "\n".join(shell.app.render_plain_viewport())
+        assert "Conversation history cleared." in text
     finally:
         shell.stop()
 

--- a/tests/test_cli/test_update_check.py
+++ b/tests/test_cli/test_update_check.py
@@ -1,4 +1,6 @@
 import asyncio
+import subprocess
+import sys
 from io import StringIO
 
 import pytest
@@ -82,6 +84,45 @@ def test_notice_before_bind_flushes_into_chat_not_stdout() -> None:
     assert "uv tool update sqlsaber" in viewport
     assert "A new version is now available!" not in buf.getvalue()
     assert "Model: gpt-test" in _footer_line(app)
+
+
+def test_update_check_without_setup_logging_does_not_print_to_stdout() -> None:
+    code = """
+import asyncio
+from unittest.mock import patch
+
+async def fake_fetch():
+    return "99.0.0"
+
+async def main() -> None:
+    from sqlsaber.cli.update_check import (
+        _check_and_notify,
+        bind_update_notice,
+        reset_update_check,
+    )
+
+    reset_update_check()
+    emitted: list[str] = []
+    bind_update_notice(lambda *blocks: emitted.append("yes"))
+    with (
+        patch("sqlsaber.cli.update_check._get_current_version", lambda: "0.1.0"),
+        patch("sqlsaber.cli.update_check._fetch_latest_version", fake_fetch),
+    ):
+        await _check_and_notify()
+    if emitted != ["yes"]:
+        raise SystemExit(f"notice missing: {emitted!r}")
+
+asyncio.run(main())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "update_check.available" not in result.stdout
+    assert "update_check.available" not in result.stderr
 
 
 def test_one_shot_bind_still_prints_to_stdout() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Interactive `saber` paints the chat editor in about 0.2s, then used to construct `SQLSaber` on the asyncio thread. That import takes about 2s and holds the GIL, so `Editor.handle_input` on the TUI reader thread stalls. Typing during `DB: starting...` feels laggy.

This change paints first and waits. `SQLSaber` is constructed only after the first submitted query. Exit before that query skips the import. A light footer is filled from config files without `SQLSaber`. The PyPI update check still runs after first paint, and the notice sink is bound on the unbound shell so an idle session can show an available version.

The TUI reader thread wakes bind/exit waits with `call_soon_threadsafe` only. Setting the asyncio event from that thread raises in asyncio debug mode and can leave `wait_for_bind_or_exit` stuck. The loop thread still sets the event directly so FakeTerminal tests see it without an extra tick.

Scheduling that check before `setup_logging()` used to let unconfigured structlog print `update_check.available` to stdout, which shares the TUI paint stream. The notice still emits; the log line only writes after logging is configured.

## Scope

- `InteractiveSession.start_unbound_shell` and `ChatShell.wait_for_bind_or_exit`
- `InteractiveSession.preview_footer` and `boot_footer`
- Interactive branch of `query()` in `src/sqlsaber/cli/commands.py`
- `_signal_loop_event` for bind and exit from the TUI thread
- Unbound `/clear` does not bind. Unbound Ctrl+C during `Starting...` exits.
- Unbound shells bind `bind_update_notice` after first paint. `schedule_update_check()` runs before `wait_for_bind_or_exit`.
- `_check_and_notify` logs `update_check.available` only when `is_configured()` is true.

Out of scope: `saber threads resume` still constructs `SQLSaber` before paint.

## Tradeoffs

Importing `pydantic_ai` before first paint would regress first-paint time. `asyncio.to_thread` does not help because the GIL is process-wide. The httpx import for the update check still happens after first paint, as in #249, not during `SQLSaber` construction.

## Blast Radius

Interactive `saber` with no question. Non-interactive queries and `--help` are unchanged. Idle sessions still run the PyPI check; they no longer leak a structlog line onto the TUI stdout stream.

## Verification

- `env -u FORCE_COLOR uv run python -m pytest` on `1563c50`. 1625 passed, 6 skipped.
- `test_unbound_shell_shows_update_notice_without_sqlsaber` shows `A new version is now available!` in the unbound viewport.
- `test_interactive_immediate_exit_does_not_construct_sqlsaber` still skips `SQLSaber` and now requires `schedule_update_check`.
- `test_update_check_without_setup_logging_does_not_print_to_stdout` on `8d84a62` keeps unconfigured structlog off stdout while the notice still emits.
- `test_interactive_query_does_not_import_pydantic_ai_before_first_paint` still passes.
- Isolated PTY typing from first paint (0.182s) for 3s at 80ms. 37/37 chars echoed. median 1.9ms, p95 2.2ms, max 17.1ms.
- `saber --help` 0.173-0.189s, all under 0.5s.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2624c6c9-bbd1-436c-a0cb-756751a15e06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2624c6c9-bbd1-436c-a0cb-756751a15e06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

