### PR TITLE
fix(cli): paint dangerous-mode notice below intro bullets

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -19,7 +19,6 @@ DANGEROUS_MODE_SCOPE = (
     "UPDATE/DELETE require WHERE."
 )
 
-DANGEROUS_MODE_WARNING = f"The assistant can execute {DANGEROUS_MODE_SCOPE}"
 DANGEROUS_MODE_HELP = f"Allow {DANGEROUS_MODE_SCOPE}"
 DATABASE_OPTION_HELP = (
     "Database connection name, file path (CSV/Parquet/SQLite/DuckDB), or connection "
@@ -380,7 +379,9 @@ def query(
                     )
                 )
                 if allow_dangerous:
-                    out(b.warn(DANGEROUS_MODE_WARNING, label="DANGEROUS MODE ENABLED"))
+                    from sqlsaber.cli.interactive import InteractiveSession
+
+                    out(InteractiveSession.dangerous_mode_notice())
                 log.info("query.execute.start", db_name=db_name, db_type=db_type)
                 meter = UsageMeter(model_id=lambda: info.model_id or info.model_name)
                 await streaming_handler.execute_streaming_query(
@@ -405,8 +406,6 @@ def query(
             else:
                 from sqlsaber.cli.interactive import InteractiveSession
 
-                if allow_dangerous:
-                    out(b.warn(DANGEROUS_MODE_WARNING, label="DANGEROUS MODE ENABLED"))
                 shell = InteractiveSession.start_unbound_shell(
                     database=selected_database,
                     allow_dangerous=allow_dangerous,

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -313,7 +313,6 @@ class InteractiveSession:
 
     @staticmethod
     def dangerous_mode_notice() -> Md:
-        """Warning-tinted markdown describing what dangerous mode permits."""
         bullets = (
             "INSERT, UPDATE, and DELETE are allowed",
             "Restricted DDL is allowed (CREATE TABLE/VIEW/INDEX, ALTER TABLE)",

--- a/src/sqlsaber/cli/interactive.py
+++ b/src/sqlsaber/cli/interactive.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from sqlsaber.cli.chat_surface import ChatSurface
     from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
     from sqlsaber.cli.usage import UsageMeter
+    from sqlsaber.render.blocks import Md
 
 
 def bind_update_notice(emit: Callable[..., None] | None) -> None:
@@ -272,10 +273,7 @@ class InteractiveSession:
         surface = ChatSurface(app)
         app_ref["app"] = app
         surface_ref["surface"] = surface
-        surface.emit(
-            b.md("**Welcome to SQLsaber!**", role="primary"),
-            b.md(cls._instructions()),
-        )
+        surface.emit(*cls._intro_blocks(allow_dangerous=allow_dangerous))
         app.tui.start()
         bind_update_notice(surface.emit)
         return ChatShell(
@@ -312,6 +310,29 @@ class InteractiveSession:
                 history_file.write(f"+{text.replace('\n', ' ')}\n")
         except OSError:
             return
+
+    @staticmethod
+    def dangerous_mode_notice() -> Md:
+        """Warning-tinted markdown describing what dangerous mode permits."""
+        bullets = (
+            "INSERT, UPDATE, and DELETE are allowed",
+            "Restricted DDL is allowed (CREATE TABLE/VIEW/INDEX, ALTER TABLE)",
+            "DROP, TRUNCATE, and admin/security operations stay blocked",
+            "UPDATE and DELETE require WHERE",
+        )
+        body = "**Dangerous mode enabled**\n\n" + "\n".join(
+            f"- {item}" for item in bullets
+        )
+        return b.md(body, role="warning")
+
+    @classmethod
+    def _intro_blocks(cls, *, allow_dangerous: bool) -> tuple[Md, ...]:
+        notice = (cls.dangerous_mode_notice(),) if allow_dangerous else ()
+        return (
+            b.md("**Welcome to SQLsaber!**", role="primary"),
+            b.md(cls._instructions()),
+            *notice,
+        )
 
     @staticmethod
     def _instructions() -> str:
@@ -385,8 +406,7 @@ class InteractiveSession:
         info = self.saber.info
         if info.is_new_thread:
             surface.emit(
-                b.md("**Welcome to SQLsaber!**", role="primary"),
-                b.md(self._instructions()),
+                *self._intro_blocks(allow_dangerous=self.saber.info.dangerous_mode),
             )
 
         if info.thread_id:

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -350,6 +350,41 @@ async def test_start_unbound_shell_paints_slash_hint_and_db_footer() -> None:
         assert "Welcome to SQLsaber!" in text
         assert "slash commands" in folded
         assert "table name completions" in folded
+        assert "Dangerous mode enabled" not in text
+        assert "DB:" in text
+        assert "verification" in folded
+        assert "█" not in text
+        assert terminal.started is True
+    finally:
+        shell.stop()
+    assert terminal.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_start_unbound_shell_paints_dangerous_mode_notice_below_instructions() -> (
+    None
+):
+    terminal = FakeTerminal(columns=100, rows=24)
+    shell = InteractiveSession.start_unbound_shell(
+        database="/tmp/fixtures/verification.db",
+        allow_dangerous=True,
+        terminal=terminal,
+    )
+    try:
+        shell.app.tui.flush_render()
+        text = "\n".join(shell.app.render_plain_viewport())
+        folded = text.casefold()
+        welcome = text.index("Welcome to SQLsaber!")
+        slash = text.index("slash commands")
+        ctrl_d = text.index("Ctrl+D")
+        notice = text.index("Dangerous mode enabled")
+        insert = text.index("INSERT, UPDATE, and DELETE are allowed")
+        assert welcome < slash < ctrl_d < notice < insert
+        assert (
+            "Restricted DDL is allowed (CREATE TABLE/VIEW/INDEX, ALTER TABLE)" in text
+        )
+        assert "DROP, TRUNCATE, and admin/security operations stay blocked" in text
+        assert "UPDATE and DELETE require WHERE" in text
         assert "DB:" in text
         assert "verification" in folded
         assert "█" not in text

--- a/tests/test_cli/test_tui_chat.py
+++ b/tests/test_cli/test_tui_chat.py
@@ -38,8 +38,9 @@ from sqlsaber.cli.output import status
 from sqlsaber.cli.tui_chat import ChatApp, build_chat_app
 from sqlsaber.cli.tui_streaming import TUIStreamingQueryHandler
 from sqlsaber.config.settings import ThinkingLevel
-from sqlsaber.render import blocks as b
 from sqlsaber.render import bind_cli_surfaces
+from sqlsaber.render import blocks as b
+from sqlsaber.render.markdown_text import markdown_source
 from sqlsaber.render.prompts import PromptForm
 from sqlsaber.render.surface import AskChoice, AskSecret, AskText, Choice
 from sqlsaber.theme.manager import get_theme_manager
@@ -794,11 +795,50 @@ def test_welcome_message_uses_compact_greeting() -> None:
     viewport = "\n".join(app.render_plain_viewport())
     assert "Welcome to SQLsaber!" in viewport
     assert "slash commands" in viewport
+    assert "Dangerous mode enabled" not in viewport
     assert "█" not in viewport
 
 
+def test_welcome_message_paints_dangerous_mode_notice_below_instructions() -> None:
+    terminal = FakeTerminal(columns=100, rows=24)
+    session = InteractiveSession(_fake_saber(dangerous_mode=True))
+    app = build_chat_app(
+        terminal=terminal,
+        on_submit=lambda text: None,
+        footer_text=session._footer_text(),
+    )
+    session.show_welcome_message(app)
+    app.tui.start()
+    app.tui.flush_render()
+
+    viewport = "\n".join(app.render_plain_viewport())
+    welcome = viewport.index("Welcome to SQLsaber!")
+    slash = viewport.index("slash commands")
+    ctrl_d = viewport.index("Ctrl+D")
+    notice = viewport.index("Dangerous mode enabled")
+    insert = viewport.index("INSERT, UPDATE, and DELETE are allowed")
+    assert welcome < slash < ctrl_d < notice < insert
+    assert (
+        "Restricted DDL is allowed (CREATE TABLE/VIEW/INDEX, ALTER TABLE)" in viewport
+    )
+    assert "DROP, TRUNCATE, and admin/security operations stay blocked" in viewport
+    assert "UPDATE and DELETE require WHERE" in viewport
+    assert "█" not in viewport
+
+
+def test_dangerous_mode_notice_markdown_source() -> None:
+    assert markdown_source(InteractiveSession.dangerous_mode_notice()) == (
+        "**Dangerous mode enabled**\n"
+        "\n"
+        "- INSERT, UPDATE, and DELETE are allowed\n"
+        "- Restricted DDL is allowed (CREATE TABLE/VIEW/INDEX, ALTER TABLE)\n"
+        "- DROP, TRUNCATE, and admin/security operations stay blocked\n"
+        "- UPDATE and DELETE require WHERE"
+    )
+
+
 def test_welcome_message_skips_greeting_when_resuming_thread() -> None:
-    saber = _fake_saber()
+    saber = _fake_saber(dangerous_mode=True)
     saber.info.is_new_thread = False
     saber.info.thread_id = "thread-123"
     terminal = FakeTerminal(columns=100, rows=24)
@@ -814,6 +854,7 @@ def test_welcome_message_skips_greeting_when_resuming_thread() -> None:
 
     viewport = "\n".join(app.render_plain_viewport())
     assert "Welcome to SQLsaber!" not in viewport
+    assert "Dangerous mode enabled" not in viewport
     assert "Resuming thread: thread-123" in viewport
     assert "█" not in viewport
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Interactive `--allow-dangerous` printed a wrapping one-line warning on stdout before the TUI welcome. That put a safety notice above the greeting. The intro now owns the notice and paints it after the instruction bullets as a warning-tinted markdown list.

## Scope

- `InteractiveSession.dangerous_mode_notice` and `_intro_blocks` in `src/sqlsaber/cli/interactive.py`
- Interactive `query` path in `src/sqlsaber/cli/commands.py` no longer emits the stdout warn
- One-shot `query` reuses the same notice after connection info
- Viewport order tests in `tests/test_cli/test_interactive_boot.py` and `tests/test_cli/test_tui_chat.py`

## Tradeoffs

Rejected keeping `b.warn` with a label. Note renders `**LABEL:** body` on one line, which is the wrapping wall of text in the screenshot. A separate warning-role Md list matches the instruction bullets.

Rejected folding the notice into `_instructions()`. Session hints and the safety policy stay separate blocks so the policy can keep the warning tint.

## Blast Radius

Interactive and one-shot `--allow-dangerous` users see the new notice. Safe mode is unchanged. SQL guard policy is unchanged.

## Verification

- `env -u FORCE_COLOR uv run python -m pytest`: 1639 passed, 6 skipped
- `uvx ty check src/`: all checks passed
- `time uv run saber --help`: 0.183s
- Isolated `verify-sqlsaber drive` of `uv run saber --allow-dangerous -d $FIXTURE`: Welcome, then instruction bullets, then `Dangerous mode enabled` and the four policy bullets. No `DANGEROUS MODE ENABLED:` line above Welcome. Footer still shows `Dangerous mode`.
- Control drive without `--allow-dangerous`: Welcome and instruction bullets only. No dangerous notice.

![Interactive TUI with dangerous-mode notice after the instruction bullets](https://cursor.com/artifacts/c/art-62041159-a293-43e9-b33c-85bd042159eb)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84ecf504-a5e7-4e4f-b49d-dcd93ae4d960?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84ecf504-a5e7-4e4f-b49d-dcd93ae4d960&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

