### PR TITLE
Rewrite docs for a first-read standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@
 [![PyPI](https://img.shields.io/pypi/v/sqlsaber.svg)](https://pypi.org/project/sqlsaber/)
 [![Docs](https://img.shields.io/badge/docs-sqlsaber.com-blue)](https://sqlsaber.com)
 
-> SQLsaber is an open-source agentic SQL assistant. Think Claude Code but for SQL.
+SQLsaber is an open-source agentic SQL assistant. Ask questions about databases, SQLite or DuckDB files, CSVs, and Parquet files in plain English from your terminal or from Python. SQLsaber reads your schema, writes SQL, runs read-only queries by default, and explains the results.
 
-Ask questions about databases, SQLite/DuckDB files, CSVs, and Parquet files in plain English from your terminal or Python code. SQLsaber reads your schema, writes SQL, executes read-only queries by default, and explains the results.
-
-`SQLSaber` is the canonical conversation lifecycle used by the CLI and TUI. Clients own input and presentation, while `SQLSaber` owns agent behavior, completed history, and thread lifecycle.
+The CLI and TUI use the `SQLSaber` conversation lifecycle. Clients own input and presentation. `SQLSaber` owns agent behavior, completed history, and thread lifecycle.
 
 ![SQLsaber demo showing a natural language database query in the terminal](./sqlsaber.gif)
 
-Featured in research: SQLsaber appears in an ACM Conference on AI and Agentic Systems '26 paper. [Read the paper](https://dl.acm.org/doi/10.1145/3786335.3813217).
+SQLsaber appears in an ACM Conference on AI and Agentic Systems '26 paper. [Read the paper](https://dl.acm.org/doi/10.1145/3786335.3813217).
 
 ## Quickstart
 
@@ -63,19 +61,19 @@ saber -d ./warehouse.duckdb "Show me the latest partition"
 # Join CSV and Parquet files using DuckDB
 saber -d ./customers.csv -d ./orders.parquet "Revenue by customer"
 
-# Connect multiple databases in one session
+# Connect several databases in one session
 saber -d sales -d analytics "Compare last month's revenue to web sessions"
 ```
 
 ## Why SQLsaber?
 
-- **No context switching** — Stay in your terminal, ask questions, get answers.
-- **Schema-aware** — Automatically discovers tables, columns, indexes, comments, and relationships.
-- **Safe by default** — Runs read-only queries unless you explicitly enable dangerous mode.
-- **Works with your stack** — PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet files.
-- **Remembers your work** — Resume previous analysis with conversation threads.
-- **Learns your business context** — Store KPI definitions, SQL patterns, and domain notes in a searchable knowledge base.
-- **Flexible model support** — Use Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, Hugging Face, and other supported providers.
+- **No context switching.** Stay in your terminal, ask questions, and get answers.
+- **Schema-aware.** Discovers tables, columns, indexes, comments, and relationships.
+- **Safe by default.** Runs read-only queries unless you pass `--allow-dangerous`.
+- **Works with your stack.** PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet files.
+- **Remembers your work.** Resume previous analysis with conversation threads.
+- **Learns your business context.** Store KPI definitions, SQL patterns, and domain notes in a searchable knowledge base.
+- **Flexible model support.** Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, Hugging Face, and other supported providers.
 
 ## Common workflows
 
@@ -84,7 +82,7 @@ saber -d sales -d analytics "Compare last month's revenue to web sessions"
 | Explore data interactively | `saber` |
 | Ask a one-off question | `saber "monthly active users"` |
 | Analyze a CSV | `saber -d ./customers.csv "customers by state"` |
-| Compare multiple databases | `saber -d sales -d analytics "compare revenue to traffic"` |
+| Compare several databases | `saber -d sales -d analytics "compare revenue to traffic"` |
 | Save a KPI definition | `saber knowledge add "Revenue KPI" "Recognized revenue from shipped orders only"` |
 | Resume previous analysis | `saber threads list` then `saber threads resume <id>` |
 | Automate a thread follow-up | `saber --thread <id> "compare with last quarter"` |
@@ -114,7 +112,7 @@ Install official plugins alongside SQLsaber:
 # Render charts in your terminal
 uv tool install --with sqlsaber-viz sqlsaber
 
-# Delegate multi-step analysis to a sandboxed notebook agent (recommended)
+# Delegate multi-step analysis to a sandboxed notebook agent
 uv tool install --with sqlsaber-notebook sqlsaber
 
 # Run one-off Python snippets in a remote sandbox
@@ -126,7 +124,7 @@ uv tool install --with sqlsaber-viz,sqlsaber-notebook,sqlsaber-sandbox sqlsaber
 
 ## Python SDK
 
-Use the same SQLsaber conversation lifecycle from Python scripts, notebooks, web apps, or pipelines. A second `saber.query()` on the same instance uses the prior completed history automatically:
+Use the same `SQLSaber` conversation lifecycle from Python scripts, notebooks, web apps, or pipelines. A second `saber.query()` on the same instance uses the prior completed history automatically:
 
 ```python
 import asyncio
@@ -170,32 +168,33 @@ See the [Capabilities guide](https://sqlsaber.com/sdk/capabilities/) for multi-d
 
 ## How it works
 
-1. **Discovery** — Lists tables and identifies relevant ones based on your question.
-2. **Schema analysis** — Introspects only the tables needed.
-3. **Knowledge retrieval** — Searches saved KPI definitions and SQL patterns when useful.
-4. **Query generation** — Writes SQL tailored to your database dialect.
-5. **Execution** — Runs the query with safety checks.
-6. **Results** — Formats the output with an explanation.
+1. **Discovery.** Lists tables and identifies relevant ones based on your question.
+2. **Schema analysis.** Introspects only the tables needed.
+3. **Knowledge retrieval.** Searches saved KPI definitions and SQL patterns when useful.
+4. **Query generation.** Writes SQL tailored to your database dialect.
+5. **Execution.** Runs the query with safety checks.
+6. **Results.** Formats the output with an explanation.
 
 ## Documentation
 
 Full docs at [sqlsaber.com](https://sqlsaber.com):
 
 - [Installation](https://sqlsaber.com/installation/)
-- [Getting Started](https://sqlsaber.com/guides/getting-started/)
-- [Database Setup](https://sqlsaber.com/guides/database-setup/)
-- [Running Queries](https://sqlsaber.com/guides/queries/)
-- [Multiple Databases](https://sqlsaber.com/guides/multi-database/)
-- [Knowledge Base](https://sqlsaber.com/guides/knowledge/)
+- [Getting started](https://sqlsaber.com/guides/getting-started/)
+- [Database setup](https://sqlsaber.com/guides/database-setup/)
+- [Running queries](https://sqlsaber.com/guides/queries/)
+- [Multiple databases](https://sqlsaber.com/guides/multi-database/)
+- [Knowledge base](https://sqlsaber.com/guides/knowledge/)
+- [Plugins](https://sqlsaber.com/guides/plugins/)
 - [Python SDK](https://sqlsaber.com/sdk/overview/)
-- [Command Reference](https://sqlsaber.com/reference/commands/)
+- [Command reference](https://sqlsaber.com/reference/commands/)
 
 ## Contributing
 
-Contributions welcome! Please open an issue first to discuss changes.
+Open an issue before large changes.
 
-If you find SQLsaber useful, a ⭐ on GitHub helps others discover it.
+If you find SQLsaber useful, a star on GitHub helps others discover it.
 
 ## License
 
-Apache-2.0 — see [LICENSE](./LICENSE)
+Apache-2.0. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SQLsaber is an open-source agentic SQL assistant. Ask questions about databases,
 
 The CLI and TUI use the `SQLSaber` conversation lifecycle. Clients own input and presentation. `SQLSaber` owns agent behavior, completed history, and thread lifecycle.
 
-![SQLsaber demo showing a natural language database query in the terminal](./sqlsaber.gif)
+[![SQLsaber demo showing a natural language database query in the terminal](https://asciinema.org/a/1265197.svg)](https://asciinema.org/a/1265197)
 
 SQLsaber appears in an ACM Conference on AI and Agentic Systems '26 paper. [Read the paper](https://dl.acm.org/doi/10.1145/3786335.3813217).
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,17 @@ SQLsaber appears in an ACM Conference on AI and Agentic Systems '26 paper. [Read
 ## Quickstart
 
 ```bash
-# Recommended
+# Recommended if you have uv
 uv tool install sqlsaber
+
+# If you do not have uv
+curl -LsSf https://uvx.sh/sqlsaber/install.sh | sh
+```
+
+On Windows without uv:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://uvx.sh/sqlsaber/install.ps1 | iex"
 ```
 
 Try SQLsaber with the sample SQLite database:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
 		starlight({
 			title: "SQLsaber",
 			description:
-				"Open-source AI SQL assistant. Ask questions in plain English and get SQL queries, results, and explanations. Supports PostgreSQL, MySQL, SQLite, and DuckDB.",
+				"Open-source AI SQL assistant. Ask questions in plain English and get SQL queries, results, and explanations. Supports PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet.",
 			customCss: ["./src/styles/global.css"],
 			head: [
 				{
@@ -77,22 +77,23 @@ export default defineConfig({
 			],
 			sidebar: [
 				{
-					label: "Getting Started",
+					label: "Start",
 					items: [
 						{ label: "Installation", slug: "installation" },
-						{ label: "Quick Start", slug: "guides/getting-started" },
+						{ label: "Getting started", slug: "guides/getting-started" },
 					],
 				},
 				{
 					label: "Guides",
 					items: [
-						{ label: "Database Setup", slug: "guides/database-setup" },
-						{ label: "Multiple Databases", slug: "guides/multi-database" },
+						{ label: "Database setup", slug: "guides/database-setup" },
+						{ label: "Multiple databases", slug: "guides/multi-database" },
 						{ label: "Authentication", slug: "guides/authentication" },
 						{ label: "Models", slug: "guides/models" },
-						{ label: "Running Queries", slug: "guides/queries" },
-						{ label: "Conversation Threads", slug: "guides/threads" },
-						{ label: "Knowledge Base", slug: "guides/knowledge" },
+						{ label: "Running queries", slug: "guides/queries" },
+						{ label: "Conversation threads", slug: "guides/threads" },
+						{ label: "Knowledge base", slug: "guides/knowledge" },
+						{ label: "Plugins", slug: "guides/plugins" },
 					],
 				},
 				{
@@ -106,11 +107,11 @@ export default defineConfig({
 							slug: "sdk/capability-query-results",
 						},
 						{
-							label: "Credentials & Models",
+							label: "Credentials and models",
 							slug: "sdk/credentials-and-models",
 						},
 						{
-							label: "Results & Streaming",
+							label: "Results and streaming",
 							slug: "sdk/results-and-streaming",
 						},
 						{ label: "Advanced", slug: "sdk/advanced" },

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -1,78 +1,54 @@
 ---
 title: Authentication
-description: "Set up API keys for Anthropic, OpenAI, Google, Groq, xAI, and other LLM providers in SQLsaber. Secure credential storage via OS keychain."
+description: Save API keys for Anthropic, OpenAI, Google, Groq, xAI, and other providers. SQLsaber stores credentials in the OS keychain.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber supports multiple LLM providers.
+Save an API key so SQLsaber can call an AI provider.
 
-### Providers
+## Providers
 
-SQLsaber supports the following LLM providers:
-
-- **Anthropic** - API key
-- **OpenAI** - API key
-- **Google** - API key
-- **Groq** - API key
-- **Mistral** - API key
-- **Cohere** - API key
-- **Hugging Face** - API key
-- **xAI** - API key (`XAI_API_KEY`; recommended model `xai:grok-4.6`)
+| Provider | Environment variable | Notes |
+| -------- | -------------------- | ----- |
+| Anthropic | `ANTHROPIC_API_KEY` | |
+| OpenAI | `OPENAI_API_KEY` | Fresh installs default to `openai:gpt-5.6-sol` |
+| Google | `GOOGLE_API_KEY` | |
+| Groq | `GROQ_API_KEY` | |
+| Mistral | `MISTRAL_API_KEY` | |
+| Cohere | `COHERE_API_KEY` | |
+| Hugging Face | `HUGGINGFACE_API_KEY` | |
+| xAI | `XAI_API_KEY` | Recommended model `xai:grok-4.6` |
 
 <Aside type="note">
-  SQLsaber stores API keys securely using your operating system's credentials
-  store.
+  SQLsaber stores API keys in your operating system credentials store.
 </Aside>
 
-### Quick Setup
-
-The fastest way to configure authentication:
+## Save a key
 
 ```bash
 saber auth setup
 ```
 
-This interactive command will:
+This command:
 
-1. Let you choose your AI provider
-2. Prompt you for an API key (or use an existing environment variable)
-3. Securely store your credentials
+1. Lets you choose an AI provider
+2. Asks for an API key, or reuses a matching environment variable
+3. Stores the key in the credentials store
 
 The default model is `openai:gpt-5.6-sol`. Save an OpenAI key for a fresh install, or run `saber models set` after you save a different provider.
 
-#### Anthropic
+To save an Anthropic key, run `saber auth setup`, choose Anthropic, and paste a key from the [Anthropic Console](https://console.anthropic.com/). Use the same steps for the other providers.
 
-##### API Key
-
-1. Get an API key from [Anthropic Console](https://console.anthropic.com/)
-2. Run the setup:
-   ```bash
-   saber auth setup
-   ```
-3. Choose "Anthropic" as your provider
-4. Enter your API key when prompted
-
-<Aside type="note">Follow the same steps for setting up other providers.</Aside>
-
-### Managing Authentication
-
-#### Check Authentication Status
-
-See which providers are configured:
+## Check saved providers
 
 ```bash
 saber auth status
 ```
 
-This shows:
+The output lists configured providers and whether each key came from an environment variable or the keychain.
 
-- Configured providers
-- Whether a provider is configured via environment variable or keychain
-
-#### Reset Authentication
-
-To remove stored credentials for a provider:
+## Remove a saved key
 
 ```bash
 saber auth reset
@@ -81,54 +57,32 @@ saber auth reset
 saber auth reset openai --yes
 ```
 
-This will:
+If you pass a provider, SQLsaber does not ask which one to reset. Destructive commands require confirmation in a terminal, or `--yes` in automation.
 
-1. Ask you to select which provider to reset
-2. Remove the stored API key from your OS credentials store
+## Use more than one provider
 
-When a provider is supplied directly, no selection prompt is needed. Destructive
-commands require confirmation in a terminal or an explicit `--yes` in automation.
+Save keys for several providers, then switch models with `saber models set`. Each provider's key is stored on its own.
 
-### Multiple Providers
-
-You can configure multiple providers and switch between them when selecting models. Each provider's credentials are stored securely and independently.
-
-### Environment Variables
-
-You can also use environment variables for setting API keys.
-
-Example:
+## Set a key in the environment
 
 ```bash
-# Anthropic
 export ANTHROPIC_API_KEY="your-api-key"
-
-# OpenAI
 export OPENAI_API_KEY="your-api-key"
-
-# Google
 export GOOGLE_API_KEY="your-api-key"
-
-# xAI
+export GROQ_API_KEY="your-api-key"
+export MISTRAL_API_KEY="your-api-key"
+export COHERE_API_KEY="your-api-key"
+export HUGGINGFACE_API_KEY="your-api-key"
 export XAI_API_KEY="your-api-key"
 ```
 
 Environment variables take precedence over stored credentials.
 
-### Getting Help
+See `saber auth status` and `saber auth --help`, or [Commands](/reference/commands/#saber-auth).
 
-Check authentication status and configuration:
+## Next steps
 
-```bash
-saber auth status
-saber auth --help
-```
-
-### What's Next?
-
-After setting up authentication:
-
-1. [Configure your preferred models](/guides/models)
-2. [Set up database connections](/guides/database-setup)
-3. [Start querying your data](/guides/getting-started)
-4. [Learn about different query modes](/guides/queries)
+1. [Choose a model](/guides/models/)
+2. [Connect a database](/guides/database-setup/)
+3. [Run a query](/guides/getting-started/)
+4. [Use thinking and other query options](/guides/queries/)

--- a/docs/src/content/docs/guides/database-setup.mdx
+++ b/docs/src/content/docs/guides/database-setup.mdx
@@ -1,51 +1,44 @@
 ---
-title: Database Setup
-description: "Connect SQLsaber to PostgreSQL, MySQL, SQLite, DuckDB, CSV, or Parquet files. Configure connection strings, SSL certificates, and schema exclusions."
+title: Database setup
+description: Connect SQLsaber to PostgreSQL, MySQL, SQLite, DuckDB, CSV, or Parquet. Configure connection strings, SSL, and schema exclusions.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber supports PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet data sources. This guide covers all the ways to configure database connections.
+Connect SQLsaber to a database or a local file, then test the connection.
 
-### Supported Database Types
+SQLsaber works with PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet. PostgreSQL and MySQL support SSL. DuckDB can open a file or run in memory. SQLsaber queries Parquet through DuckDB.
 
-- **PostgreSQL** - Full support with SSL
-- **MySQL** - Full support with SSL
-- **SQLite** - Local database files
-- **DuckDB** - Local DuckDB files or in-memory analytics
-- **CSV** - Local CSV files
-- **Parquet** - Local Parquet files, queried using DuckDB
-
-### Adding Database
+## Add a saved connection
 
 ```bash
 saber db add my-database
 ```
 
-This will prompt you for all necessary connection details.
+SQLsaber prompts for the connection details.
 
-For scripts and coding agents, provide every required value and disable prompts:
+For scripts and coding agents, pass every required value and disable prompts:
 
 ```bash
 # Local database
 saber db add local --type sqlite --database ./local.db --no-interactive
 
-# Server database; keep the password out of argv and shell history
+# Server database. Keep the password out of argv and shell history.
 printf '%s' "$DB_PASSWORD" | saber db add analytics --no-interactive \
   --host db.example.com --database analytics --username agent --password-stdin
 ```
 
-You can also attach an optional description to a connection. Descriptions are
-shown to the agent when [several databases are connected at once](/guides/multi-database)
-to help it pick the right one:
+If you will connect several databases in one session, add a short description so the agent can tell them apart:
 
 ```bash
 saber db add my-database --description "Production Postgres: orders and revenue"
 ```
 
-### Connection Strings
+See [Multiple databases](/guides/multi-database/) for that session type.
 
-SQLsaber supports direct connection strings for PostgreSQL and MySQL, plus file URIs for SQLite and DuckDB.
+## Connect with a string
+
+Pass a PostgreSQL or MySQL URL, or a SQLite or DuckDB file URI:
 
 ```bash
 saber -d "postgresql://user:password@localhost:5432/database"
@@ -55,44 +48,37 @@ saber -d "mysql://user:password@localhost:3306/database"
 saber -d "duckdb:///path/to/data.duckdb"
 ```
 
-### Files
+## Query a local file
 
-#### SQLite
+### SQLite
 
 ```bash
-# Use SQLite file directly
 saber -d "./data/sales.db" "Show me total sales by month"
 
-# Relative paths work too
 saber -d "~/Documents/mydata.db" "Count all records"
 ```
 
-#### DuckDB
+### DuckDB
 
 ```bash
-# Query a DuckDB file
 saber -d "./warehouse/data.duckdb" "Show the latest partition"
 
-# Use an absolute path
 saber -d "duckdb:///Users/me/analytics.duckdb" "Describe orders"
 ```
 
-#### CSV
-
-SQLsaber can also analyze CSV files directly.
+### CSV
 
 ```bash
 saber -d "./customers.csv" "How many customers are from each state?"
 ```
 
 <Aside type="note">
-  For CSV files, first row should contain column headers. SQLsaber will infer
-  data types automatically.
+  The first row must contain column headers. SQLsaber infers column types.
 </Aside>
 
-#### Parquet
+### Parquet
 
-Query a local `.parquet` file directly, or use a `parquet:///` URL:
+Query a local `.parquet` file, or use a `parquet:///` URL:
 
 ```bash
 saber -d "./orders.parquet" "What is total revenue?"
@@ -100,107 +86,83 @@ saber -d "parquet:///orders.parquet" "Describe the columns"
 saber -d "./customers.csv" -d "./orders.parquet" "Revenue by customer"
 ```
 
-DuckDB reads column names and types from the Parquet schema; no CSV delimiter or
-header options are needed. Each file becomes a table named after its filename
-without the extension (for example, `orders`). Repeated CSV/Parquet inputs share
-one database, so SQL joins work across them.
+DuckDB reads column names and types from the Parquet schema. Each file becomes a table named after its filename without the extension. For example, `orders.parquet` is the table `orders`. Repeated CSV and Parquet inputs share one database, so SQL joins work across them.
 
-Like CSV inputs, files are materialized into in-memory tables on every query,
-then external file access is disabled for read-only execution. This preserves
-the existing safety boundary, but is not a lazy, large-file Parquet scan: allow
-enough memory for the loaded data. Use explicit local files, not remote URLs or
-partition-directory inputs.
+SQLsaber loads each file into memory on every query, then disables further file access for read-only execution. That is not a lazy scan of a large Parquet file. Give the process enough memory for the loaded data. Use explicit local files. Remote URLs and partition-directory inputs are not supported.
 
-### Managing Connections
+## Manage saved connections
 
-#### List All Connections
+List connections:
 
 ```bash
 saber db list
 ```
 
-#### Set Default Database
-
-If you have multiple databases, set one as default:
+If you have several connections, set one as the default:
 
 ```bash
 saber db set-default my-database
 ```
 
 <Aside type="note">
-  By default, SQLsaber will set the first added connection as default.
+  The first connection you add becomes the default.
 </Aside>
 
-#### Test Connections
-
-Verify that a database connection works:
+Test a connection:
 
 ```bash
 saber db test my-database
 ```
 
-#### Remove Connections
+Remove a connection:
 
 ```bash
 saber db remove my-database
 
-# Non-interactive, explicit deletion
+# Non-interactive deletion
 saber db remove my-database --yes
 ```
 
-### Connecting to Multiple Databases
+## Connect several databases at once
 
-A single session can be connected to several databases at once by repeating the
-`-d` flag. The agent then queries each database separately and combines the
-results in its answer:
+Repeat `-d` to attach more than one database to a session. The agent queries each database separately and combines the answers:
 
 ```bash
 saber -d sales -d analytics "Compare revenue to web sessions"
 ```
 
-See the [Multiple Databases guide](/guides/multi-database) for details.
+See [Multiple databases](/guides/multi-database/).
 
-### Security
+## Keep queries read-only
 
-#### Read-only by Default
+SQLsaber blocks `INSERT`, `UPDATE`, `DELETE`, and DDL by default. Only `SELECT` runs unless you pass `--allow-dangerous`.
 
-SQLsaber blocks all write operations (INSERT, UPDATE, DELETE, DDL) by default. Only SELECT queries are allowed unless you explicitly enable dangerous mode with `--allow-dangerous`.
+Even with `--allow-dangerous`, SQLsaber still blocks destructive statements such as `DROP` and `TRUNCATE`, and admin statements such as `GRANT`, `REVOKE`, and `CREATE FUNCTION`, `CREATE USER`, `CREATE ROLE`, or `CREATE DATABASE`.
 
-Even in dangerous mode, destructive operations like DROP/TRUNCATE and admin/security operations (for example GRANT/REVOKE, CREATE FUNCTION/USER/ROLE/DATABASE) are always blocked.
+If you connect a production database, create a read-only database role and use those credentials in SQLsaber.
 
-#### Read-only Database Role
-
-> **If you are using SQLsaber with a production database, we recommend setting up a read-only role for your database and using those credentials to setup connection in SQLsaber.**
-
-SQLsaber uses AST-based validation (via sqlglot) to analyze every query before execution. This catches write operations in nested queries, CTEs, subqueries, and dialect-specific dangerous functions. However, no validation is fool-proof.
-
-**The most secure approach is to create a read-only database role and use those credentials with SQLsaber.** This provides database-level enforcement that cannot be bypassed regardless of what queries are generated.
+SQLsaber uses AST validation through sqlglot before it runs a query. That catches writes in nested queries, CTEs, subqueries, and some dialect-specific functions. Validation can miss a case. A read-only role enforces the limit in the database.
 
 <Aside type="note">
-  For development setups, this isn't required but is a good practice if you wish
-  to ensure with absolute certainty that no data modifying queries are ever
-  executed.
+  A read-only role is optional for local development. Use one when you need the
+  database itself to reject writes.
 </Aside>
 
-#### Password Storage
+SQLsaber stores database passwords in your operating system credentials store.
 
-SQLsaber stores database passwords securely using your operating system's credentials store.
+Store SSL certificates in a secure location. Use absolute paths when you configure a connection. SSL modes are listed in [Commands](/reference/commands/#saber-db-add).
 
-#### SSL Certificates
+## Skip schemas during introspection
 
-Store SSL certificates in a secure location and use absolute paths when configuring connections.
-
-### Schema Introspection Filters
-
-SQLsaber skips noisy system schemas for every supported database when it introspects metadata, and you can layer on your own exclusions during setup or later via `saber db exclude`.
+SQLsaber skips noisy system schemas for every supported database. Add more exclusions when you add a connection, or later with `saber db exclude`.
 
 Default exclusions:
 
-- **PostgreSQL:** `pg_catalog`, `information_schema`, `_timescaledb_internal`, `_timescaledb_cache`, `_timescaledb_config`, `_timescaledb_catalog`
-- **MySQL:** `information_schema`, `performance_schema`, `mysql`, `sys`
-- **DuckDB / CSV / Parquet:** `information_schema`, `pg_catalog`, `duckdb_catalog`
+- PostgreSQL: `pg_catalog`, `information_schema`, `_timescaledb_internal`, `_timescaledb_cache`, `_timescaledb_config`, `_timescaledb_catalog`
+- MySQL: `information_schema`, `performance_schema`, `mysql`, `sys`
+- DuckDB, CSV, and Parquet: `information_schema`, `pg_catalog`, `duckdb_catalog`
 
-When you run `saber db add`, the interactive flow prompts for extra schemas to ignore (or pass `--exclude-schemas schema1,schema2` in non-interactive mode). You can revisit an existing connection at any time:
+When you run `saber db add`, the interactive flow asks for extra schemas to ignore. In non-interactive mode, pass `--exclude-schemas schema1,schema2`. Change an existing connection at any time:
 
 ```bash
 # Replace the exclusion list interactively
@@ -210,46 +172,32 @@ saber db exclude my-database
 saber db exclude my-database --add reporting_temp,rollups
 ```
 
-For ad-hoc connections created from raw URLs or file paths, use environment variables to extend the default filters:
+For ad-hoc connections from URLs or file paths, extend the defaults with environment variables:
 
 ```bash
 export SQLSABER_PG_EXCLUDE_SCHEMAS="schema1,schema2"
-export SQLSABER_MYSQL_EXCLUDE_SCHEMAS="temp_db, staging"
+export SQLSABER_MYSQL_EXCLUDE_SCHEMAS="temp_db,staging"
 export SQLSABER_DUCKDB_EXCLUDE_SCHEMAS="internal_schema"
 ```
 
-Both the `list_tables` and `introspect_schema` tools respect these filters.
+Both `list_tables` and `introspect_schema` apply these filters.
 
-### Troubleshooting
-
-Always test new connections after adding them.
+## Fix a failed connection
 
 ```bash
-# Test the connection
 saber db test my-database
 
-# If connection fails, check the details
 saber db list
 
-# Update connection if needed
 saber db remove my-database
-saber db add my-database  # Start over with correct details
+saber db add my-database
 ```
 
-### Getting Help
+See `saber db --help` and `saber db add --help`, or [Commands](/reference/commands/#saber-db).
 
-Use the help commands for more information:
+## Next steps
 
-```bash
-saber db --help
-saber db add --help
-```
-
-### What's Next?
-
-After setting up your database connections:
-
-1. [Configure authentication](/guides/authentication) for AI providers
-2. [Start querying your data](/guides/getting-started)
-3. [Connect to multiple databases at once](/guides/multi-database)
-4. [Manage conversation threads](/guides/threads)
+1. [Set up authentication](/guides/authentication/)
+2. [Run your first query](/guides/getting-started/)
+3. [Connect several databases](/guides/multi-database/)
+4. [Resume a conversation](/guides/threads/)

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -40,8 +40,8 @@ SQLsaber lists relevant tables, reads their schema, writes SQL, runs the query, 
 To leave interactive mode, type `/exit` or press Ctrl+D.
 
 <script
-  src="https://asciinema.org/a/39e71PIiGJetHBPy08L1TOotB.js"
-  id="asciicast-39e71PIiGJetHBPy08L1TOotB"
+  src="https://asciinema.org/a/1265197.js"
+  id="asciicast-1265197"
   async="true"
 ></script>
 

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -5,10 +5,7 @@ description: Connect SQLsaber to a database and run your first natural-language 
 
 We will connect the sample legislators database and ask how many vice presidents became president by election in the 20th century.
 
-You need:
-
-- Python 3.12 or later
-- An API key from Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, or Hugging Face
+You need an API key from Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, or Hugging Face.
 
 If SQLsaber is not installed, follow [Installation](/installation/) first.
 

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -1,72 +1,46 @@
 ---
-title: Getting Started
-description: "Quick start guide for SQLsaber. Connect to PostgreSQL, MySQL, SQLite, or DuckDB and run your first natural language SQL query."
+title: Getting started
+description: Connect SQLsaber to a database and run your first natural-language query.
 ---
 
-import { Aside, Code } from "@astrojs/starlight/components";
+We will connect the sample legislators database and ask how many vice presidents became president by election in the 20th century.
 
-**Goal:** Go from zero to running your first natural language database query.
+You need:
 
-**Time:** ~3 minutes
+- Python 3.12 or later
+- An API key from Anthropic, OpenAI, Google, Groq, xAI, Mistral, Cohere, or Hugging Face
 
-**Prerequisites:**
+If SQLsaber is not installed, follow [Installation](/installation/) first.
 
-- A database (PostgreSQL, MySQL, SQLite, or DuckDB)
-- An API key from Anthropic, OpenAI, Google, or Groq
-
-## 1. Install
-
-```bash
-uv tool install sqlsaber
-```
-
-<Aside type="tip">
-Don't have `uv`? Install it first:
-
-```bash
-# macOS/Linux
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows
-winget install --id=astral-sh.uv -e
-```
-
-</Aside>
-
-## 2. Run the setup
-
-```bash
-saber
-```
-
-On first run, SQLsaber walks you through:
-
-1. **Database connection** — Choose your database type and enter connection details
-2. **Authentication** — Enter your AI provider API key; credentials are stored in your OS keychain
-
-<Aside type="note">
-**Need a test database?** Download the legislators SQLite file:
+## 1. Download the sample database
 
 ```bash
 curl -L -o legislators.db https://github.com/SarthakJariwala/sqlsaber/raw/refs/heads/main/legislators.db
 ```
 
-</Aside>
+You should now have `legislators.db` in the current directory.
 
-## 3. Ask your first question
+To use your own database instead, see [Database setup](/guides/database-setup/).
 
-After setup completes, you're in interactive mode. Try:
+## 2. Start SQLsaber
+
+```bash
+saber -d ./legislators.db
+```
+
+On first launch, SQLsaber asks you to choose an AI provider and enter an API key. It stores the key in your operating system credentials store.
+
+After setup you should see the interactive prompt.
+
+## 3. Ask a question
 
 ```
 > How many VPs have become presidents via election in the 20th century?
 ```
 
-SQLsaber will:
+SQLsaber lists relevant tables, reads their schema, writes SQL, runs the query, and explains the result. You should see the generated SQL and a short answer.
 
-1. **Discover** relevant tables
-2. **Analyze** their schema
-3. **Generate** SQL
-4. **Execute** and explain results
+To leave interactive mode, type `/exit` or press Ctrl+D.
 
 <script
   src="https://asciinema.org/a/39e71PIiGJetHBPy08L1TOotB.js"
@@ -74,45 +48,37 @@ SQLsaber will:
   async="true"
 ></script>
 
-## Interactive mode commands
+Type `/help` for slash commands. Type `@` and press Tab to complete a table name. The full list is in [Commands](/reference/commands/#interactive-mode).
 
-| Command      | Action                                 |
-| ------------ | -------------------------------------- |
-| `/clear`     | Clear conversation history             |
-| `/exit`      | Exit SQLsaber                          |
-| `@tablename` | Autocomplete table names               |
-
-## Non-interactive mode
-
-Run single queries without entering the REPL:
+## Ask a question without the prompt
 
 ```bash
-# Direct query
-saber "How many users signed up this week?"
+saber -d ./legislators.db "How many VPs became president by election in the 20th century?"
+```
 
-# Specific database
-saber -d production "Show me failed payments"
+Pipe a question:
 
-# Pipe from stdin
+```bash
 echo "Top 10 customers by revenue" | saber
+```
 
-# Save output
+Write the answer to a file:
+
+```bash
 saber "Monthly active users" > report.md
 ```
 
+## If setup fails
+
+If you see `No database connections configured`, run `saber db add mydb`.
+
+If you see `Authentication not configured`, run `saber auth setup`.
+
+If you see `Database connection failed`, run `saber db test mydb`.
+
 ## Next steps
 
-- **[Add knowledge](/guides/knowledge)** — Store searchable KPI definitions and SQL patterns
-- **[Resume threads](/guides/threads)** — Continue past conversations
-- **[Configure models](/guides/models)** — Switch AI providers or models
-- **[Database setup](/guides/database-setup)** — SSL, connection strings, multiple databases
-
-## Troubleshooting
-
-| Error                                | Fix                                  |
-| ------------------------------------ | ------------------------------------ |
-| "No database connections configured" | Run `saber db add mydb`              |
-| "Authentication not configured"      | Run `saber auth setup`               |
-| "Database connection failed"         | Run `saber db test mydb` to diagnose |
-
-For command reference, see [`saber --help`](/reference/commands) or the [full documentation](/).
+- [Database setup](/guides/database-setup/) to connect PostgreSQL, MySQL, SQLite, DuckDB, CSV, or Parquet
+- [Knowledge base](/guides/knowledge/) to store KPI definitions and SQL patterns
+- [Conversation threads](/guides/threads/) to resume a later session
+- [Models](/guides/models/) to change the AI provider or model

--- a/docs/src/content/docs/guides/knowledge.mdx
+++ b/docs/src/content/docs/guides/knowledge.mdx
@@ -1,75 +1,69 @@
 ---
-title: Knowledge Base
-description: "Store reusable KPI definitions, SQL patterns, and business context in SQLsaber's knowledge base. Searchable, database-scoped entries for better query generation."
+title: Knowledge base
+description: Save KPI definitions, SQL patterns, and domain notes. SQLsaber searches database-scoped entries when a question matches.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber includes a knowledge base for storing reusable context such as metric definitions, query patterns, and domain terminology.
+Save reusable business context so SQLsaber answers the same metric the same way.
 
 Knowledge entries are:
 
-- Database-specific
-- Persisted locally (SQLite by default)
-- Retrieved by the built-in `search_knowledge` tool when relevant
+- Scoped to one database
+- Stored locally, in SQLite by default
+- Retrieved by the built-in `search_knowledge` tool when they match the question
 
-Use knowledge as the default place to store reusable business context, metric definitions, and query patterns.
+## Add an entry
 
-### Add Knowledge
-
-Add entries with a required `name` and `description`, plus optional `--sql` and `--source`.
+`name` and `description` are required. `--sql` and `--source` are optional.
 
 ```bash
-# Add to default database
+# Add to the default database
 saber knowledge add "Revenue KPI" "Recognized revenue from shipped orders only"
 
-# Add SQL pattern and source reference
+# Add a SQL pattern and a source
 saber knowledge add "Monthly revenue rollup" \
   "Use shipped orders for monthly recognized revenue" \
   --sql "SELECT date_trunc('month', shipped_at) AS month, SUM(amount) FROM orders WHERE status = 'shipped' GROUP BY 1" \
   --source "finance-wiki"
 
-# Add to a specific configured database
+# Add to a named connection
 saber knowledge add "NRR formula" "Net Revenue Retention excludes new logo revenue" -d prod-db
 ```
 
-For long descriptions or SQL, keep content in files and pass it in:
+For long text, read from files:
 
 ```bash
-# Long description from a file
 saber knowledge add "Revenue definition" "$(cat ./knowledge/revenue_definition.md)"
 
-# Long description + long SQL from files
 saber knowledge add "Monthly revenue rollup" "$(cat ./knowledge/monthly_revenue_notes.md)" \
   --sql "$(cat ./sql/monthly_revenue_rollup.sql)" \
   --source "finance-wiki"
 ```
 
 <Aside type="tip">
-Use specific names and include searchable terms in descriptions, so retrieval works better.
+Use specific names. Put searchable terms in the description so retrieval can match them.
 </Aside>
 
-### List, Search, and Inspect
-
-List all entries:
+## List, search, and inspect
 
 ```bash
 saber knowledge list
 ```
 
-Search entries by keyword (default limit is 10):
+Search by keyword. The default limit is 10:
 
 ```bash
 saber knowledge search "revenue shipped" --limit 5
 ```
 
-Show a full entry by ID:
+Show one entry by ID:
 
 ```bash
 saber knowledge show a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
-### Remove or Clear
+## Remove entries
 
 Remove one entry:
 
@@ -80,7 +74,7 @@ saber knowledge remove a1b2c3d4-e5f6-7890-abcd-ef1234567890
 saber knowledge remove a1b2c3d4-e5f6-7890-abcd-ef1234567890 --yes
 ```
 
-Clear all entries for a database:
+Clear every entry for a database:
 
 ```bash
 saber knowledge clear
@@ -89,21 +83,22 @@ saber knowledge clear
 saber knowledge clear --yes
 ```
 
-### How the Tool Is Used
+## How the agent uses knowledge
 
-You do not invoke `search_knowledge` manually in normal chat flow. The SQLsaber agent calls it when it needs context about definitions, terms, or known SQL patterns.
+You do not call `search_knowledge` in chat. The SQLsaber agent calls it when it needs a definition, a term, or a known SQL pattern.
 
-Search results are scoped to the active database, so entries saved for one database do not leak into another.
+Search is scoped to the active database. Entries saved for one database do not appear in another.
 
-### Python API (Optional)
+## Inject a store from Python
 
-You can inject your own knowledge manager/store via the Python API:
+If you already own a knowledge store, pass it into `SQLSaberOptions`:
 
 ```python
 import asyncio
 
 from sqlsaber import SQLSaber, SQLSaberOptions
 from sqlsaber.knowledge import KnowledgeManager, SQLiteKnowledgeStore
+
 
 async def main() -> None:
     manager = KnowledgeManager(store=SQLiteKnowledgeStore(db_path="knowledge.db"))
@@ -123,23 +118,19 @@ async def main() -> None:
             knowledge_manager=manager,
         )
     ) as saber:
-        answer = await saber.query("How do we define gross margin?")
-        print(answer)
+        result = await saber.query("How do we define gross margin?")
+        print(result.text)
 
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-### Getting Help
+See [Advanced](/sdk/advanced/#inject-a-knowledge-base) for lifecycle details.
 
-```bash
-saber knowledge --help
-saber knowledge add --help
-saber knowledge search --help
-```
+See `saber knowledge --help`, or [Commands](/reference/commands/#saber-knowledge).
 
-### What's Next?
+## Next steps
 
-1. [Run natural-language queries](/guides/queries)
-2. [Review all command options](/reference/commands)
+1. [Run a query](/guides/queries/)
+2. [Command reference](/reference/commands/)

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -1,73 +1,64 @@
 ---
 title: Models
-description: "Choose and configure AI models for SQL generation in SQLsaber. Supports Claude, GPT, Gemini, and other LLMs with extended thinking modes."
+description: Choose the model SQLsaber uses for SQL generation. Set the default, override subagents, and configure thinking.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber supports many LLM models across different providers.
+Pick the model SQLsaber uses for queries.
 
-This guide covers model selection, configuration, and recommendations for the best SQL query generation.
-
-### Default Model
+## Default model
 
 SQLsaber uses `openai:gpt-5.6-sol` when no model is configured. `saber models reset` writes that same identifier.
 
-### Recommended Models
+## Recommended models
 
-While SQLsaber supports a lot of models, we recommend the following for best results:
+These models produce strong SQL in practice:
 
-- Claude Opus 5
-- Gemini 3.1 Pro, 3.5 Flash or later
-- Codex-5.3, 5.2, GPT-5.4, 5.5 or later
-- Grok 4.6 (`xai:grok-4.6`)
+- `anthropic:claude-opus-5`
+- `openai:gpt-5.6-sol`
+- `google:gemini-2.5-pro`
+- `xai:grok-4.6`
 
-<Aside type="tip">
-  Consider using one of the recommended models for best results.
-</Aside>
+The picker also ranks a default for Groq, Mistral, and Cohere when those providers are configured. See `saber models list`.
 
-### Model Management
-
-#### List Available Models
+## List available models
 
 ```bash
 saber models list
 ```
 
-#### Set Your Default Model
-
-Change the default model:
+## Set the default model
 
 ```bash
 saber models set
 ```
 
-This interactive command lets you:
+This command lets you:
 
-1. Choose from configured providers
-2. Select a specific model
-3. Set it as your default
+1. Choose a configured provider
+2. Select a model
+3. Save it as the default
 4. Configure thinking
 
 <Aside type="tip">
-  This list is long - type to search and filter the list.
+  The list is long. Type to search and filter it.
 </Aside>
 
-For scripts and coding agents, set the model and thinking level directly without
-fetching the model list or opening a prompt:
+For scripts and coding agents, set the model and thinking level without fetching the list:
 
 ```bash
 saber models set openai:gpt-5 --thinking-level medium
 ```
 
-#### Subagent Overrides
+## Override a subagent model
 
-You can override the model used by subagents like handoff and viz without changing
-the main model:
+Set a model for handoff, viz, or notebook without changing the main model:
 
 ```bash
 saber models set --agent handoff
 saber models set --agent viz
+saber models set --agent notebook
 
 # Direct, non-interactive override
 saber models set openai:gpt-5 --agent handoff
@@ -75,28 +66,24 @@ saber models set openai:gpt-5 --agent handoff
 
 If no override is set, the subagent uses the main model.
 
-#### Reset to Default
-
-Return to `openai:gpt-5.6-sol`:
+## Reset to the default
 
 ```bash
 saber models reset
 saber models reset --yes
 ```
 
-### Getting Help
+This writes `openai:gpt-5.6-sol` again.
 
-Check your current model and available options:
+## Check the current model
 
 ```bash
 saber models current
 saber models --help
 ```
 
-### What's Next?
+## Next steps
 
-After configuring your models:
-
-1. [Learn different ways to query your data](/guides/queries)
-2. [Manage conversation threads](/guides/threads)
-3. [Explore the command reference](/reference/commands)
+1. [Run a query](/guides/queries/)
+2. [Resume a conversation](/guides/threads/)
+3. [Command reference](/reference/commands/)

--- a/docs/src/content/docs/guides/multi-database.mdx
+++ b/docs/src/content/docs/guides/multi-database.mdx
@@ -1,57 +1,48 @@
 ---
-title: Multiple Databases
-description: "Connect a single SQLsaber session to several databases at once. Query each database separately and let the agent combine the results."
+title: Multiple databases
+description: Connect one SQLsaber session to several databases. Query each database separately and let the agent combine the answers.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-A single SQLsaber session can connect to more than one database at the same time.
-The agent picks which database to query for each step, runs the queries separately,
-and combines the results in its answer. You can ask a question that spans several
-databases without switching sessions.
+Connect one SQLsaber session to more than one database. The agent picks a database for each step, runs those queries separately, and combines the answers.
 
 <Aside type="note">
-  SQLsaber does **not** attempt cross-database JOINs. When multiple databases
-  are connected, the agent queries each one independently and stitches the
-  results together in plain language in its reply.
+  SQLsaber does not run cross-database JOINs. It queries each database on its
+  own and combines the results in the reply.
 </Aside>
 
-### Starting a multi-database session
+## Start a multi-database session
 
-Connect to multiple databases by repeating the `-d` / `--database` flag. Each
-value can be a configured connection name, a connection string, or a file path.
-You can mix these target types freely.
+Repeat `-d` or `--database`. Each value can be a saved connection name, a connection string, or a file path. Mix those forms.
 
 ```bash
-# Two configured connections
+# Two saved connections
 saber -d sales -d analytics "Compare last month's revenue to web sessions"
 
-# Mix a configured name with a connection string
+# Mix a saved name with a connection string
 saber -d sales -d "postgresql://user:pass@host:5432/events" "..."
 
-# Start interactive mode across several databases
+# Interactive mode across several databases
 saber -d sales -d analytics -d inventory
 ```
 
-Everything works the same in single-query mode and interactive mode. In
-interactive mode the footer shows all connected databases:
+Single-query mode and interactive mode both work. In interactive mode the footer lists every connected database:
 
 ```
 DBs: sales, analytics, inventory | Model: ... | ...
 ```
 
 <Aside type="caution">
-  Each connected database must resolve to a **unique name**. Connecting two
-  databases that resolve to the same name (for example the same connection used
-  twice) raises an error. Names come from the configured connection name, or are
-  derived from the database/file name for ad-hoc connection strings and paths.
+  Each connected database must resolve to a unique name. Connecting two
+  databases that share a name raises an error. The name is the saved connection
+  name, or a name derived from the database or file for ad-hoc strings and
+  paths.
 </Aside>
 
-#### CSV and Parquet files are different
+### CSV and Parquet files are different
 
-Passing **multiple CSV/Parquet files** does not create a multi-database session. Instead,
-all files are loaded into a single in-memory DuckDB database with one table per
-file, so you can join across them:
+Passing several CSV or Parquet files does not create a multi-database session. SQLsaber loads every file into one in-memory DuckDB database, with one table per file, so you can join across them:
 
 ```bash
 saber -d users.csv -d orders.csv "Join users and orders"
@@ -59,15 +50,11 @@ saber -d users.csv -d orders.parquet "Revenue by user"
 saber -d users.parquet -d orders.parquet "Join users and orders"
 ```
 
-When repeated targets include another database type or a configured connection,
-each target instead resolves independently into a multi-database session.
+If the repeated targets include another database type or a saved connection, each target resolves on its own into a multi-database session.
 
-### Describing connections
+## Describe connections
 
-When several databases are connected, the agent needs to decide which one holds
-the data for a given question. You can help it by attaching a short description
-to each connection. Descriptions are shown to the agent (and surfaced by the
-`list_dbs` tool) but are otherwise optional.
+When several databases are connected, the agent has to choose which one holds the data. Attach a short description to each connection. Descriptions are shown to the agent, and by the `list_dbs` tool. They are otherwise optional.
 
 ```bash
 saber db add sales \
@@ -77,48 +64,35 @@ saber db add analytics \
   --description "ClickHouse warehouse: web sessions, events, funnels"
 ```
 
-You can add a description to any connection. See [Database Setup](/guides/database-setup)
-for the full `saber db add` flow.
+Add a description to any connection. See [Database setup](/guides/database-setup/) for `saber db add`.
 
 <Aside type="tip">
-  Clear, distinct descriptions noticeably improve how reliably the agent routes
-  a question to the right database. Mention the kind of data each connection
-  holds (tables, domains, environments).
+  Distinct descriptions help the agent route a question. Name the kind of data
+  each connection holds: tables, domains, or environments.
 </Aside>
 
-### How the agent routes queries
+## How the agent routes queries
 
-When more than one database is connected, the agent's behavior changes in a few
-ways:
+When more than one database is connected:
 
-- **`db_name` on every tool call.** The SQL and knowledge tools require a
-  `db_name` argument that names the target database. The agent must choose a
-  connected database for each `list_tables`, `introspect_schema`,
-  `execute_sql`, and knowledge-base call.
-- **A `list_dbs` tool.** A dedicated tool lists every connected database with
-  its name, dialect, and description, so the agent can see its options before
-  exploring schemas.
-- **Per-database knowledge.** [Knowledge entries](/guides/knowledge) remain
-  scoped per database, so each connection contributes its own context.
+- SQL and knowledge tools require a `db_name` argument. The agent must choose a connected database for each `list_tables`, `introspect_schema`, `execute_sql`, and knowledge-base call.
+- A `list_dbs` tool lists every connected database with its name, dialect, and description.
+- [Knowledge entries](/guides/knowledge/) stay scoped per database. Each connection contributes its own context.
 
-In single-database sessions none of this is visible. The tool schemas and system
-prompt are identical to before, and there is no `db_name` argument or `list_dbs`
-tool.
+In a single-database session none of this is visible. Tool schemas have no `db_name` argument, and there is no `list_dbs` tool.
 
-### Resuming multi-database threads
+## Resume a multi-database thread
 
-[Conversation threads](/guides/threads) created in a multi-database session
-record all of the connected databases. When you resume such a thread, SQLsaber
-reconnects to the same set automatically:
+[Conversation threads](/guides/threads/) created in a multi-database session record every connected database. When you resume that thread, SQLsaber reconnects to the same set:
 
 ```bash
 saber threads resume a1b2c3d4
 ```
 
 <Aside type="note">
-  Automatic resume only works when **every** database in the thread is a saved
-  connection (added with `saber db add`). If a thread used an ad-hoc connection
-  string or file path, resume it with explicit `-d` flags:
+  Automatic resume works only when every database on the thread is a saved
+  connection (added with `saber db add`). If a thread used a connection string
+  or file path, resume it with explicit `-d` flags:
 
 ```bash
 saber threads resume a1b2c3d4 -d sales -d "postgresql://user:pass@host:5432/events"
@@ -126,11 +100,9 @@ saber threads resume a1b2c3d4 -d sales -d "postgresql://user:pass@host:5432/even
 
 </Aside>
 
-### Using the Python SDK
+## Use the Python SDK
 
-The SDK exposes the same capability through `SQLSaberOptions`. Pass a list of
-targets to connect to multiple databases at once. Use `saber.info.database_names`
-when you need metadata only:
+Pass a list of targets in `SQLSaberOptions`. Read names from `saber.info.database_names` when you need metadata only:
 
 ```python
 import asyncio
@@ -152,11 +124,10 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-See the [SDK Configuration guide](/sdk/configuration) for the full set of
-options.
+See [Configuration](/sdk/configuration/) for the full options list.
 
-### What's Next?
+## Next steps
 
-- [Database Setup](/guides/database-setup) — register and describe connections
-- [Knowledge Base](/guides/knowledge) — give each database extra context
-- [Conversation Threads](/guides/threads) — resume multi-database sessions
+- [Database setup](/guides/database-setup/) to register and describe connections
+- [Knowledge base](/guides/knowledge/) to give each database extra context
+- [Conversation threads](/guides/threads/) to resume a multi-database session

--- a/docs/src/content/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/guides/plugins.mdx
@@ -3,7 +3,13 @@ title: Plugins
 description: Add terminal charts, sandboxed notebook analysis, and remote Python execution to SQLsaber.
 ---
 
-Install a plugin beside SQLsaber with `uv tool install --with`. The `saber` CLI loads installed plugins from the `sqlsaber.capabilities` entry-point group.
+Install a plugin beside SQLsaber by passing the plugin package in `--with`:
+
+```bash
+uv tool install --with sqlsaber-viz sqlsaber
+```
+
+The `saber` CLI loads installed plugins from the `sqlsaber.capabilities` entry-point group.
 
 An embedded `SQLSaber` session does not load installed plugins. Import the plugin factories you want and list them in `SQLSaberOptions.capabilities`. See [Capabilities](/sdk/capabilities/).
 

--- a/docs/src/content/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/guides/plugins.mdx
@@ -1,33 +1,27 @@
 ---
 title: Plugins
-description: "Extend SQLsaber with plugins for terminal chart visualization and secure Python sandbox execution. Build and register custom tools."
+description: Add terminal charts, sandboxed notebook analysis, and remote Python execution to SQLsaber.
 ---
 
-SQLsaber supports optional plugins that extend its capabilities. Plugins are installed alongside SQLsaber using `uv tool install --with`.
+Install a plugin beside SQLsaber with `uv tool install --with`. The `saber` CLI loads installed plugins from the `sqlsaber.capabilities` entry-point group.
 
-The `saber` CLI loads installed plugins from the `sqlsaber.capabilities` entry-point group. An embedded `SQLSaber` session does not. Import the plugin factories you want and list them in `SQLSaberOptions.capabilities`. See [Capabilities](/sdk/capabilities).
+An embedded `SQLSaber` session does not load installed plugins. Import the plugin factories you want and list them in `SQLSaberOptions.capabilities`. See [Capabilities](/sdk/capabilities/).
 
-You can even write your own plugins and make them available to SQLsaber to use.
+## Visualization
 
-## Visualization Plugin
-
-The visualization plugin renders charts directly in your terminal from query results.
-
-### Installation
+The visualization plugin renders charts in the terminal from query results.
 
 ```bash
 uv tool install --with sqlsaber-viz sqlsaber
 ```
 
-Or if you already have SQLsaber installed:
+If SQLsaber is already installed:
 
 ```bash
 uv tool install --with sqlsaber-viz --force sqlsaber
 ```
 
-### Usage
-
-After running a query, ask for a visualization in natural language:
+After a query, ask for a chart:
 
 ```
 > Show me the top 10 customers by revenue
@@ -39,116 +33,71 @@ After running a query, ask for a visualization in natural language:
 | ...           | ...           |
 
 > Plot that as a bar chart
-
-┌────────────────────────────────────────────────────┐
-│ ███████████████████████████████████████████  50000 │
-│ ██████████████████████████████████████       45000 │
-│ ...                                                │
-└────────────────────────────────────────────────────┘
 ```
 
-### Supported Chart Types
+You do not need to name the chart type. Describe what you want to see. SQLsaber picks among bar, line, scatter, histogram, and boxplot from the data.
 
-| Chart Type    | Best For                                      |
-| ------------- | --------------------------------------------- |
-| **Bar**       | Comparing categories, rankings, distributions |
-| **Line**      | Time series, trends over time                 |
-| **Scatter**   | Correlations between two numeric variables    |
-| **Histogram** | Distribution of a single numeric variable     |
-| **Boxplot**   | Statistical distribution across categories    |
+## Notebook analysis
 
-You don't need to specify the chart type explicitly. Just describe what you
-want to see and SQLsaber will pick the appropriate chart type based on your
-data.
+The notebook plugin runs multi-step analysis in a sandbox. It uses prior SQL results for calculations, statistics, transformations, and plots. Bounded notebooks and plot previews appear in the terminal. Notebook bytes and images are not sent to the parent model.
 
----
+```bash
+uv tool install --with sqlsaber-notebook sqlsaber
+```
 
-## Python Sandbox Plugin
+Docker is the default local backend. After a query, ask SQLsaber to analyze or plot the results.
 
-The sandbox plugin lets SQLsaber run Python code in a secure remote sandbox. This is useful for calculations, stats, or data transformations that are easier in Python than SQL.
+Set a dedicated notebook model without changing the main model:
 
-### Installation
+```bash
+saber models set --agent notebook
+```
+
+Select a backend with `SQLSABER_NOTEBOOK_BACKEND`. Backends never fall back automatically.
+
+| Backend | Where it runs | Notes |
+| ------- | ------------- | ----- |
+| Docker | Local | Default |
+| Microsandbox | Local microVM | Install the `microsandbox` extra. Query results stay on the machine. |
+| Modal | Remote | Query results are uploaded to a third party. |
+| Daytona | Remote | Query results are uploaded to the configured Daytona service. |
+
+```bash
+uv tool install --with 'sqlsaber-notebook[microsandbox]' sqlsaber
+SQLSABER_NOTEBOOK_BACKEND=microsandbox saber
+```
+
+For an embedded `SQLSaber` session, list the notebook factory in `SQLSaberOptions.capabilities`. Persist notebooks and plots with `SQLSaberOptions.artifact_store`. See [Results and streaming](/sdk/results-and-streaming/#notebook-and-plot-artifacts).
+
+## Python sandbox
+
+The sandbox plugin runs Python in a remote sandbox. Use it for calculations that are easier in Python than in SQL.
 
 ```bash
 uv tool install --with sqlsaber-sandbox sqlsaber
 ```
 
-### Configuration
+Configure at least one provider:
 
-You need to configure at least one sandbox provider:
-
-| Provider   | Environment Variable                                   |
+| Provider   | Environment variable                                   |
 | ---------- | ------------------------------------------------------ |
 | Daytona    | `DAYTONA_API_KEY`                                      |
 | E2B        | `E2B_API_KEY`                                          |
 | Sprites    | `SPRITES_TOKEN`                                        |
 | Hopx       | `HOPX_API_KEY`                                         |
 | Modal      | `MODAL_TOKEN_ID` or `~/.modal.toml`                    |
-| Cloudflare | `CLOUDFLARE_SANDBOX_BASE_URL` + `CLOUDFLARE_API_TOKEN` |
+| Cloudflare | `CLOUDFLARE_SANDBOX_BASE_URL` and `CLOUDFLARE_API_TOKEN` |
 
-When at least one provider is configured, the agent can use a `run_python` tool to execute Python code in that sandbox. If no provider is configured, the tool is not available.
+When a provider is configured, the agent can call `run_python`. If none is configured, the tool is not available.
 
----
-
-## Installing Multiple Plugins
-
-You can install multiple plugins at once:
+## Install several plugins
 
 ```bash
-uv tool install --with sqlsaber-viz,sqlsaber-sandbox sqlsaber
+uv tool install --with sqlsaber-viz,sqlsaber-notebook,sqlsaber-sandbox sqlsaber
 ```
 
-## Building a plugin
+## Build a plugin
 
-Plugins ship pydantic-ai capabilities through an entry point:
+Export a capability factory through the `sqlsaber.capabilities` entry-point group. See [Capabilities](/sdk/capabilities/#build-a-plugin-capability) for the factory contract, `PluginContext`, and display-tool registration.
 
-```toml
-[project.entry-points."sqlsaber.capabilities"]
-my_plugin = "my_plugin:capability"
-```
-
-A typical one-tool plugin is small:
-
-```python
-from pydantic_ai.capabilities import Capability
-from sqlsaber.capabilities.plugins import PluginContext
-
-
-def my_tool(value: str) -> str:
-    """Process a value using my application."""
-    return value
-
-
-def capability(context: PluginContext):
-    return Capability(
-        id="my-plugin",
-        description="Process values with my application.",
-        tools=[my_tool],
-    )
-```
-
-The factory receives a `PluginContext` containing SQLsaber's database registry,
-knowledge manager, dangerous-mode setting, normalized tool model overrides, the
-session's required `query_result_store`, and the optional application-owned
-`artifact_store`. Plugins that consume SQL rows should use
-`query_result_references_from_messages()` and `resolve_query_result()` instead of
-parsing `execute_sql` content; this provides verified complete bytes, current-context
-authorization, and the compatibility-only legacy fallback.
-It can return one capability or a sequence. See the [Capabilities SDK guide](/sdk/capabilities) for standalone composition and lifecycle details.
-
-Plugins that can reconstruct durable results during `saber threads show` may also
-register context-free display tools:
-
-```toml
-[project.entry-points."sqlsaber.display_tools"]
-my_plugin = "my_plugin:display_tools"
-```
-
-The factory takes no arguments and returns a mapping from tool name to `Tool`
-renderer. These renderers must not require live execution resources; SQLsaber may
-supply verified resolved artifact publications through
-`set_resolved_artifact_publications()` before replay.
-
-:::caution[Plugin API change]
-The former `sqlsaber.tools` entry-point group and global `ToolRegistry` no longer load. Existing plugins should keep their execution function or `Tool` class, wrap it in a capability, and export a `capability(context)` factory through `sqlsaber.capabilities`.
-:::
+The former `sqlsaber.tools` entry-point group and global `ToolRegistry` no longer load. Keep your execution function or `Tool` class, wrap it in a capability, and export `capability(context)` through `sqlsaber.capabilities`.

--- a/docs/src/content/docs/guides/queries.mdx
+++ b/docs/src/content/docs/guides/queries.mdx
@@ -1,15 +1,13 @@
 ---
-title: Running Queries
-description: "Query databases using natural language with SQLsaber. Interactive REPL, single-shot CLI queries, stdin piping, extended thinking, and table autocomplete."
+title: Running queries
+description: Ask SQLsaber questions in interactive mode, as a single CLI query, or from stdin. Control thinking, handoff, and write access.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber offers multiple ways to query your database using natural language. This guide covers all the different query modes and their use cases.
+Ask a question about your data. SQLsaber writes SQL, runs it, and explains the result.
 
-### Interactive Mode
-
-Ideal for back and forth conversations about your data.
+## Start interactive mode
 
 ```bash
 saber
@@ -21,96 +19,58 @@ saber
   async="true"
 ></script>
 
-### Single Query Mode
+Type `/help` for slash commands. Type `@` and press Tab to complete a table name. The full list is in [Commands](/reference/commands/#interactive-mode).
 
-Run a one-off query without entering interactive mode:
+## Ask one question
 
 ```bash
 saber "How many orders were placed last week?"
 ```
 
-Useful for:
+Use this in scripts, for a quick check, or for a one-line report.
 
-- Shell scripting
-- Quick checks
-- Automated reporting
-
-### Stdin Mode
-
-Pipe queries from other commands or files:
+## Pipe a question
 
 ```bash
-# From echo
 echo "Count all active customers from last week" | saber
 
-# From file
 cat query.txt | saber
-
-# From other commands
-curl -s https://api.example.com/query | saber
 ```
 
-Useful for:
+## Select a database
 
-- Shell scripting
-- Batch processing
-- Integration with other tools
-- Automation
+If a default connection exists:
 
-### Features
-
-#### Slash Commands
-
-Special commands in interactive mode:
-
-- `/clear` - Clear conversation history
-- `/exit` or `/quit` - Exit SQLsaber
-- `/thinking on` - Enable extended thinking mode
-- `/thinking off` - Disable extended thinking mode
-- `/handoff <goal>` - Start a fresh thread with context from current conversation
-
-```
-> /clear
-Conversation history cleared.
-
-> /thinking on
-✓ Thinking enabled
-
-> /exit
-Goodbye!
+```bash
+saber "Show me sales data"
 ```
 
-#### Table Autocomplete
+To use a saved connection by name:
 
-Type `@` followed by a table name to get autocomplete suggestions:
-
-```
-> Show me all records from @cus[TAB]
-> Show me all records from @customers
+```bash
+saber -d prod-db "What's our revenue this month?"
 ```
 
-Supports schema-aware completions:
+To use a local file:
 
+```bash
+saber -d "./data/sales.db" "Top selling products"
+saber -d "./data/warehouse.duckdb" "Latest partitions"
+saber -d "./customers.csv" "How many customers per state?"
+saber -d "./orders.parquet" "What is total revenue?"
 ```
-> @pub[TAB] → @public.customers
+
+To use a connection string for this run only:
+
+```bash
+saber -d "postgresql://user:pass@host:5432/db" "Count all users"
 ```
 
-#### Extended Thinking Mode
+## Turn thinking on or off
 
-A fresh install has thinking on at medium. Change the level or turn thinking off when a query does not need it.
+A fresh install has thinking on at medium. Raise the level for harder analysis. Turn thinking off when the question is small.
 
-**Thinking Levels:**
-
-| Level     | Use Case           | Description                           |
-| --------- | ------------------ | ------------------------------------- |
-| `off`     | Disable            | No extended thinking                  |
-| `minimal` | Quick responses    | Minimal reasoning overhead            |
-| `low`     | Light reasoning    | Faster, cheaper                       |
-| `medium`  | Balanced (default) | Good balance of cost and quality      |
-| `high`    | Deep reasoning     | More thorough analysis                |
-| `maximum` | Complex problems   | Highest reasoning depth, highest cost |
-
-**In interactive mode:**
+In interactive mode:
 
 ```
 > /thinking
@@ -120,169 +80,73 @@ Thinking: enabled (medium)
 ✓ Thinking: enabled (high)
 
 > Analyze sales trends and forecast next quarter
-💭 Thinking...
-[reasoning process appears here]
-[followed by final answer]
 
 > /thinking off
 ✓ Thinking: disabled
 ```
 
-**For single queries:**
+For a single query:
 
 ```bash
-# Enable thinking for complex analysis
 saber --thinking "Compare performance across regions with seasonal adjustments"
 
-# Disable for simple queries
 saber --no-thinking "How many users do we have?"
 ```
 
-**Configuring thinking level:**
+To save a default level, run `saber models set` and answer the thinking prompts. Check the saved values with `saber models current`.
 
-Use `saber models set` to configure thinking level after selecting a model:
+Levels are `off`, `minimal`, `low`, `medium`, `high`, and `maximum`. Each level maps to a provider setting:
 
-```bash
-saber models set
-# After selecting model, you'll be prompted:
-# ? Configure thinking mode? [Y/n]: y
-# ? Select thinking level: medium (Recommended)
-```
-
-Check current settings with:
-
-```bash
-saber models current
-# Current model: anthropic:claude-sonnet-4-5-20250929
-# Thinking: enabled (medium)
-```
-
-**Provider-specific mapping:**
-
-Each thinking level maps to provider-specific configurations:
-
-- **Anthropic**: `budget_tokens` (1,024 → 100,000)
-- **OpenAI**: `reasoning_effort` (minimal → xhigh)
-- **Google**: `thinking_level` (MINIMAL → HIGH)
-- **Groq**: Binary (any non-off level enables reasoning)
+- Anthropic: `budget_tokens` from 1,024 to 100,000
+- OpenAI: `reasoning_effort` from minimal to xhigh
+- Google: `thinking_level` from MINIMAL to HIGH
+- Groq: any non-off level enables reasoning
 
 <Aside type="note">
   Extended thinking is supported for Anthropic, OpenAI, Google, and Groq
   reasoning models.
 </Aside>
 
-#### Handoff
+## Start a fresh thread with context
 
-When your conversation gets long or you want to start fresh while preserving context, use the `/handoff` command:
+When the conversation is long, or you want a new direction without losing what you found, run `/handoff`:
 
 ```
 > /handoff optimize the monthly revenue query for better performance
 ```
 
-The handoff:
+SQLsaber summarizes the conversation, shows an editable draft prompt, ends the current thread, and starts a new one with that prompt.
 
-1. Summarizes your conversation (tables discovered, SQL queries run, key findings)
-2. Presents an editable draft prompt
-3. Ends the current thread and starts fresh with your edited prompt
+## Allow writes
 
-<Aside type="tip">
-  Use handoff when you want to pivot to a new direction while keeping relevant
-  history.
-</Aside>
-
-#### Dangerous Mode
-
-By default, SQLsaber only allows read-only SELECT queries. To enable write operations, use the `--allow-dangerous` flag:
+SQLsaber allows `SELECT` only unless you pass `--allow-dangerous`:
 
 ```bash
-# Single query with write access
 saber --allow-dangerous "Insert a new user with email test@example.com"
 
-# Interactive mode with write access
 saber --allow-dangerous
 ```
 
 <Aside type="caution">
-  This mode allows data modifications and a restricted subset of DDL. Use with
-  caution as these can modify your data.
+  This mode allows data changes and a restricted subset of DDL. Review the
+  generated SQL before you rely on it.
 </Aside>
 
-**What's allowed in dangerous mode:**
+Dangerous mode allows `INSERT`, `UPDATE`, and `DELETE` (`UPDATE` and `DELETE` require `WHERE`), plus `CREATE TABLE`, `CREATE VIEW`, `CREATE INDEX`, and `ALTER TABLE`.
 
-- DML: INSERT, UPDATE, DELETE (UPDATE/DELETE require `WHERE`)
-- Restricted DDL:
-  - CREATE TABLE
-  - CREATE VIEW
-  - CREATE INDEX
-  - ALTER TABLE
+It still blocks `DROP`, `TRUNCATE`, transaction control, `GRANT`, `REVOKE`, `ATTACH`, `DETACH`, and admin objects such as functions, procedures, triggers, users, roles, and databases.
 
-**What's always blocked (even in dangerous mode):**
+The full policy is in [Commands](/reference/commands/#saber).
 
-- DROP, TRUNCATE (destructive operations)
-- Transaction control (BEGIN, COMMIT, ROLLBACK)
-- Security operations (GRANT, REVOKE)
-- Database operations (ATTACH, DETACH)
-- Admin/executable schema objects (e.g., CREATE FUNCTION/PROCEDURE/TRIGGER,
-  CREATE USER/ROLE/DATABASE)
-
-### Database Selection
-
-#### Using Default
-
-If you have a default database configured:
+## If the connection fails
 
 ```bash
-saber "Show me sales data"
-```
-
-#### Specifying Database by Name
-
-Use a configured database connection:
-
-```bash
-saber -d prod-db "What's our revenue this month?"
-```
-
-#### Using Files Directly
-
-Work with SQLite, DuckDB, CSV, or Parquet files directly:
-
-```bash
-# SQLite file
-saber -d "./data/sales.db" "Top selling products"
-
-# DuckDB file
-saber -d "./data/warehouse.duckdb" "Latest partitions"
-
-# CSV file
-saber -d "./customers.csv" "How many customers per state?"
-
-# Parquet file
-saber -d "./orders.parquet" "What is total revenue?"
-```
-
-#### Connection Strings
-
-Use connection strings for temporary connections:
-
-```bash
-saber -d "postgresql://user:pass@host:5432/db" "Count all users"
-```
-
-### Connection Issues
-
-```bash
-# Test the connection
 saber db test my-database
-
-# Check database list
 saber db list
 ```
 
-### What's Next?
+## Next steps
 
-Now that you know how to query effectively:
-
-1. [Learn about conversation threads](/guides/threads)
-2. [Explore the command reference](/reference/commands)
-3. [Configure advanced database settings](/guides/database-setup)
+1. [Resume a conversation](/guides/threads/)
+2. [Command reference](/reference/commands/)
+3. [Database setup](/guides/database-setup/)

--- a/docs/src/content/docs/guides/threads.md
+++ b/docs/src/content/docs/guides/threads.md
@@ -1,120 +1,85 @@
 ---
-title: Conversation Threads
-description: "Save, resume, and manage conversation threads in SQLsaber. Continue past database analysis sessions with full context preserved."
+title: Conversation threads
+description: List, show, resume, export, and prune saved SQLsaber conversations.
 ---
 
-SQLsaber automatically saves your conversations locally so that you can view, resume, and manage them.
+SQLsaber saves each conversation as a thread on your machine. Resume a thread to continue the same analysis.
 
-Threads allow you to pick up where you left off and track your analytical work over time.
+Complete SQL rows live in a private `query-results` directory. Notebooks, plots, and generated files live in a private `artifacts` directory. Thread messages keep short previews and references, not the full bytes. `show`, export, resume, visualization, sandbox, and notebook reload those files. Terminal and HTML views may still show a bounded table.
 
-Complete SQL row results are stored separately under SQLsaber's private user-data
-`query-results` directory; thread messages retain only stable bounded model
-projections and opaque descriptors. Show, export, resume, visualization, sandbox,
-and notebook paths hydrate complete data from that store without rewriting thread
-history. Terminal and HTML views may still intentionally render a bounded table.
+Resume never reopens an old notebook kernel. If a notebook is missing or invalid, replay lists the artifacts and notes that they are unavailable. If a query result or artifact is missing or corrupt, replay marks it unavailable. It does not rewrite the saved descriptor.
 
-Capability artifacts are stored separately under the private user-data `artifacts`
-directory. Thread messages retain only publication references, not notebook, image,
-or generated-file bytes. For retained notebook analyses, show and resume reconstruct
-bounded notebook cells and available plots and list generated-file locations. If the
-notebook is missing or invalid, replay falls back to the generic artifact listing
-with an availability notice. Resume is read-only: it never reopens an old notebook
-kernel.
+Prune deletes old threads, then removes unreferenced query results and artifacts older than a 24-hour creation-time grace period. Normal saves run that cleanup at most once a day.
 
-Thread retention is the source of truth for both CLI query-result and artifact
-retention. After pruning, SQLsaber removes unreferenced entries older than a 24-hour
-creation-time safety grace period. Normal saves run maintenance at most daily. If a
-query result or artifact is missing or corrupt, replay marks it unavailable rather
-than trusting or rewriting the historical descriptor.
-
-### Show All Threads
-
-View all your conversation threads:
+## List threads
 
 ```bash
 saber threads list
 ```
 
-### Show Full Conversation
-
-View the complete transcript of a thread:
+## Show a transcript
 
 ```bash
 saber threads show bb7b4d72
 ```
 
-### List Thread Artifacts
+## List thread artifacts
 
-List publication IDs, artifact names, kinds, sizes, and local URIs without replaying
-the full transcript:
+List publication IDs, artifact names, kinds, sizes, and local URIs without replaying the full transcript:
 
 ```bash
 saber threads artifacts bb7b4d72
 ```
 
-### Continue Previous Thread
-
-Resume an existing conversation thread:
+## Resume a thread
 
 ```bash
 saber threads resume bb7b4d72
 ```
 
-This:
-- Loads the full conversation context
-- Connects to the same database used in the original thread
-- Uses the currently configured model
-- Allows you to continue where you left off in interactive mode
+This loads the saved messages, reconnects to the databases stored on the thread, and uses the model you have configured now. You continue in interactive mode.
 
-For one non-interactive follow-up, pass the thread to the root query command:
+For one follow-up without the prompt, pass the thread to the root command:
 
 ```bash
 saber --thread bb7b4d72 "Now compare that with last quarter"
 ```
 
-This loads the saved message history, keeps the same thread ID, and uses the
-stored configured database. Pass `-d DATABASE` to override it.
+This keeps the same thread ID and the stored database. Pass `-d DATABASE` to override the database.
 
-### Prune Old Threads Safely
+Automatic resume requires every database on the thread to be a saved connection. If the thread used a connection string or file path, pass `-d` again. See [Multiple databases](/guides/multi-database/#resume-a-multi-database-thread).
 
-Preview cleanup before deleting anything:
+## Export a thread as HTML
+
+```bash
+saber threads export bb7b4d72
+saber threads export bb7b4d72 --output analysis.html
+```
+
+With no `--output`, SQLsaber writes `thread-<id>.html` in the current directory.
+
+## Preview prune, then delete old threads
 
 ```bash
 saber threads prune --days 30 --dry-run
 ```
 
-Run the deletion interactively, or make the intent explicit in automation:
+To delete, confirm in a terminal, or pass `--yes` in automation:
 
 ```bash
 saber threads prune --days 30 --yes
 ```
 
-### Sharing Threads
+## Share a transcript
 
 ```bash
-# Review what you analyzed
 saber threads show abc123 > analysis_report.md
-
-# Share the conversation transcript with colleagues
-cat analysis_report.md
 ```
 
-### Getting Help
+See `saber threads --help`, or [Commands](/reference/commands/#saber-threads).
 
-Check thread commands and options:
+## Next steps
 
-```bash
-saber threads --help
-saber threads list --help
-saber threads resume --help
-saber threads artifacts --help
-saber threads prune --help
-```
-
-### What's Next?
-
-Now that you understand conversation threads:
-
-1. [Learn advanced querying techniques](/guides/queries)
-2. [Explore model selection](/guides/models) for different thread purposes
-3. [Review the command reference](/reference/commands) for all thread options
+1. [Run a query](/guides/queries/)
+2. [Choose a model](/guides/models/)
+3. [Command reference](/reference/commands/)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Agentic SQL Assistant"
+title: "Agentic SQL assistant"
 description: "Open-source CLI and SDK that converts natural language to SQL. Query PostgreSQL, MySQL, SQLite, and DuckDB databases by asking questions in plain English. Schema-aware, read-only by default, with knowledge retrieval and conversation threads."
 template: splash
 hero:
-  tagline: Ask questions in plain English. SQLsaber reads your schema, writes SQL, runs it securely, and explains the results.
+  tagline: Ask questions in plain English. SQLsaber reads your schema, writes SQL, runs it read-only by default, and explains the results.
   actions:
     - text: Get started
       link: /installation/
@@ -29,9 +29,8 @@ import {
   <div class="max-w-3xl mx-auto">
     <Card title="ACM CAIS '26" icon="open-book">
       <p class="text-lg text-muted-foreground">
-        SQLsaber is featured in a paper accepted at the{" "}
+        SQLsaber appears in a paper at the{" "}
         <strong>ACM Conference on AI and Agentic Systems (CAIS '26)</strong>.
-        Read the publication for a deeper look at the approach behind the tool.
       </p>
       <div class="mt-6">
         <LinkButton
@@ -59,26 +58,26 @@ import {
   <CardGrid>
     <Card title="Schema-aware queries" icon="magnifier">
       <p class="text-lg text-muted-foreground">
-        <strong>Automatically introspects</strong> your database structure. No
-        manual schema documentation needed.
+        SQLsaber reads tables, columns, indexes, comments, and relationships
+        from the database. You do not maintain a separate schema file.
       </p>
     </Card>
     <Card title="Safe execution" icon="approve-check">
       <p class="text-lg text-muted-foreground">
-        <strong>Read-only by default.</strong> SQLsaber won't modify, delete, or
-        alter your data.
+        SQLsaber allows <code>SELECT</code> only unless you pass{" "}
+        <code>--allow-dangerous</code>.
       </p>
     </Card>
     <Card title="Knowledge base" icon="document">
       <p class="text-lg text-muted-foreground">
-        Store reusable KPI/query definitions and business semantics with{" "}
-        <code>saber knowledge add</code> so answers stay consistent.
+        Save KPI definitions and SQL patterns with{" "}
+        <code>saber knowledge add</code>. The agent searches them when a
+        question matches.
       </p>
     </Card>
     <Card title="Conversation threads" icon="comment-alt">
       <p class="text-lg text-muted-foreground">
-        Resume past conversations. Ask follow-up questions without repeating
-        context.
+        Resume a saved conversation without restating earlier context.
       </p>
     </Card>
   </CardGrid>
@@ -93,29 +92,22 @@ import {
       <li class="flex items-center gap-3">
         <Icon name="seti:db" />
         <span>
-          <strong>Databases:</strong> PostgreSQL, MySQL, SQLite, DuckDB, CSV
-          files
+          PostgreSQL, MySQL, SQLite, DuckDB, CSV, and Parquet
         </span>
       </li>
       <li class="flex items-center gap-3">
         <Icon name="sun" />
         <span>
-          <strong>AI providers:</strong> Anthropic, OpenAI, Google, and others
+          Anthropic, OpenAI, Google, Groq, xAI, and other providers
         </span>
       </li>
       <li class="flex items-center gap-3">
         <Icon name="seti:shell" />
-        <span>
-          <strong>Interface:</strong> Interactive REPL or single-shot CLI
-          queries
-        </span>
+        <span>Interactive mode or a single CLI question</span>
       </li>
       <li class="flex items-center gap-3">
         <Icon name="forward-slash" />
-        <span>
-          <strong>Composable:</strong> Pipe queries, redirect output, use in
-          scripts
-        </span>
+        <span>stdin, redirects, and scripts</span>
       </li>
     </ul>
   </div>
@@ -123,7 +115,7 @@ import {
 
 <section class="mx-auto max-w-screen-lg px-4 sm:px-6 lg:px-8 py-12 text-center">
   <h2 class="font-sans text-3xl md:text-4xl tracking-normal">
-    Get started in 2 commands
+    Install and run
   </h2>
   <div class="mt-8 text-left mx-auto max-w-3xl">
     <Code
@@ -137,9 +129,9 @@ lang="bash"
 
   </div>
   <div class="mt-8 flex flex-wrap items-center justify-center gap-4">
-    <LinkButton href="/installation/">Installation guide</LinkButton>
+    <LinkButton href="/installation/">Installation</LinkButton>
     <LinkButton href="/guides/getting-started/" variant="secondary">
-      Quick start
+      Getting started
     </LinkButton>
   </div>
 </section>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -46,8 +46,8 @@ import {
 </section>
 
 <script
-  src="https://asciinema.org/a/746773.js"
-  id="asciicast-746773"
+  src="https://asciinema.org/a/1265197.js"
+  id="asciicast-1265197"
   async="true"
 ></script>
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -1,22 +1,26 @@
 ---
 title: Installation
-description: Install the SQLsaber CLI with uv, pipx, or the standalone installer.
+description: Install the SQLsaber CLI with uv, uvx.sh, or pipx.
 ---
 
 Install SQLsaber, then confirm that the `saber` command runs.
 
 ## Install with uv
 
+If you already have [uv](https://docs.astral.sh/uv/):
+
 ```bash
 uv tool install sqlsaber
 ```
 
-If you do not have uv, use the standalone installer.
+## Install without uv
+
+If you do not have uv, use [uvx.sh](https://uvx.sh/). One command installs SQLsaber. You do not need uv or Python first.
 
 On macOS and Linux:
 
 ```bash
-curl -LsSf uvx.sh/sqlsaber/install.sh | sh
+curl -LsSf https://uvx.sh/sqlsaber/install.sh | sh
 ```
 
 On Windows:
@@ -24,6 +28,10 @@ On Windows:
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://uvx.sh/sqlsaber/install.ps1 | iex"
 ```
+
+The script installs uv when it is missing. Then it installs SQLsaber.
+
+## Install with pipx
 
 If you already use pipx:
 
@@ -41,7 +49,7 @@ You should see a version number.
 
 ## Add official plugins
 
-Plugins add extra tools to the `saber` CLI. Pass each plugin package in `--with` when you run `uv tool install`.
+Plugins add extra tools to the `saber` CLI. Pass each plugin package in `--with` when you run `uv tool install`. After a uvx.sh install, uv is on your machine. The same commands work.
 
 ```bash
 # Charts in the terminal
@@ -60,6 +68,8 @@ uv tool install --with sqlsaber-viz,sqlsaber-notebook,sqlsaber-sandbox sqlsaber
 See [Plugins](/guides/plugins/) for setup and usage.
 
 ## Upgrade
+
+If you installed with uv or uvx.sh:
 
 ```bash
 uv tool upgrade sqlsaber

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -41,7 +41,7 @@ You should see a version number.
 
 ## Add official plugins
 
-Plugins add extra tools to the `saber` CLI. Install them beside SQLsaber with `uv tool install --with`.
+Plugins add extra tools to the `saber` CLI. Pass each plugin package in `--with` when you run `uv tool install`.
 
 ```bash
 # Charts in the terminal

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -1,77 +1,80 @@
 ---
 title: Installation
-description: "Install SQLsaber with uv or pipx. Set up the AI-powered SQL assistant CLI tool on macOS, Linux, or Windows in under a minute."
+description: Install the SQLsaber CLI with uv, pipx, or the standalone installer.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+Install SQLsaber, then confirm that the `saber` command runs.
 
-## Install
+## Install with uv
 
 ```bash
 uv tool install sqlsaber
 ```
 
-<Aside type="note">
-**Don't have uv?** Use the standalone installer:
+If you do not have uv, use the standalone installer.
 
-macOS and Linux:
+On macOS and Linux:
 
 ```bash
 curl -LsSf uvx.sh/sqlsaber/install.sh | sh
 ```
 
-Windows:
+On Windows:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://uvx.sh/sqlsaber/install.ps1 | iex"
 ```
 
-You can also use `pipx` if you have it and prefer to use it.
+If you already use pipx:
 
 ```bash
 pipx install sqlsaber
 ```
-</Aside>
 
-## Verify installation
+## Confirm the install
 
 ```bash
 saber --version
 ```
 
-## Plugins
+You should see a version number.
 
-SQLsaber supports optional plugins that allows users to extend its capabilities.
+## Add official plugins
 
-There are two official plugins for visualization and Python execution:
+Plugins add extra tools to the `saber` CLI. Install them beside SQLsaber with `uv tool install --with`.
 
 ```bash
-# Visualization plugin - render charts in your terminal
+# Charts in the terminal
 uv tool install --with sqlsaber-viz sqlsaber
 
-# Python sandbox plugin - run Python in a secure sandbox
+# Sandboxed notebook analysis
+uv tool install --with sqlsaber-notebook sqlsaber
+
+# One-off Python in a remote sandbox
 uv tool install --with sqlsaber-sandbox sqlsaber
 
-# Or install both
-uv tool install --with sqlsaber-viz,sqlsaber-sandbox sqlsaber
+# All three
+uv tool install --with sqlsaber-viz,sqlsaber-notebook,sqlsaber-sandbox sqlsaber
 ```
 
-See the [plugins guide](/guides/plugins) for detailed setup and usage.
+See [Plugins](/guides/plugins/) for setup and usage.
 
 ## Upgrade
 
 ```bash
-# uv
 uv tool upgrade sqlsaber
+```
 
-# pipx
+If you installed with pipx:
+
+```bash
 pipx upgrade sqlsaber
 ```
 
-## Next: Run your first query
+## Run SQLsaber
 
 ```bash
 saber
 ```
 
-On first launch, SQLsaber walks you through database and AI provider setup. See the [getting started guide](/guides/getting-started) for a full walkthrough.
+On first launch, SQLsaber walks you through a database connection and an API key. Continue in [Getting started](/guides/getting-started/).

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -1,15 +1,13 @@
 ---
-title: Command Reference
-description: "Complete CLI reference for SQLsaber commands. Database management, authentication, models, knowledge, threads, and query options."
+title: Commands
+description: CLI reference for SQLsaber. Database connections, authentication, models, knowledge, threads, and query options.
 ---
 
-This is a comprehensive reference for all SQLsaber commands and their options.
+Options, flags, and slash commands for the `saber` CLI.
 
-### `saber`
+## `saber`
 
-The main SQLsaber command for running queries.
-
-**Usage:**
+Runs a query. With no question, starts interactive mode.
 
 ```bash
 # Interactive mode (default)
@@ -18,38 +16,38 @@ saber
 # Single query
 saber "How many users do we have?"
 
-# With specific database
+# Named connection
 saber -d my-database "Show me recent orders"
 
-# With connection string
+# Connection string
 saber -d "postgresql://user:pass@host:5432/db" "User statistics for 2024"
 
-# With multiple databases (repeat -d)
+# Several databases (repeat -d)
 saber -d sales -d analytics "Compare revenue to web sessions"
 
-# Continue a saved thread with one non-interactive follow-up
+# One follow-up on a saved thread
 saber --thread a1b2c3d4 "Now compare that with last quarter"
 ```
 
 **Parameters:**
 
-- `QUERY-TEXT` - SQL query in natural language (optional, starts interactive mode if not provided)
-- `-d, --database` - Database connection name, file path (CSV/Parquet/SQLite/DuckDB), or connection string (postgresql://, mysql://, duckdb://, csv:///, parquet:///). Repeat the flag to connect to [multiple databases](/guides/multi-database) at once (or to load multiple CSV/Parquet files into one DuckDB session with one table per file).
-- `--thinking` / `--no-thinking` - Enable/disable extended thinking/reasoning mode
-- `--csv-tool-results` / `--no-csv-tool-results` - Opt in to experimental CSV tables in model-facing SQL tool results. Defaults to JSON; applies to both single-shot queries and interactive mode.
-- `--allow-dangerous` - Allow INSERT/UPDATE/DELETE and restricted DDL (CREATE TABLE/VIEW/INDEX, ALTER TABLE). DROP/TRUNCATE and admin/security operations remain blocked; UPDATE/DELETE require WHERE.
-- `--system-prompt` - Custom system prompt text or path to a file (overrides built-in prompt)
-- `--thread` - Continue a saved thread non-interactively. Requires a query; uses the stored configured database unless `-d` overrides it.
+- `QUERY-TEXT` - Natural-language question. Optional. Omit it to start interactive mode.
+- `-d, --database` - Saved connection name, file path (CSV, Parquet, SQLite, or DuckDB), or connection string (`postgresql://`, `mysql://`, `duckdb://`, `csv:///`, `parquet:///`). Repeat the flag to connect [several databases](/guides/multi-database/) at once, or to load several CSV or Parquet files into one DuckDB session with one table per file.
+- `--thinking` / `--no-thinking` - Enable or disable extended thinking for this run.
+- `--csv-tool-results` / `--no-csv-tool-results` - Opt in to experimental CSV tables in model-facing SQL tool results. JSON is the default. Applies to single queries and interactive mode.
+- `--allow-dangerous` - Allow `INSERT`, `UPDATE`, `DELETE`, and restricted DDL (`CREATE TABLE`, `CREATE VIEW`, `CREATE INDEX`, `ALTER TABLE`). `DROP`, `TRUNCATE`, and admin or security operations stay blocked. `UPDATE` and `DELETE` require `WHERE`.
+- `--system-prompt` - Custom system prompt text, or a path to a file. Overrides the built-in prompt.
+- `--thread` - Continue a saved thread without interactive mode. Requires a query. Uses the stored saved connection unless `-d` overrides it.
 
-**Global Options:**
+**Global options:**
 
-- `--help, -h` - Display help message
-- `--version` - Show version information
+- `--help, -h` - Show help
+- `--version` - Show the version
 
-### Experimental CSV tool results
+## Experimental CSV tool results
 
 ```bash
-# One query (also works with a query piped through stdin)
+# One query (also works with a question piped through stdin)
 saber --csv-tool-results -d analytics "Show recent orders"
 
 # Interactive session
@@ -62,55 +60,37 @@ saber threads resume THREAD_ID --csv-tool-results
 saber --thread THREAD_ID --csv-tool-results "Compare with last month"
 ```
 
-JSON remains the default. CSV applies only to tabular results sent to the model
-by `list_tables`, `introspect_schema`, `execute_sql`, and `list_dbs`. Metadata,
-errors, and empty results remain JSON. Displayed terminal tables and complete
-saved JSON results do not change, and SQL previews retain their 12 KiB limit.
+JSON remains the default. CSV applies only to tabular results sent to the model by `list_tables`, `introspect_schema`, `execute_sql`, and `list_dbs`. Metadata, errors, and empty results stay JSON. Displayed terminal tables and complete saved JSON results do not change. SQL previews keep a 12 KiB limit.
 
-This is a session option, not a persisted preference. Interactive thread switches
-keep the current session's choice; a new CLI invocation defaults to JSON unless
-the flag is supplied again. Existing thread messages are not converted. There is
-no in-session toggle; launch with the desired flag.
+This is a session option, not a saved preference. Interactive thread switches keep the current session's choice. A new CLI process defaults to JSON unless the flag is passed again. Existing thread messages are not converted. There is no in-session toggle. Launch with the flag you want.
 
-CSV often reduces token usage for multi-row data, but small results may be larger.
-The effect on model answer quality is not yet established, so this remains opt-in.
-For Python usage, see [SDK configuration](/sdk/configuration#experimental-csv-tool-results).
+CSV often reduces token usage for multi-row data. Small results can be larger. The effect on answer quality is not established, so the flag stays opt-in. For Python, see [Configuration](/sdk/configuration/#experimental-csv-tool-results).
 
 ---
 
-### `saber auth`
+## `saber auth`
 
-Manage authentication configuration for AI providers.
+Authentication for AI providers.
 
-#### `saber auth setup`
+### `saber auth setup`
 
-Configure authentication for SQLsaber (API keys).
-
-**Usage:**
+Save an API key.
 
 ```bash
 saber auth setup
 ```
 
-#### `saber auth status`
+### `saber auth status`
 
-Check current authentication configuration.
-
-**Usage:**
+Show which providers are configured, and whether each key came from an environment variable or the keychain.
 
 ```bash
 saber auth status
 ```
 
-**Output shows:**
-
-- Configured providers
-
-#### `saber auth reset`
+### `saber auth reset`
 
 Remove stored credentials for a provider.
-
-**Usage:**
 
 ```bash
 saber auth reset
@@ -119,20 +99,17 @@ saber auth reset
 saber auth reset openai --yes
 ```
 
-Pass the provider directly for automation. `--yes` skips confirmation; without it,
-the command prompts only when attached to an interactive terminal.
+Pass the provider for automation. `--yes` skips confirmation. Without `--yes`, the command prompts only when attached to an interactive terminal.
 
 ---
 
-### `saber db`
+## `saber db`
 
-Manage database connections.
+Saved database connections.
 
-#### `saber db add`
+### `saber db add`
 
-Add a new database connection.
-
-**Usage:**
+Add a connection.
 
 ```bash
 saber db add my-database [OPTIONS]
@@ -140,72 +117,61 @@ saber db add my-database [OPTIONS]
 # Non-interactive SQLite setup
 saber db add local --type sqlite --database ./local.db --no-interactive
 
-# Read a server password from stdin instead of an argument or prompt
+# Read a server password from stdin
 printf '%s' "$DB_PASSWORD" | saber db add analytics --no-interactive \
   --host db.example.com --database analytics --username agent --password-stdin
 ```
 
 **Parameters:**
 
-- `NAME` - Name for the database connection (required)
+- `NAME` - Connection name (required)
 
 **Options:**
 
 - `-t, --type` - Database type: `postgresql`, `mysql`, `sqlite`, `duckdb` (default: postgresql)
-- `-h, --host` - Database host
-- `-p, --port` - Database port
+- `-h, --host` - Host
+- `-p, --port` - Port
 - `--database, --db` - Database name
 - `-u, --username` - Username
-- `--exclude-schemas` - Comma-separated list of schemas to skip during introspection
-- `--description` - Short human-readable description of the connection. Shown to the agent in [multi-database sessions](/guides/multi-database) to help it pick the right database.
-- `--ssl-mode` - SSL mode (see SSL options below)
+- `--exclude-schemas` - Comma-separated schemas to skip during introspection
+- `--description` - Short description shown to the agent in [multi-database sessions](/guides/multi-database/)
+- `--ssl-mode` - SSL mode (see SSL modes below)
 - `--ssl-ca` - SSL CA certificate file path
 - `--ssl-cert` - SSL client certificate file path
 - `--ssl-key` - SSL client private key file path
-- `--interactive/--no-interactive` - Use interactive mode (default: true)
+- `--interactive/--no-interactive` - Interactive prompts (default: true)
 - `--password-stdin` - Read the database password from stdin. Requires `--no-interactive`.
 
-**SSL Modes:**
+**SSL modes:**
 
 _PostgreSQL:_
 
 - `disable` - No SSL
-- `allow` - Try SSL, fallback to non-SSL
+- `allow` - Try SSL, fall back to non-SSL
 - `prefer` - Try SSL first (default)
 - `require` - Require SSL
-- `verify-ca` - Require SSL and verify certificate
-- `verify-full` - Require SSL, verify certificate and hostname
+- `verify-ca` - Require SSL and verify the certificate
+- `verify-full` - Require SSL, verify the certificate and hostname
 
 _MySQL:_
 
 - `DISABLED` - No SSL
 - `PREFERRED` - Try SSL first (default)
 - `REQUIRED` - Require SSL
-- `VERIFY_CA` - Require SSL and verify certificate
-- `VERIFY_IDENTITY` - Require SSL, verify certificate and hostname
+- `VERIFY_CA` - Require SSL and verify the certificate
+- `VERIFY_IDENTITY` - Require SSL, verify the certificate and hostname
 
-#### `saber db list`
+### `saber db list`
 
-List all configured database connections.
-
-**Usage:**
+List saved connections: names, host, port, database, excluded schemas, and the default marker.
 
 ```bash
 saber db list
 ```
 
-**Output shows:**
+### `saber db exclude NAME`
 
-- Database names
-- Connection details (host, port, database)
-- Any excluded schemas configured for the connection
-- Default database indicator
-
-#### `saber db exclude NAME`
-
-Update or inspect schema exclusions for an existing database connection.
-
-**Usage:**
+Update or inspect schema exclusions for a saved connection.
 
 ```bash
 saber db exclude my-database [--set SCHEMAS | --add SCHEMAS | --remove SCHEMAS | --clear]
@@ -213,65 +179,45 @@ saber db exclude my-database [--set SCHEMAS | --add SCHEMAS | --remove SCHEMAS |
 
 **Options:**
 
-- `--set` — Replace the exclusion list entirely with the provided comma-separated schemas
-- `--add` — Append schemas to the current exclusion list (duplicates are ignored)
-- `--remove` — Remove the provided schemas from the exclusion list
-- `--clear` — Remove all exclusions
+- `--set` - Replace the exclusion list with the given comma-separated schemas
+- `--add` - Append schemas (duplicates are ignored)
+- `--remove` - Remove the given schemas
+- `--clear` - Remove all exclusions
 
-Run without flags to interactively edit the exclusion list.
+With no flags, the command edits the list interactively.
 
-#### `saber db set-default NAME`
+### `saber db set-default NAME`
 
-Set a database as the default connection.
-
-**Usage:**
+Set the default connection.
 
 ```bash
 saber db set-default my-database
 ```
 
-#### `saber db test NAME`
+### `saber db test NAME`
 
-Test a database connection.
-
-**Usage:**
+Test a connection. Prints success or the error details.
 
 ```bash
 saber db test my-database
 ```
 
-**Output:**
+### `saber db remove`
 
-- Connection success/failure
-- Error details if connection fails
-
-#### `saber db remove`
-
-Remove a database connection.
-
-**Usage:**
+Remove a connection. Prompts for confirmation in a terminal. `--yes` skips the prompt.
 
 ```bash
 saber db remove my-database
 saber db remove my-database --yes
 ```
 
-**Confirmation required** - Will prompt before deletion in a terminal. Use `--yes`
-for a deliberate non-interactive removal.
-
 ---
 
-### `saber knowledge`
+## `saber knowledge`
 
-Manage database-specific knowledge entries used by the `search_knowledge` tool.
+Database-scoped knowledge entries used by the `search_knowledge` tool. Entries may include SQL snippets and source references.
 
-Knowledge entries are scoped per database and support optional SQL snippets and source references.
-
-#### `saber knowledge add`
-
-Add a new knowledge entry.
-
-**Usage:**
+### `saber knowledge add`
 
 ```bash
 saber knowledge add "Name" "Description" [OPTIONS]
@@ -279,37 +225,31 @@ saber knowledge add "Name" "Description" [OPTIONS]
 
 **Parameters:**
 
-- `NAME` - Knowledge entry name (required)
-- `DESCRIPTION` - Knowledge description (required)
+- `NAME` - Entry name (required)
+- `DESCRIPTION` - Description (required)
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
-- `--sql` - Optional SQL query or pattern
-- `--source` - Optional source reference (wiki, URL, etc.)
+- `-d, --database` - Saved connection name (uses the default if omitted)
+- `--sql` - SQL query or pattern
+- `--source` - Source reference, such as a wiki page or URL
 
 **Examples:**
 
 ```bash
-# Add to default database
 saber knowledge add "Revenue KPI" "Recognized revenue from shipped orders only"
 
-# Include SQL pattern
 saber knowledge add "Monthly revenue rollup" "Use shipped orders for monthly revenue" --sql "SELECT date_trunc('month', shipped_at), SUM(amount) FROM orders WHERE status = 'shipped' GROUP BY 1"
 
-# Include a source reference
 saber knowledge add "NRR definition" "Exclude new logo revenue from NRR" --source "finance-wiki"
 
-# Use files for long content
 saber knowledge add "Revenue definition" "$(cat ./knowledge/revenue_definition.md)"
 saber knowledge add "Monthly revenue rollup" "$(cat ./knowledge/monthly_revenue_notes.md)" --sql "$(cat ./sql/monthly_revenue_rollup.sql)"
 ```
 
-#### `saber knowledge list`
+### `saber knowledge list`
 
-List all knowledge entries for a database.
-
-**Usage:**
+Lists ID, name, description preview, and last updated time.
 
 ```bash
 saber knowledge list [OPTIONS]
@@ -317,20 +257,9 @@ saber knowledge list [OPTIONS]
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
+- `-d, --database` - Saved connection name (uses the default if omitted)
 
-**Output shows:**
-
-- Knowledge ID
-- Name
-- Description preview
-- Last updated timestamp
-
-#### `saber knowledge show`
-
-Show a full knowledge entry by ID.
-
-**Usage:**
+### `saber knowledge show`
 
 ```bash
 saber knowledge show ENTRY_ID [OPTIONS]
@@ -338,17 +267,13 @@ saber knowledge show ENTRY_ID [OPTIONS]
 
 **Parameters:**
 
-- `ENTRY_ID` - Knowledge ID from `saber knowledge list` output
+- `ENTRY_ID` - ID from `saber knowledge list`
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
+- `-d, --database` - Saved connection name (uses the default if omitted)
 
-#### `saber knowledge search`
-
-Search knowledge entries for a database.
-
-**Usage:**
+### `saber knowledge search`
 
 ```bash
 saber knowledge search "QUERY" [OPTIONS]
@@ -356,23 +281,16 @@ saber knowledge search "QUERY" [OPTIONS]
 
 **Parameters:**
 
-- `QUERY` - Keyword query to search for
+- `QUERY` - Keyword query
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
-- `--limit` - Maximum number of entries to return (default: 10)
+- `-d, --database` - Saved connection name (uses the default if omitted)
+- `--limit` - Maximum entries to return (default: 10)
 
-**Notes:**
+Results are ranked by full-text relevance and scoped to one database.
 
-- Results are ranked by full-text relevance.
-- Search is database-scoped.
-
-#### `saber knowledge remove`
-
-Remove a specific knowledge entry.
-
-**Usage:**
+### `saber knowledge remove`
 
 ```bash
 saber knowledge remove ENTRY_ID [OPTIONS]
@@ -380,18 +298,16 @@ saber knowledge remove ENTRY_ID [OPTIONS]
 
 **Parameters:**
 
-- `ENTRY_ID` - Knowledge ID from `saber knowledge list` output
+- `ENTRY_ID` - ID from `saber knowledge list`
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
-- `--yes` - Skip confirmation prompt (required when no interactive terminal is available)
+- `-d, --database` - Saved connection name (uses the default if omitted)
+- `--yes` - Skip confirmation (required when no interactive terminal is available)
 
-#### `saber knowledge clear`
+### `saber knowledge clear`
 
-Remove all knowledge entries for a database.
-
-**Usage:**
+Remove every knowledge entry for a database.
 
 ```bash
 saber knowledge clear [OPTIONS]
@@ -399,28 +315,22 @@ saber knowledge clear [OPTIONS]
 
 **Options:**
 
-- `-d, --database` - Database connection name (uses default if not specified)
-- `--yes` - Skip confirmation prompt
+- `-d, --database` - Saved connection name (uses the default if omitted)
+- `--yes` - Skip confirmation
 
-### `saber models`
+## `saber models`
 
-Manage LLM models from different providers.
+LLM models from configured providers.
 
-#### `saber models list`
-
-List all available models for configured providers.
-
-**Usage:**
+### `saber models list`
 
 ```bash
 saber models list
 ```
 
-#### `saber models set`
+### `saber models set`
 
-Set the default model and configure thinking level.
-
-**Usage:**
+Set the default model and thinking level.
 
 ```bash
 # Interactive selection
@@ -433,14 +343,10 @@ saber models set openai:gpt-5 --agent handoff
 
 **Options:**
 
-- `--agent` - Target agent to configure (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
+- `--agent` - Agent to configure (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
 - `--thinking-level` - Main-model thinking mode: `off`, `minimal`, `low`, `medium`, `high`, or `maximum`.
 
-#### `saber models current`
-
-Show the currently configured model and thinking settings.
-
-**Usage:**
+### `saber models current`
 
 ```bash
 saber models current
@@ -448,13 +354,11 @@ saber models current
 
 **Options:**
 
-- `--agent` - Show model for a specific agent (`main`, `handoff`, `viz`, `notebook`).
+- `--agent` - Show the model for one agent (`main`, `handoff`, `viz`, `notebook`).
 
-#### `saber models reset`
+### `saber models reset`
 
-Reset to the default model (`openai:gpt-5.6-sol`).
-
-**Usage:**
+Reset to `openai:gpt-5.6-sol`.
 
 ```bash
 saber models reset
@@ -463,38 +367,34 @@ saber models reset --agent handoff --yes
 
 **Options:**
 
-- `--agent` - Reset a specific agent (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
-- `--yes` - Skip confirmation prompt (required when no interactive terminal is available).
+- `--agent` - Agent to reset (`main`, `handoff`, `viz`, `notebook`). Defaults to `main`.
+- `--yes` - Skip confirmation (required when no interactive terminal is available).
 
 ---
 
-### `saber theme`
+## `saber theme`
 
-Manage syntax highlighting theme settings.
+Syntax highlighting theme.
 
-#### `saber theme set`
+### `saber theme set`
 
-Select a syntax highlighting theme. Omit the theme name to browse interactively.
-
-**Usage:**
+Omit the theme name to browse interactively.
 
 ```bash
 saber theme set
 saber theme set dracula
 ```
 
-You can also set themes via environment variable:
+Override the theme for one process:
 
 ```bash
 export SQLSABER_THEME=dracula
 saber
 ```
 
-#### `saber theme reset`
+### `saber theme reset`
 
-Reset to the default theme (nord).
-
-**Usage:**
+Reset to the default theme (`nord`).
 
 ```bash
 saber theme reset
@@ -505,15 +405,11 @@ saber theme reset --yes
 
 ---
 
-### `saber threads`
+## `saber threads`
 
-Manage conversation threads.
+Saved conversation threads.
 
-#### `saber threads list`
-
-List conversation threads.
-
-**Usage:**
+### `saber threads list`
 
 ```bash
 saber threads list [OPTIONS]
@@ -524,11 +420,9 @@ saber threads list [OPTIONS]
 - `-d, --database` - Filter by database name
 - `-n, --limit` - Maximum threads to return (default: 50)
 
-#### `saber threads show`
+### `saber threads show`
 
-Show complete thread transcript.
-
-**Usage:**
+Prints thread metadata (database, model, timestamps), the full transcript, SQL and results, tool calls, and durable artifact names and links.
 
 ```bash
 saber threads show a1b2c3d4
@@ -536,34 +430,36 @@ saber threads show a1b2c3d4
 
 **Parameters:**
 
-- `THREAD_ID` - Thread ID from `saber threads list`
+- `THREAD_ID` - ID from `saber threads list`
 
-**Output shows:**
+### `saber threads artifacts`
 
-- Thread metadata (database, model, timestamps)
-- Complete conversation history
-- SQL queries and results
-- Tool calls and responses
-- Durable artifact names and links
-
-#### `saber threads artifacts`
-
-List durable artifacts referenced by a thread without replaying its full transcript.
-
-**Usage:**
+Lists durable artifacts for a thread without replaying the transcript. Output includes publication ID and kind, artifact kind, name, size, local URI, and an unavailable marker when integrity verification fails.
 
 ```bash
 saber threads artifacts a1b2c3d4
 ```
 
-The output includes publication ID and kind, artifact kind/name/size, local URI,
-and an unavailable marker when integrity verification fails.
+### `saber threads export`
 
-#### `saber threads resume`
+Writes a standalone HTML transcript. Default path is `./thread-<id>.html`.
 
-Resume an existing conversation thread.
+```bash
+saber threads export a1b2c3d4
+saber threads export a1b2c3d4 --output analysis.html
+```
 
-**Usage:**
+**Parameters:**
+
+- `THREAD_ID` - ID from `saber threads list`
+
+**Options:**
+
+- `-o, --output` - Output HTML file path
+
+### `saber threads resume`
+
+Resume a thread in interactive mode.
 
 ```bash
 saber threads resume a1b2c3d4 [OPTIONS]
@@ -571,35 +467,27 @@ saber threads resume a1b2c3d4 [OPTIONS]
 
 **Parameters:**
 
-- `THREAD_ID` - Thread ID to resume
+- `THREAD_ID` - Thread to resume
 
 **Options:**
 
-- `-d, --database` - Use a different database than the original thread. Repeat the flag to resume against multiple databases.
+- `-d, --database` - Use a different database than the original thread. Repeat the flag to resume against several databases.
 
-**Features:**
-
-- Loads full conversation context
-- Uses the currently configured model
-- Reconnects to the original database(s), including [multi-database](/guides/multi-database) threads
-- Continues where conversation left off in interactive mode
+Loads the saved messages, uses the currently configured model, and reconnects to the original database or databases, including [multi-database](/guides/multi-database/) threads.
 
 :::note
-Automatic resume requires every database in the thread to be a saved connection. If a thread used an ad-hoc connection string or file path, resume it with explicit `-d` flags.
+Automatic resume requires every database on the thread to be a saved connection. If a thread used a connection string or file path, resume it with explicit `-d` flags.
 :::
 
-For one automated follow-up rather than an interactive session, use the root
-command:
+For one follow-up without interactive mode, use the root command:
 
 ```bash
 saber --thread a1b2c3d4 "Now compare that with last quarter"
 ```
 
-#### `saber threads prune`
+### `saber threads prune`
 
-Clean up old conversation threads.
-
-**Usage:**
+Delete threads older than a given number of days.
 
 ```bash
 saber threads prune
@@ -610,48 +498,47 @@ saber threads prune --days 30 --yes
 **Options:**
 
 - `-n, --days` - Delete threads older than this many days (default: 30)
-- `--dry-run` - Report how many threads would be deleted without deleting them
-- `--yes` - Skip confirmation prompt (required when no interactive terminal is available)
+- `--dry-run` - Report how many threads would be deleted, without deleting them
+- `--yes` - Skip confirmation (required when no interactive terminal is available)
 
 ---
 
-### Interactive Mode
+## Interactive mode
 
-When in interactive mode (`saber` with no arguments), you have access to a few additional features:
+`saber` with no question starts interactive mode. Session commands:
 
-#### Slash Commands
-
+- `/help [GROUP [COMMAND]]` - Show slash-command help (`/?` is an alias)
 - `/clear` - Clear conversation history
-- `/exit` - Exit SQLsaber
-- `/quit` - Exit SQLsaber (alias for `/exit`)
+- `/exit` - End the session (`/quit` is an alias)
 - `/thinking` - Show current thinking status and level
-- `/thinking on` - Enable extended thinking with current level
+- `/thinking on` - Enable extended thinking at the current level
 - `/thinking off` - Disable extended thinking
-- `/thinking <level>` - Set thinking level (implies enable)
+- `/thinking <level>` - Set thinking level (also enables thinking)
+- `/handoff GOAL` - Draft a prompt for a new thread from the current context
 
-**Thinking Levels:**
+Management commands from the CLI also work with a leading `/`. Examples: `/db list`, `/auth status`, `/threads resume ID`. Type `/help` for the full list.
+
+**Thinking levels:**
 
 | Level | Description |
 |-------|-------------|
-| `off` | Disable extended thinking |
-| `minimal` | Quick responses, minimal reasoning |
+| `off` | No extended thinking |
+| `minimal` | Least reasoning |
 | `low` | Light reasoning |
-| `medium` | Balanced cost/quality (default) |
-| `high` | Deep reasoning |
-| `maximum` | Complex problems, highest cost |
+| `medium` | Default balance of cost and quality |
+| `high` | Deeper reasoning |
+| `maximum` | Highest reasoning depth and cost |
 
-#### Autocomplete
+**Autocomplete:**
 
-- **Table names** - Type `@table_name[TAB]` for completions
-- **Slash commands** - Type `/[TAB]` for command completions
+- Table names: type `@table_name` and press Tab
+- Slash commands: type `/` and press Tab
 
 ---
 
-### Environment Variables
+## Environment variables
 
-These environment variables adjust runtime behavior:
-
-- `SQLSABER_THEME` — Override the configured theme for the session.
-- `SQLSABER_PG_EXCLUDE_SCHEMAS` — Comma-separated list of PostgreSQL schemas to exclude from schema discovery and introspection. Defaults already exclude `pg_catalog`, `information_schema`, `_timescaledb_internal`, `_timescaledb_cache`, `_timescaledb_config`, `_timescaledb_catalog`.
-- `SQLSABER_MYSQL_EXCLUDE_SCHEMAS` — Comma-separated list of MySQL databases to omit from discovery. Defaults exclude `information_schema`, `performance_schema`, `mysql`, and `sys`.
-- `SQLSABER_DUCKDB_EXCLUDE_SCHEMAS` — Comma-separated list of DuckDB schemas to skip during introspection. Defaults exclude `information_schema`, `pg_catalog`, and `duckdb_catalog`.
+- `SQLSABER_THEME` - Override the configured theme for this process
+- `SQLSABER_PG_EXCLUDE_SCHEMAS` - Extra PostgreSQL schemas to skip during discovery and introspection. Defaults already skip `pg_catalog`, `information_schema`, `_timescaledb_internal`, `_timescaledb_cache`, `_timescaledb_config`, `_timescaledb_catalog`.
+- `SQLSABER_MYSQL_EXCLUDE_SCHEMAS` - Extra MySQL databases to skip. Defaults skip `information_schema`, `performance_schema`, `mysql`, and `sys`.
+- `SQLSABER_DUCKDB_EXCLUDE_SCHEMAS` - Extra DuckDB schemas to skip. Defaults skip `information_schema`, `pg_catalog`, and `duckdb_catalog`.

--- a/docs/src/content/docs/sdk/advanced.mdx
+++ b/docs/src/content/docs/sdk/advanced.mdx
@@ -1,15 +1,13 @@
 ---
 title: Advanced
-description: "Advanced SQLsaber SDK usage: per-tool model overrides, custom system prompts, write access, and injecting knowledge base and conversation thread managers."
+description: Per-tool model overrides, custom system prompts, write access, and injectable knowledge and thread managers in the SQLsaber SDK.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
 ## Per-tool model overrides
 
-You can run specific internal tools (for example a visualization or summarization
-tool) on a different model than the main agent. Use `tool_overrides`, mapping a
-tool name to a `ModelOverides`:
+Run a specific internal tool, such as visualization or summarization, on a different model than the main agent. Use `tool_overrides`, mapping a tool name to a `ModelOverides`:
 
 ```python
 from sqlsaber import SQLSaber, SQLSaberOptions, ModelOverides
@@ -26,7 +24,7 @@ options = SQLSaberOptions(
 )
 ```
 
-You may also pass a plain dict instead of `ModelOverides`:
+A plain dict also works:
 
 ```python
 tool_overrides={"viz": {"model_name": "openai:gpt-5-mini"}}
@@ -57,26 +55,24 @@ SQLSaberOptions(
 )
 ```
 
-## Allowing write operations
+## Allow write operations
 
-By default the SDK only permits read-only `SELECT` queries. Set
-`allow_dangerous=True` to permit DML and a restricted subset of DDL:
+By default the SDK only permits read-only `SELECT` queries. Set `allow_dangerous=True` to permit DML and a restricted subset of DDL:
 
 ```python
 SQLSaberOptions(database="sqlite:///my.db", allow_dangerous=True)
 ```
 
 <Aside type="caution">
-  This allows data modifications (INSERT/UPDATE/DELETE, with UPDATE/DELETE
-  requiring a `WHERE`) and limited DDL. Destructive operations such as DROP and
-  TRUNCATE remain blocked. See [Running Queries](/guides/queries#dangerous-mode)
-  for the full policy.
+  This allows data modifications (`INSERT`, `UPDATE`, `DELETE`, with `UPDATE`
+  and `DELETE` requiring a `WHERE`) and limited DDL. Destructive operations such
+  as `DROP` and `TRUNCATE` remain blocked. See [Running
+  queries](/guides/queries/#allow-writes) for the full policy.
 </Aside>
 
-## Injecting a knowledge base
+## Inject a knowledge base
 
-Provide domain context by injecting your own `KnowledgeManager`. The agent can
-search it while answering:
+Provide domain context by injecting your own `KnowledgeManager`. The agent can search it while answering:
 
 ```python
 import asyncio
@@ -109,17 +105,16 @@ if __name__ == "__main__":
 ```
 
 <Aside type="note">
-  When you inject your own `knowledge_manager`, the session does **not** close it
-  for you — you own its lifecycle. If you omit it, the session creates and closes
-  one automatically.
+  When you inject your own `knowledge_manager`, the session does not close it.
+  You own its lifecycle. If you omit it, the session creates and closes one
+  automatically.
 </Aside>
 
-See the [Knowledge Base guide](/guides/knowledge) for managing entries.
+See [Knowledge base](/guides/knowledge/) for managing entries.
 
-## Persisting conversation threads
+## Persist conversation threads
 
-Inject a `ThreadManager` to persist each completed query's history, as the CLI does
-between sessions:
+Inject a `ThreadManager` to persist each completed query's history, as the CLI does between sessions:
 
 ```python
 from sqlsaber import SQLSaber, SQLSaberOptions
@@ -134,13 +129,9 @@ async with SQLSaber(options=options) as saber:
     result = await saber.query("How many orders shipped last week?")
 ```
 
-The session saves each completed query and ends the current thread when it closes.
-The default manager uses SQLsaber's local thread storage. Inject a manager with your
-own `ThreadStorage` when the application needs a different storage location or
-lifecycle.
+The session saves each completed query and ends the current thread when it closes. The default manager uses SQLsaber's local thread storage. Inject a manager with your own `ThreadStorage` when the application needs a different storage location or lifecycle.
 
-Resume a stored thread with `SQLSaber.resume()`. If the thread stores a configured
-database name, leave `options.database` as `None` and SQLsaber selects that name:
+Resume a stored thread with `SQLSaber.resume()`. If the thread stores a saved connection name, leave `options.database` as `None` and SQLsaber selects that name:
 
 ```python
 import asyncio
@@ -161,13 +152,8 @@ async def continue_thread() -> None:
 asyncio.run(continue_thread())
 ```
 
-Pass an explicit `options.database` to override the stored selector. SQLsaber does
-not persist raw connection strings or file paths for automatic resume.
+Pass an explicit `options.database` to override the stored selector. SQLsaber does not persist raw connection strings or file paths for automatic resume.
 
-`SQLSaber.resume()` raises typed errors. Catch `ThreadNotFoundError` when the ID does
-not exist, `ThreadResumeHistoryError` when the stored Pydantic AI history is missing
-or corrupt, `ThreadDatabaseRequiredError` when a safe database selector is missing,
-and `ThreadDatabaseUnavailableError` when a stored configured database is no longer
-available. All resume errors inherit from `ThreadResumeError`.
+`SQLSaber.resume()` raises typed errors. Catch `ThreadNotFoundError` when the ID does not exist, `ThreadResumeHistoryError` when the stored Pydantic AI history is missing or corrupt, `ThreadDatabaseRequiredError` when a safe database selector is missing, and `ThreadDatabaseUnavailableError` when a stored saved connection is no longer available. All resume errors inherit from `ThreadResumeError`.
 
-See the [Conversation Threads guide](/guides/threads) for CLI thread commands.
+See [Conversation threads](/guides/threads/) for CLI thread commands.

--- a/docs/src/content/docs/sdk/capabilities.mdx
+++ b/docs/src/content/docs/sdk/capabilities.mdx
@@ -5,7 +5,7 @@ description: "Compose SQLsaber SQL and knowledge tools into your own pydantic-ai
 
 import { Aside } from '@astrojs/starlight/components';
 
-SQLsaber exposes its database behavior as [pydantic-ai capabilities](https://ai.pydantic.dev/capabilities/). You can attach SQLsaber to an agent you own, or add your capabilities to SQLsaber's managed agent.
+SQLsaber exposes its database behavior as [pydantic-ai capabilities](https://ai.pydantic.dev/capabilities/). Attach SQLsaber to an agent you own, or add your capabilities to SQLsaber's managed agent.
 
 ## Add SQL tools to your agent
 
@@ -40,14 +40,14 @@ When `SqlTools` receives `database=`, it owns the resulting connections. Enter t
 
 ### Multiple databases
 
-Pass configured database names or DSNs as a sequence:
+Pass saved connection names or DSNs as a sequence:
 
 ```python
 sql = SqlTools(database=["production", "warehouse"])
 agent = Agent("openai:gpt-5.2", capabilities=[sql])
 ```
 
-SQLsaber includes a database catalog in the capability instructions. Cross-database joins are not attempted; the model queries each database separately.
+SQLsaber includes a database catalog in the capability instructions. Cross-database joins are not attempted. The model queries each database separately.
 
 ### Experimental CSV tool results
 
@@ -58,7 +58,7 @@ sql = SqlTools(database="analytics", csv_tool_results=True)
 ```
 
 The option applies to all SQL tools in this capability, including `list_dbs`.
-Metadata and errors remain JSON; retained query data and terminal rendering do
+Metadata and errors remain JSON. Retained query data and terminal rendering do
 not change. Token savings do not establish equivalent answer quality. See
 [CSV tool result behavior](/sdk/configuration#experimental-csv-tool-results)
 for details. Managed sessions use `SQLSaberOptions(csv_tool_results=True)` instead.

--- a/docs/src/content/docs/sdk/capability-query-results.mdx
+++ b/docs/src/content/docs/sdk/capability-query-results.mdx
@@ -113,7 +113,7 @@ first_row {'id': 1, 'name': 'customer-000-xxxxxxxxxxxxxxxxxxxxxxxx', 'revenue': 
 last_row {'id': 250, 'name': 'customer-249-xxxxxxxxxxxxxxxxxxxxxxxx', 'revenue': 1249}
 ```
 
-That is the same retrieve path as `SQLSaber.get_query_result()`, without the managed client. `query_result_references_from_messages` currently lives on `sqlsaber.query_result_resolution`. When the store authorizes by tenant, pass `conversation_id` and `metadata` through `QueryResultContext`.
+That is the same retrieve path as `SQLSaber.get_query_result()`, without the managed client. Import `query_result_references_from_messages` from `sqlsaber.query_result_resolution`. When the store authorizes by tenant, pass `conversation_id` and `metadata` through `QueryResultContext`.
 
 ## Share the store with notebook, viz, or sandbox
 

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -1,12 +1,11 @@
 ---
 title: Configuration
-description: "Configure the SQLsaber Python SDK with SQLSaberOptions: database connections, model selection, thinking, system prompts, and injectable components."
+description: Configure the SQLsaber Python SDK with SQLSaberOptions: database connections, model selection, thinking, system prompts, and injectable components.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-Every `SQLSaber` session is configured through a single `SQLSaberOptions`
-dataclass. Construct it with keyword arguments and pass it to `SQLSaber(options=...)`.
+Every `SQLSaber` session is configured through one `SQLSaberOptions` dataclass. Construct it with keyword arguments and pass it to `SQLSaber(options=...)`.
 
 ```python
 from sqlsaber import SQLSaberOptions
@@ -22,28 +21,28 @@ options = SQLSaberOptions(
 
 | Field               | Type                                          | Default | Description                                                                                  |
 | ------------------- | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, configured DB name, a list of CSV/Parquet paths, or a list of targets for a [multi-database](/guides/multi-database) session. |
-| `model_name`        | `str \| None`                                 | `None`  | Model in `"provider:model"` form. Falls back to your configured/default model.               |
-| `api_key`           | `str \| None`                                 | `None`  | API key for the model's provider. Usually unnecessary — see [Credentials](/sdk/credentials-and-models). |
+| `database`          | `str \| list[str] \| tuple[str, ...] \| None` | `None`  | Connection string, file path, saved connection name, a list of CSV or Parquet paths, or a list of targets for a [multi-database](/guides/multi-database/) session. |
+| `model_name`        | `str \| None`                                 | `None`  | Model in `"provider:model"` form. Falls back to your configured default model.               |
+| `api_key`           | `str \| None`                                 | `None`  | API key for the model's provider. Usually unnecessary. See [Credentials and models](/sdk/credentials-and-models/). |
 | `thinking_enabled`  | `bool \| None`                                | `None`  | Toggle extended thinking on supported reasoning models.                                      |
 | `thinking_level`    | `ThinkingLevel \| str \| None`                | `None`  | `"minimal" \| "low" \| "medium" \| "high" \| "maximum"`. Setting a level enables thinking.   |
 | `system_prompt`     | `str \| Path \| None`                         | `None`  | Custom system prompt text, or a path to a file containing it.                                |
-| `settings`          | `Config \| None`                              | `None`  | Inject a `Config` (e.g. `Config.in_memory(...)`). Defaults to file-backed `Config.default()`. |
-| `knowledge_manager` | `KnowledgeManager \| None`                    | `None`  | Inject your own knowledge base (see [Advanced](/sdk/advanced)).                              |
-| `thread_manager`    | `ThreadManager \| None`                       | `None`  | Persist conversation history across runs (see [Advanced](/sdk/advanced)).                    |
-| `capabilities` | `Sequence[AbstractCapability[Any] \| Callable]` | `()` | Explicit pydantic-ai capabilities and plugin factories (see [Capabilities](/sdk/capabilities)). SQLSaber always includes SQL and knowledge tools. An embedded session includes only the listed capabilities. The CLI loads installed plugins. |
+| `settings`          | `Config \| None`                              | `None`  | Inject a `Config`, for example `Config.in_memory(...)`. Defaults to file-backed `Config.default()`. |
+| `knowledge_manager` | `KnowledgeManager \| None`                    | `None`  | Inject your own knowledge base. See [Advanced](/sdk/advanced/).                              |
+| `thread_manager`    | `ThreadManager \| None`                       | `None`  | Persist conversation history across runs. See [Advanced](/sdk/advanced/).                    |
+| `capabilities` | `Sequence[AbstractCapability[Any] \| Callable]` | `()` | Explicit pydantic-ai capabilities and plugin factories. See [Capabilities](/sdk/capabilities/). SQLsaber always includes SQL and knowledge tools. An embedded session includes only the listed capabilities. The CLI loads installed plugins. |
 | `artifact_store` | `ArtifactStore \| None`                    | `None`  | Application-owned publication and retrieval for artifacts such as analysis notebooks and plots. |
 | `artifact_failure_mode` | `"required" \| "best_effort"`            | `"required"` | Fail the tool or retain its answer when artifact publication fails.                      |
 | `query_result_store` | `QueryResultStore \| None` | `None` | Store for complete SQL row results. Defaults to a session-owned in-memory store. Inject application storage for durable or tenant-scoped retrieval. |
 | `workspace_input_resolver` | `WorkspaceInputResolver \| None` | `None` | Application-owned resolver for opaque, authorized inputs to the managed notebook analyst. |
-| `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)).                            |
-| `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL (see [Advanced](/sdk/advanced)).       |
+| `tool_overrides`    | `Mapping[str, ModelOverides] \| None`         | `None`  | Per-tool model and API-key overrides. See [Advanced](/sdk/advanced/).                            |
+| `allow_dangerous`   | `bool`                                        | `False` | Allow write operations and a restricted subset of DDL. See [Advanced](/sdk/advanced/).       |
 | `csv_tool_results` | `bool` | `False` | Opt in to experimental CSV tables in model-facing SQL tool results. JSON remains the default. |
 
 <Aside type="note">
-  `model_name`, `thinking_*`, `system_prompt`, and the injectable components all
-  have sensible defaults. For many use cases just `database` (plus credentials in
-  your environment) is enough.
+  `model_name`, `thinking_*`, `system_prompt`, and the injectable components have
+  defaults. For many cases, `database` plus credentials in the environment is
+  enough.
 </Aside>
 
 ## Experimental CSV tool results
@@ -59,66 +58,33 @@ saber = SQLSaber(options=SQLSaberOptions(
 ))
 ```
 
-This changes the tabular portions of `list_tables`, `introspect_schema`,
-`execute_sql`, and multi-database `list_dbs` results sent to the model. Metadata,
-schema constraints, errors, and empty results remain JSON. CSV cells use standard
-quoting, `\N` for null, and escaped backslashes; nested cell values use JSON.
-Complete retained query results remain typed JSON. Terminal tables, plugin access,
-and the 12 KiB SQL preview limit are unchanged. Structured rendering data is kept
-in message metadata, not sent to the model as a second copy of the result.
+This changes the tabular portions of `list_tables`, `introspect_schema`, `execute_sql`, and multi-database `list_dbs` results sent to the model. Metadata, schema constraints, errors, and empty results remain JSON. CSV cells use standard quoting, `\N` for null, and escaped backslashes. Nested cell values use JSON. Complete retained query results remain typed JSON. Terminal tables, plugin access, and the 12 KiB SQL preview limit are unchanged. Structured rendering data stays in message metadata. It is not sent to the model as a second copy of the result.
 
-CSV can reduce tokens for multi-row results, but tiny results can be larger and
-its effect on answer quality has not been established. Evaluate it with your
-models and queries before enabling it broadly.
+CSV can reduce tokens for multi-row results. Tiny results can be larger. The effect on answer quality has not been established. Evaluate it with your models and queries before enabling it broadly.
 
-The setting is available as `saber.info.csv_tool_results`. It is not a saved
-global preference or restored from thread history: pass it again in
-`SQLSaber.resume(..., options=SQLSaberOptions(csv_tool_results=True))` to opt in
-for new calls. Existing messages are not rewritten. For a standalone capability,
-use [`SqlTools(csv_tool_results=True)`](/sdk/capabilities#experimental-csv-tool-results).
+The setting is available as `saber.info.csv_tool_results`. It is not a saved global preference, and it is not restored from thread history. Pass it again in `SQLSaber.resume(..., options=SQLSaberOptions(csv_tool_results=True))` to opt in for new calls. Existing messages are not rewritten. For a standalone capability, use [`SqlTools(csv_tool_results=True)`](/sdk/capabilities/#experimental-csv-tool-results).
 
 ## Artifact storage
 
-Embedded SQLsaber does not persist artifacts unless `artifact_store` is injected.
-The injected store is application-owned and is never closed or garbage-collected by
-SQLsaber. The CLI explicitly uses `FilesystemArtifactStore` under its private user
-data directory.
+Embedded SQLsaber does not persist artifacts unless `artifact_store` is injected. The injected store is application-owned. SQLsaber never closes it or garbage-collects it. The CLI uses `FilesystemArtifactStore` under its private user data directory.
 
-Cloud stores should authorize `get()` from the current identity in
-`ArtifactContext.metadata`, keep objects private, and return `ArtifactUnavailable`
-for both missing and unauthorized IDs. Stable descriptor URIs are locators; SQLsaber
-retrieves bytes through the store rather than dereferencing those URIs.
+Cloud stores should authorize `get()` from the current identity in `ArtifactContext.metadata`, keep objects private, and return `ArtifactUnavailable` for both missing and unauthorized IDs. Stable descriptor URIs are locators. SQLsaber retrieves bytes through the store rather than opening those URIs.
 
 ## Query result storage
 
-Every successful row-returning query writes its complete canonical JSON payload to
-`query_result_store`. The model and message history receive only a stable 12 KiB
-projection. An injected store is application-owned and SQLsaber does not close it.
-The SDK default is in-memory; the CLI explicitly uses private filesystem storage.
-A storage failure makes that row-returning tool call fail rather than silently
-claiming complete data is available.
+Every successful row-returning query writes its complete canonical JSON payload to `query_result_store`. The model and message history receive only a stable 12 KiB projection. An injected store is application-owned. SQLsaber does not close it. The SDK default is in-memory. The CLI uses private filesystem storage. A storage failure makes that row-returning tool call fail rather than claiming complete data is available.
 
-For web applications, implement `QueryResultStore.put/get` over a private database
-or object store. Authorize `get` from current identity in
-`QueryResultContext.metadata`; do not authorize solely from possession of a result
-ID, filename, or historical conversation metadata.
+For web applications, implement `QueryResultStore.put` and `QueryResultStore.get` over a private database or object store. Authorize `get` from the current identity in `QueryResultContext.metadata`. Do not authorize solely from possession of a result ID, filename, or historical conversation metadata.
 
 ## Managed notebook inputs
 
-When `sqlsaber-notebook` is listed in `SQLSaberOptions.capabilities`,
-`workspace_input_resolver` lets a
-host application make authorized files available to `analyze_data` without exposing
-filesystem paths, URLs, bucket names, object keys, or raw bytes to the main model.
-See [Analyzing application-owned inputs](/sdk/results-and-streaming#analyzing-application-owned-inputs)
-for the resolver contract and trust boundary.
+When `sqlsaber-notebook` is listed in `SQLSaberOptions.capabilities`, `workspace_input_resolver` lets a host application make authorized files available to `analyze_data` without exposing filesystem paths, URLs, bucket names, object keys, or raw bytes to the main model. See [Application-owned notebook inputs](/sdk/results-and-streaming/#application-owned-notebook-inputs) for the resolver contract and trust boundary.
 
-Without a resolver, SQLsaber preserves the original `analyze_data(goal, files=None)`
-schema: `attachment_refs` is not advertised to the model and SQL result selection is
-unchanged.
+Without a resolver, SQLsaber keeps the original `analyze_data(goal, files=None)` schema: `attachment_refs` is not advertised to the model, and SQL result selection is unchanged.
 
-## Choosing a database
+## Database targets
 
-The `database` option accepts the same targets as the CLI's `-d` flag.
+The `database` option accepts the same targets as the CLI `-d` flag.
 
 ### Connection strings
 
@@ -139,21 +105,18 @@ SQLSaberOptions(database="./customers.csv")
 SQLSaberOptions(database="./orders.parquet")
 ```
 
-### Multiple CSV or Parquet files
+### Several CSV or Parquet files
 
-Pass a list (or tuple) of CSV/Parquet paths to query across them together. All files are
-merged into a single in-memory database with one table per file:
+Pass a list or tuple of CSV or Parquet paths to query them together. All files merge into one in-memory database with one table per file:
 
 ```python
 SQLSaberOptions(database=["users.csv", "orders.csv"])
 SQLSaberOptions(database=["users.csv", "orders.parquet"])
 ```
 
-### Multiple databases
+### Several databases
 
-Pass a list including other targets (configured names, connection strings, or database file
-paths) to connect to [several databases](/guides/multi-database) in one session.
-The agent queries each one separately and combines the results:
+Pass a list that includes other targets (saved names, connection strings, or database file paths) to connect to [several databases](/guides/multi-database/) in one session. The agent queries each one separately and combines the results:
 
 ```python
 SQLSaberOptions(database=["sales", "postgresql://user:pass@host:5432/events"])
@@ -168,8 +131,7 @@ async with SQLSaber(options=options) as saber:
     saber.info.database_names  # ("sales", "events")
 ```
 
-The compatibility properties `saber.db_names` and `saber.connections` remain
-available for callers that need the managed names or connection objects:
+The compatibility properties `saber.db_names` and `saber.connections` remain available for callers that need the managed names or connection objects:
 
 ```python
 async with SQLSaber(options=options) as saber:
@@ -177,14 +139,12 @@ async with SQLSaber(options=options) as saber:
     saber.connections  # {name: connection, ...}
 ```
 
-### A configured database
+### Saved connection
 
-If you've already registered a connection with the CLI (`saber db add`), refer
-to it by name:
+If you already registered a connection with the CLI (`saber db add`), refer to it by name:
 
 ```python
 SQLSaberOptions(database="prod-db")
 ```
 
-See the [Database Setup guide](/guides/database-setup) for details on connection
-strings and registering databases.
+See [Database setup](/guides/database-setup/) for connection strings and registering databases.

--- a/docs/src/content/docs/sdk/configuration.mdx
+++ b/docs/src/content/docs/sdk/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configure the SQLsaber Python SDK with SQLSaberOptions: database connections, model selection, thinking, system prompts, and injectable components.
+description: Configure the SQLsaber Python SDK with SQLSaberOptions. Set database connections, model selection, thinking, system prompts, and injectable components.
 ---
 
 import { Aside } from "@astrojs/starlight/components";

--- a/docs/src/content/docs/sdk/credentials-and-models.mdx
+++ b/docs/src/content/docs/sdk/credentials-and-models.mdx
@@ -1,18 +1,15 @@
 ---
-title: Credentials & Models
-description: "Provide API keys and select models for the SQLsaber Python SDK using stored CLI auth, environment variables, or an in-memory Config."
+title: Credentials and models
+description: Provide API keys and select models for the SQLsaber Python SDK using stored CLI auth, environment variables, or an in-memory Config.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-The SDK needs an LLM provider API key to run queries. There are three ways to
-supply credentials, and you can choose whichever fits your deployment.
+The SDK needs an LLM provider API key to run queries. There are three ways to supply credentials.
 
 ## 1. Reuse CLI-stored credentials (default)
 
-If you omit `settings`, the session uses a file-backed `Config.default()` — the
-same configuration the `saber` CLI uses. Any keys you saved with `saber auth`
-are picked up automatically:
+If you omit `settings`, the session uses a file-backed `Config.default()`, the same configuration the `saber` CLI uses. Keys you saved with `saber auth` are picked up automatically:
 
 ```python
 from sqlsaber import SQLSaber, SQLSaberOptions
@@ -21,13 +18,11 @@ from sqlsaber import SQLSaber, SQLSaberOptions
 options = SQLSaberOptions(database="sqlite:///my.db")
 ```
 
-This is the most convenient option for local scripts on a machine where you
-already use SQLsaber. See the [Authentication guide](/guides/authentication).
+This is the usual choice for local scripts on a machine where you already use SQLsaber. See [Authentication](/guides/authentication/).
 
 ## 2. Environment variables
 
-Both the default and in-memory configs check the provider's environment variable
-before anything else, so exporting a key just works:
+Both the default and in-memory configs check the provider's environment variable first:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-..."
@@ -40,14 +35,20 @@ options = SQLSaberOptions(
 )
 ```
 
-Each provider has its own variable (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-`GOOGLE_API_KEY`, `GROQ_API_KEY`, `XAI_API_KEY`).
+Each provider has its own variable:
 
-## 3. Pass keys explicitly in code
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `GOOGLE_API_KEY`
+- `GROQ_API_KEY`
+- `MISTRAL_API_KEY`
+- `COHERE_API_KEY`
+- `HUGGINGFACE_API_KEY`
+- `XAI_API_KEY`
 
-For servers, CI, or notebooks where you don't want to touch the filesystem or
-keyring, build an in-memory `Config` and inject it via `settings`. This avoids
-any file or keyring I/O:
+## 3. Pass keys in code
+
+For servers, CI, or notebooks where you do not want filesystem or keyring I/O, build an in-memory `Config` and inject it through `settings`:
 
 ```python
 from sqlsaber import SQLSaber, SQLSaberOptions
@@ -62,16 +63,14 @@ options = SQLSaberOptions(
 )
 ```
 
-`api_keys` is a mapping of provider name to key. Supported provider keys are
-`anthropic`, `openai`, `google`, `groq`, and `xai`.
+`api_keys` maps provider name to key. Supported keys are `anthropic`, `openai`, `google`, `groq`, `mistral`, `cohere`, `huggingface`, and `xai`.
 
 <Aside type="caution">
-  Avoid hard-coding API keys in source files. Prefer environment variables or a
+  Do not hard-code API keys in source files. Prefer environment variables or a
   secrets manager, and read them into `api_keys` at runtime.
 </Aside>
 
-For a single key without building a `Config`, you can also set `api_key` directly
-on `SQLSaberOptions` (it requires `model_name` so the provider can be determined):
+For a single key without building a `Config`, set `api_key` on `SQLSaberOptions`. `model_name` is required so the provider can be determined:
 
 ```python
 options = SQLSaberOptions(
@@ -81,7 +80,7 @@ options = SQLSaberOptions(
 )
 ```
 
-## Selecting a model
+## Select a model
 
 Models are identified as `"provider:model"`:
 
@@ -92,8 +91,7 @@ SQLSaberOptions(database="...", model_name="google:gemini-2.5-pro")
 SQLSaberOptions(database="...", model_name="xai:grok-4.6")
 ```
 
-If `model_name` is omitted, the session uses your configured default model. See
-the [Models guide](/guides/models) for the full list of supported providers.
+If `model_name` is omitted, the session uses your configured default model. See [Models](/guides/models/) for supported providers.
 
 ## Extended thinking
 
@@ -107,11 +105,10 @@ SQLSaberOptions(
 )
 ```
 
-Setting `thinking_level` implies `thinking_enabled=True`. You can also set
-`thinking_enabled` on its own to use the model's default level.
+Setting `thinking_level` implies `thinking_enabled=True`. Set `thinking_enabled` on its own to use the model's default level.
 
 <Aside type="note">
   Extended thinking is supported for Anthropic, OpenAI, Google, and Groq
-  reasoning models. See [Running Queries](/guides/queries) for how levels map to
+  reasoning models. See [Running queries](/guides/queries/) for how levels map to
   each provider.
 </Aside>

--- a/docs/src/content/docs/sdk/overview.mdx
+++ b/docs/src/content/docs/sdk/overview.mdx
@@ -1,39 +1,35 @@
 ---
 title: Overview
-description: "Use SQLsaber from Python. Run natural-language to SQL queries with the async SQLSaber conversation lifecycle."
+description: Use SQLsaber from Python. Run natural-language SQL queries with the async SQLSaber conversation lifecycle.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-SQLsaber ships a small public Python API (the SDK) for running natural-language
-queries from Python code. `SQLSaber` is the canonical conversation lifecycle used by
-the CLI and TUI. It is not a separate embedded wrapper. Clients own input and
-presentation, while `SQLSaber` owns agent behavior, completed history, thread
-lifecycle, and managed resources.
+The SQLsaber Python API runs natural-language queries from Python. `SQLSaber` is the conversation lifecycle used by the CLI and TUI. It is not a separate wrapper. Clients own input and presentation. `SQLSaber` owns agent behavior, completed history, thread lifecycle, and managed resources.
 
-The SDK exposes its primary agent and capability building blocks from the top-level `sqlsaber` package:
+Primary exports from the `sqlsaber` package:
 
 | Export            | Purpose                                                       |
 | ----------------- | ------------------------------------------------------------- |
-| `SQLSaber`        | Canonical conversation lifecycle for the CLI, TUI, and SDK. |
-| `SQLSaberOptions` | Typed options bag used to configure a `SQLSaber` session.     |
-| `ModelOverides`   | Per-tool model/API-key overrides (see [Advanced](/sdk/advanced)). |
-| `SqlTools`        | SQL capability for composing with your own pydantic-ai agent. |
+| `SQLSaber`        | Conversation lifecycle for the CLI, TUI, and SDK. |
+| `SQLSaberOptions` | Typed options bag for a `SQLSaber` session.     |
+| `ModelOverides`   | Per-tool model and API-key overrides. See [Advanced](/sdk/advanced/). |
+| `SqlTools`        | SQL capability for an agent you own. |
 | `Knowledge`       | Database-scoped knowledge search capability.                  |
 | `ArtifactStore` | Protocol for immutable artifact publication and authorized retrieval. |
-| `FilesystemArtifactStore` | Durable private local artifact store for CLI/server development. |
-| `InMemoryArtifactStore` | Explicit in-memory artifact store for tests and short-lived workflows. |
+| `FilesystemArtifactStore` | Durable private local artifact store for CLI and server development. |
+| `InMemoryArtifactStore` | In-memory artifact store for tests and short-lived workflows. |
 | `StoredArtifact` / `LoadedArtifact` | Serializable descriptor and verified artifact bytes. |
 | `QueryResultStore` | Protocol for private complete SQL result storage and retrieval. |
 | `InMemoryQueryResultStore` | Session-local SDK default and test implementation. |
-| `FilesystemQueryResultStore` | Durable private local implementation (the CLI uses this explicitly). |
+| `FilesystemQueryResultStore` | Durable private local implementation. The CLI uses this explicitly. |
 | `StoredQueryResult` / `LoadedQueryResult` | Serializable descriptor and verified complete result bytes. |
 
-See [Capabilities](/sdk/capabilities) to use SQLsaber inside your own agent or add your capabilities to its managed agent. See [Build an agent that keeps complete SQL results](/sdk/capability-query-results) to store and reload complete `execute_sql` rows on that agent. See [Results & Streaming](/sdk/results-and-streaming#persisting-notebooks-and-plots) for artifact publishing.
+See [Capabilities](/sdk/capabilities/) to use SQLsaber inside your own agent, or to add capabilities to the managed agent. See [Build an agent that keeps complete SQL results](/sdk/capability-query-results/) to store and reload complete `execute_sql` rows. See [Results and streaming](/sdk/results-and-streaming/#notebook-and-plot-artifacts) for artifact publishing.
 
 ## Installation
 
-The SDK is included with the main package — no extra install required.
+The SDK ships in the main package. No extra install is required.
 
 ```bash
 uv add sqlsaber
@@ -43,8 +39,7 @@ pip install sqlsaber
 
 ## Quickstart
 
-Create a `SQLSaberOptions`, open a `SQLSaber` session, and `await` a query. The
-result behaves like a string containing the agent's answer.
+Create a `SQLSaberOptions`, open a `SQLSaber` session, and `await` a query. The result behaves like a string that holds the agent's answer.
 
 ```python
 import asyncio
@@ -69,37 +64,26 @@ if __name__ == "__main__":
 ```
 
 <Aside type="note">
-  `query()` is asynchronous, so call it inside an `async` function (e.g. via
-  `asyncio.run`). The `SQLSaber` constructor is keyword-only — always pass
+  `query()` is asynchronous, so call it inside an `async` function, for example
+  through `asyncio.run`. The `SQLSaber` constructor is keyword-only. Always pass
   `options=...`.
 </Aside>
 
 ## Use the conversation lifecycle
 
-A `SQLSaber` instance keeps the completed history for its conversation. A second
-`query()` on the same instance uses that history automatically.
+A `SQLSaber` instance keeps the completed history for its conversation. A second `query()` on the same instance uses that history automatically.
 
-Use these methods for common lifecycle tasks:
-
-- `SQLSaber.info` returns immutable metadata such as database names, model details,
-  thinking state, dangerous mode, and the current thread ID. Access it as
-  `saber.info`.
-- `saber.set_thinking(enabled=..., level=...)` changes reasoning controls for later
-  queries and returns the new `ThinkingState`.
+- `SQLSaber.info` returns immutable metadata such as database names, model details, thinking state, dangerous mode, and the current thread ID. Access it as `saber.info`.
+- `saber.set_thinking(enabled=..., level=...)` changes reasoning controls for later queries and returns the new `ThinkingState`.
 - `await saber.list_tables()` returns `TableInfo` values for every managed database.
-- `await saber.draft_handoff(goal)` creates a handoff draft from the conversation's
-  history.
+- `await saber.draft_handoff(goal)` creates a handoff draft from the conversation's history.
 - `await saber.end_thread()` marks the current persisted thread as ended.
-- `await saber.new_thread()` ends the current persisted thread, clears conversation
-  history, and returns the previous thread ID.
-- `await SQLSaber.resume(thread_id, options=options)` restores a persisted thread.
-  See [Advanced](/sdk/advanced) for resume errors and storage details.
+- `await saber.new_thread()` ends the current persisted thread, clears conversation history, and returns the previous thread ID.
+- `await SQLSaber.resume(thread_id, options=options)` restores a persisted thread. See [Advanced](/sdk/advanced/) for resume errors and storage details.
 
-## Managing the connection
+## Close the connection
 
-`SQLSaber` owns a live database connection. Use it as an async context manager
-(`async with`) so the connection is closed automatically, or call `await
-saber.close()` yourself:
+`SQLSaber` owns a live database connection. Use it as an async context manager so the connection closes automatically, or call `await saber.close()` yourself:
 
 ```python
 options = SQLSaberOptions(database="sqlite:///my.db")
@@ -112,14 +96,11 @@ finally:
 
 ## Credentials
 
-By default the SDK reuses the credentials you configured for the CLI (via
-`saber auth`) and any provider environment variables such as
-`ANTHROPIC_API_KEY`. You can also pass keys explicitly in code — see
-[Credentials & Models](/sdk/credentials-and-models).
+By default the SDK reuses the credentials you configured for the CLI with `saber auth`, and any provider environment variables such as `ANTHROPIC_API_KEY`. Pass keys in code when you do not want CLI or keyring storage. See [Credentials and models](/sdk/credentials-and-models/).
 
-## Where to next?
+## Next steps
 
-1. [Configuration](/sdk/configuration) — every `SQLSaberOptions` field.
-2. [Credentials & Models](/sdk/credentials-and-models) — auth and model selection.
-3. [Results & Streaming](/sdk/results-and-streaming) — read SQL, usage, and stream events.
-4. [Advanced](/sdk/advanced) — tool overrides, custom prompts, write access, and more.
+1. [Configuration](/sdk/configuration/) for every `SQLSaberOptions` field
+2. [Credentials and models](/sdk/credentials-and-models/) for auth and model selection
+3. [Results and streaming](/sdk/results-and-streaming/) for SQL, usage, and stream events
+4. [Advanced](/sdk/advanced/) for tool overrides, custom prompts, and write access

--- a/docs/src/content/docs/sdk/results-and-streaming.mdx
+++ b/docs/src/content/docs/sdk/results-and-streaming.mdx
@@ -1,21 +1,18 @@
 ---
-title: Results & Streaming
-description: "Read SQLsaber SDK query results: the text answer, generated SQL, token usage, streaming events, and stateful follow-up conversations."
+title: Results and streaming
+description: "Read SQLsaber SDK query results: the text answer, generated SQL, token usage, streaming events, and follow-up conversations."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-`saber.query()` returns a `SQLSaberResult`. It subclasses `str`, so it is the
-agent's text answer, while also exposing the full execution details. A
-`SQLSaber` instance stores the completed history from each successful query, so a
-later query on the same instance continues the conversation.
+`saber.query()` returns a `SQLSaberResult`. It subclasses `str`, so it is the agent's text answer and also exposes the full execution details. A `SQLSaber` instance stores the completed history from each successful query, so a later query on the same instance continues the conversation.
 
 ```python
 result = await saber.query("How many orders shipped last week?")
 
 print(result)            # the answer, as a string
 print(result.usage)      # token usage for this run
-print(result.new_messages)  # messages from this run (incl. tool calls / SQL)
+print(result.new_messages)  # messages from this run, including tool calls and SQL
 ```
 
 ## Result properties
@@ -33,7 +30,7 @@ print(result.new_messages)  # messages from this run (incl. tool calls / SQL)
 | `.query_results`  | Durable complete-query-result descriptors created during this run.                                      |
 | `.artifacts`      | Durable artifact references published by capabilities during this run.                                   |
 
-## Controlling run usage
+## Run usage limits
 
 Pass Pydantic AI's `UsageLimits` to `query()` when a long-horizon task needs a
 larger request budget or when the embedding application needs token or tool-call
@@ -57,10 +54,10 @@ The managed notebook analyst always shares the parent's live usage counter, so i
 model requests are included exactly once in `result.usage`. When the caller
 explicitly passes `usage_limits`, the analyst inherits that budget. When the caller
 omits `usage_limits`, the analyst itself is uncapped (`request_limit=None`) rather
-than silently acquiring Pydantic AI's per-agent default; the parent SQLsaber run
+than silently acquiring Pydantic AI's per-agent default. The parent SQLsaber run
 still retains its safe default.
 
-## Retrieving complete query results
+## Complete query results
 
 Complete rows are deliberately absent from model history. Use the descriptors on
 the result and retrieve bytes through the configured store. On an agent you own,
@@ -85,21 +82,19 @@ for descriptor in result.query_results:
 
 These are separate concepts:
 
-- **complete result availability** means every row returned by SQLsaber remains
-  retrievable through the store;
-- **UI rendering policy** may show a bounded terminal or HTML table; and
-- **model projection** is a deterministic, byte-bounded preview and must not be
-  used for whole-dataset statistics when marked truncated.
+- **Complete result availability.** Every row returned by SQLsaber remains retrievable through the store.
+- **UI rendering policy.** Terminal and HTML views may still show a bounded table.
+- **Model projection.** A deterministic, byte-bounded preview. Do not use it for whole-dataset statistics when it is marked truncated.
 
 Legacy threads containing embedded complete rows remain readable during the
 compatibility window, but are not automatically imported into durable storage.
 
-## Analyzing application-owned inputs
+## Application-owned notebook inputs
 
 Install `sqlsaber-notebook` and list it in `SQLSaberOptions.capabilities` when the
 managed agent should analyze private images, arrays, JSON, or other application-owned
 files. The CLI lists installed plugins for you. The model sees only opaque
-`attachment_refs`; your resolver converts authorized references into trusted
+`attachment_refs`. Your resolver converts authorized references into trusted
 `WorkspaceFile` bytes:
 
 ```python
@@ -159,16 +154,14 @@ async with SQLSaber(options=options) as saber:
     )
 ```
 
-The host—not SQLsaber or the notebook package—owns reference issuance, retrieval,
+The host, not SQLsaber or the notebook package, owns reference issuance, retrieval,
 authorization, expiration, and history scoping. Never treat possession of a reference
 as authorization, and never interpret model-provided values as local paths, URLs,
 bucket names, or object keys. Raise `WorkspaceInputUnavailable` with the same bounded
 message for missing and unauthorized references. SQLsaber hides unexpected resolver
 exceptions so storage details do not enter model history.
 
-Resolver output is validated before any notebook starts. Names must be visible,
-single-component filenames; `manifest.json` is reserved; bytes must be immutable;
-and duplicate names or collisions with SQL result names fail the request. The managed
+Resolver output is validated before any notebook starts. Names must be visible, single-component filenames. `manifest.json` is reserved. Bytes must be immutable. Duplicate names or collisions with SQL result names fail the request. The managed
 workspace allows at most 50 files, 100 MiB per file, and 250 MiB total across SQL
 results and resolved inputs. Filenames are capped at 255 UTF-8 bytes, and the staged
 metadata manifest has a separate 1 MiB limit. Explicit SQL result order is preserved,
@@ -177,11 +170,11 @@ to `manifest.json`.
 
 With no resolver, `attachment_refs` is omitted from the model-visible tool schema.
 The existing `files` selector still means only complete `execute_sql` result keys.
-Resolved images are staged as notebook files; they are not automatically sent as
+Resolved images are staged as notebook files. They are not automatically sent as
 initial multimodal content to the child model. The analyst can load and display an
 image, after which existing bounded PNG snapshot behavior applies.
 
-## Persisting notebooks and plots
+## Notebook and plot artifacts
 
 Pass the notebook factory in `SQLSaberOptions.capabilities`.
 Inject an `artifact_store` to retain executed notebooks, plots, and generated files.
@@ -217,10 +210,10 @@ async with SQLSaber(options=options) as saber:
 ```
 
 `ArtifactStore.publish()` receives an `ArtifactBundle` and current
-`ArtifactContext`; `get()` retrieves one artifact by opaque ID. A cloud store must
+`ArtifactContext`. `get()` retrieves one artifact by opaque ID. A cloud store must
 authorize retrieval from the *current* context metadata, return
 `ArtifactUnavailable` for both missing and unauthorized IDs, and return stable
-private object keys/internal URIs rather than expiring signed URLs. Generate signed
+private object keys or internal URIs rather than expiring signed URLs. Generate signed
 download URLs only in the host application's serving layer.
 
 The store is application-owned and SQLsaber never closes or garbage-collects it.
@@ -233,7 +226,7 @@ Use `"best_effort"` to preserve the analyst's answer and expose an
 `artifact_error` in tool metadata instead.
 
 The same application-owned store also supports direct `sqlsaber-notebook`
-embedding. Analysis remains storage-independent; publish its completed result in a
+embedding. Analysis remains storage-independent. Publish its completed result in a
 second explicit operation:
 
 ```python
@@ -262,7 +255,7 @@ Managed SQLsaber calls this same publication operation. The standalone
 explicit notebook and sibling artifact directory and never silently uses SQLsaber's
 user-data store.
 
-## Inspecting the generated SQL
+## Generated SQL
 
 The SQL the agent ran lives in the run's messages as tool calls. Message values
 and streaming event values use `pydantic_ai` types, not framework-neutral SDK
@@ -282,9 +275,7 @@ for message in result.new_messages:
 
 ## Streaming events
 
-Pass an `event_stream_handler` to react to events (text chunks, tool calls,
-etc.) as they arrive, rather than waiting for the final answer. The handler is an
-async function that receives the run context and an async iterable of events:
+Pass an `event_stream_handler` to react to events as they arrive, such as text chunks and tool calls, rather than waiting for the final answer. The handler is an async function that receives the run context and an async iterable of events:
 
 ```python
 from collections.abc import AsyncIterable
@@ -324,10 +315,10 @@ columns to PostgreSQL and stores payload bytes in a private `bytea` column (or a
 object key for private blob storage). Its `get` implementation should query by both
 `result_id` and the current `tenant_id` from `QueryResultContext.metadata`, then
 raise `QueryResultUnavailable` for both missing and unauthorized rows. Apply
-application retention, encryption, audit, and deletion policies there; filesystem
+application retention, encryption, audit, and deletion policies there. Filesystem
 storage is not suitable for horizontally scaled web deployments.
 
-## Multi-turn conversations
+## Follow-up queries
 
 Run follow-up queries on the same `SQLSaber` instance. Each completed query updates
 that instance's conversation history automatically.

--- a/plugins/sandbox/README.md
+++ b/plugins/sandbox/README.md
@@ -1,3 +1,9 @@
-# SQLSaber Sandbox Plugin
+# SQLsaber sandbox plugin
 
-Provides the `run_python` tool for SQLsaber via the `sqlsaber-sandbox` plugin.
+The `sqlsaber-sandbox` plugin adds a `run_python` tool. SQLsaber executes Python in a remote sandbox when a provider is configured.
+
+```bash
+uv tool install --with sqlsaber-sandbox sqlsaber
+```
+
+Set at least one provider key, such as `E2B_API_KEY` or `DAYTONA_API_KEY`. See [Plugins](https://sqlsaber.com/guides/plugins/).

--- a/plugins/viz/README.md
+++ b/plugins/viz/README.md
@@ -1,3 +1,9 @@
-# SQLSaber Visualization Plugin
+# SQLsaber visualization plugin
 
-Provides the `viz` tool for SQLSaber via the `sqlsaber-viz` plugin. The tool generates a declarative chart spec and renders ASCII charts in the terminal using plotext.
+The `sqlsaber-viz` plugin adds a `viz` tool. It builds a chart spec from query results and renders ASCII charts in the terminal with plotext.
+
+```bash
+uv tool install --with sqlsaber-viz sqlsaber
+```
+
+After a query, ask SQLsaber to plot the result. See [Plugins](https://sqlsaber.com/guides/plugins/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pass applies a layered writing standard to the site, README, and short plugin READMEs.

**What changed**

- Each user-facing page now has one job. Getting started is a tutorial. Guides are how-tos. Commands is reference. SDK pages stay lookup or how-to, not a mix of both in the same section.
- Prose talks to you, uses the real command and symbol names, and cuts words that do no work.
- The sidebar lists Plugins. Installation and the plugins guide include `sqlsaber-notebook`. Command reference documents `saber threads export` and `/help`.
- Authentication lists every provider environment variable from `sqlsaber.config.providers`.
- Getting started no longer lists Python as a prerequisite. The CLI installers do not require a local Python.
- Installation presents [uvx.sh](https://uvx.sh/) as a first-class path: one curl or PowerShell command for people who do not have uv.
- Home, Getting started, and the README now use asciinema recording [1265197](https://asciinema.org/a/1265197). The docs pages embed the player. The README uses the image-link embed because GitHub Markdown cannot run the player script. Queries still uses recording 739399.

**Out of scope**

The changelog is a historical record, so those entries stay as written. The long notebook plugin README is operator detail and was left in place.

**How to review**

Skim Getting started, Installation, Database setup, Plugins, and Commands. Confirm the uvx.sh curl and PowerShell commands, the new sidebar Plugins entry, and that notebook install instructions match `uv tool install --with`. Play the demo on Home and Getting started, and click the README preview image through to https://asciinema.org/a/1265197.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08ee9-7f1d-71ea-a6ac-6c99c266611a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08ee9-7f1d-71ea-a6ac-6c99c266611a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

