### PR TITLE
feat(rpc): add saber rpc JSONL protocol for embedding

### DIFF
--- a/.agents/skills/verify-sqlsaber/features/README.md
+++ b/.agents/skills/verify-sqlsaber/features/README.md
@@ -49,3 +49,4 @@ Each feature file has an H1 title and one user-focused summary. It then uses fou
 - [Knowledge base](./knowledge-base.md) covers database-scoped add, list, show, search, remove, clear, and agent retrieval.
 - [Conversation threads](./conversation-threads.md) covers empty and populated listing, transcript display, artifacts, resume, export, and pruning.
 - [Terminal output](./terminal-output.md) covers redirected Markdown, stream separation, and ANSI-free output.
+- [RPC mode](./rpc-mode.md) covers headless JSONL embedding: help, startup errors, idle commands, keep-open stdin, and abort.

--- a/.agents/skills/verify-sqlsaber/features/command-discovery.md
+++ b/.agents/skills/verify-sqlsaber/features/command-discovery.md
@@ -5,7 +5,7 @@ Command discovery lets a user identify the installed SQLsaber version, see the r
 ## Sub-features
 
 - `discovery-version` prints the checkout's application version and exits successfully.
-- `discovery-root-help` lists the `auth`, `db`, `knowledge`, `models`, `theme`, and `threads` commands.
+- `discovery-root-help` lists the `auth`, `db`, `knowledge`, `models`, `theme`, `threads`, and `rpc` commands.
 - `discovery-command-help` shows parameters, options, and repository-backed examples for a selected command.
 - `discovery-read-only` does not create database, model, knowledge, or thread files.
 
@@ -23,7 +23,7 @@ Preconditions:
 - No SQLsaber feature command has run in this isolated home.
 
 - **Version entry.** Run `.agents/skills/verify-sqlsaber/bin/verify-sqlsaber drive "$RUN_ID" --evidence command-discovery/version.txt -- uv run saber --version`. Exit code `0` and terminal output are the version in `pyproject.toml`.
-- **Root help entry.** Run `.agents/skills/verify-sqlsaber/bin/verify-sqlsaber drive "$RUN_ID" --evidence command-discovery/root-help.txt -- uv run saber --help`. Exit code `0`, the heading contains `Commands`, and all six command families appear.
+- **Root help entry.** Run `.agents/skills/verify-sqlsaber/bin/verify-sqlsaber drive "$RUN_ID" --evidence command-discovery/root-help.txt -- uv run saber --help`. Exit code `0`, the heading contains `Commands`, and all seven command families appear.
 - **Short help entry.** Run `.agents/skills/verify-sqlsaber/bin/verify-sqlsaber drive "$RUN_ID" --evidence command-discovery/short-help.txt -- uv run saber -h`. It reaches the same root help and exits `0`.
 - **Command help entry.** Run `.agents/skills/verify-sqlsaber/bin/verify-sqlsaber drive "$RUN_ID" --evidence command-discovery/db-add-help.txt -- uv run saber db add --help`. The output names `NAME`, `--type`, `--database`, `--no-interactive`, and the SQLite example.
 - **Read-only proof.** Run `STATE=$(.agents/skills/verify-sqlsaber/bin/verify-sqlsaber path "$RUN_ID" state)` and `find "$STATE/home/config" "$STATE/home/data" -type f -print | sort > ".agents/skills/verify-sqlsaber/artifacts/$RUN_ID/command-discovery/app-state-files.txt"`. The file is empty. The app log may exist at the separate path returned by `path log`, and `uv run` may populate `home/cache`; neither is user configuration.

--- a/.agents/skills/verify-sqlsaber/features/rpc-mode.md
+++ b/.agents/skills/verify-sqlsaber/features/rpc-mode.md
@@ -1,0 +1,43 @@
+# RPC mode
+
+`saber rpc` speaks JSONL on stdin/stdout so an IDE or other app can embed the SQL agent without the terminal UI.
+
+## Sub-features
+
+- `rpc-help` lists flags and repository-backed examples from `saber rpc --help`.
+- `rpc-startup-no-database` writes one `startup` JSON error to stdout and exits `1` when no database is configured.
+- `rpc-usage` reports `--thread` with `--no-thread` on stderr and exits `2` with empty stdout.
+- `rpc-ready` emits a `ready` event for an ad hoc SQLite file, then answers `get_state`, `get_tables`, `get_messages`, and `shutdown` as JSONL on stdout.
+- `rpc-keep-open` answers a command while stdin stays open. Closing stdin after every line is not enough; that path can hide a buffered-read deadlock.
+- `rpc-abort` accepts a `prompt`, then a `shutdown` (or `abort`) before the model finishes, and emits `agent_end` with `status:"aborted"`.
+
+## How to get to it (user POV)
+
+- Run `saber rpc --help`.
+- Run `saber rpc` with no saved database.
+- Pipe JSONL: `printf '%s\n' '{"type":"get_state"}' '{"type":"shutdown"}' | saber rpc -d FILE --no-thread`.
+- Keep stdin open and write one command at a time (the embedding path).
+
+## Driving it with verify-sqlsaber
+
+Preconditions:
+
+- Doctor reports `HEALTHY`.
+- Use `verify-sqlsaber run`, not `drive`. RPC is redirected JSONL. `run` sets the child's stdin to `/dev/null`, so any session that needs commands must wrap a pipe or a keep-open writer in `bash -c` or `python3`.
+- `FIXTURE=$("$VERIFY_SQLSABER" path "$RUN_ID" fixture)`.
+
+- **Help.** `run` `uv run saber rpc --help`. Exit `0`. Stdout contains `Examples` and `--no-thread`.
+- **No database.** `run` `uv run saber rpc`. Exit `1`. Stdout is one JSON object with `command` `startup`, `success` false, and `sqlsaber db add`. Stderr is empty.
+- **Exclusive flags.** `run` `uv run saber rpc --thread abc --no-thread`. Exit `2`. Stderr contains `mutually exclusive`. Stdout is empty.
+- **Idle session.** Pipe `get_state`, `get_tables`, `get_messages`, `get_last_assistant_text`, and `shutdown` into `uv run saber rpc -d "$FIXTURE" --no-thread`. Exit `0`. First line is `ready` with `database.name` `verification` and `threadPersistence` false. `get_tables` lists `departments`, `employees`, and `orders`. Stderr is empty.
+- **Keep stdin open.** Start `uv run saber rpc -d "$FIXTURE" --no-thread` with a Python `Popen` pipe. Read `ready`. Write one `get_state` line and flush without closing stdin. The `get_state` response must arrive while the pipe is still open. Then `shutdown`.
+- **Abort.** Pipe a `prompt` and an immediate `shutdown`. Require `response` `prompt` success, `agent_start` with `promptId`, `agent_end` `aborted`, and `shutdown` success. Do not require a model completion.
+- **Completed prompt.** Optional. Keep stdin open after `prompt` until `agent_end`. Needs a working provider credential. If the model never streams, retain the idle and abort transcripts and mark this entry unreachable.
+
+## Gotchas
+
+- `echo "show users" | saber` is a one-shot question, not RPC. RPC is the `rpc` subcommand.
+- Construction can prompt for an API key via `getpass`. RPC disables that; a missing key is a `startup` JSON error.
+- `verify-sqlsaber run` cannot feed stdin itself. A batch `printf | saber rpc` also sends EOF, so it does not prove the keep-open path.
+- `BufferedReader.read(n)` on stdin waits for `n` bytes or EOF. The process must use a single raw read (`read1`) or an interactive client hangs after `ready`.
+- Default thinking follows the saved model config. `--no-thinking` is the same flag pair as the root command.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -120,6 +120,7 @@ export default defineConfig({
 					label: "Reference",
 					items: [
 						{ label: "Commands", slug: "reference/commands" },
+						{ label: "RPC mode", slug: "reference/rpc" },
 					],
 				},
 				{

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -12,6 +12,10 @@ All notable changes to SQLsaber will be documented here.
 * add xAI Grok as a first-class provider (`xai:grok-4.6`)
 * add `saber rpc` headless JSONL mode for embedding the SQL agent
 
+### Bug Fixes
+
+* **rpc:** answer commands while stdin stays open (stop filling an 8 KiB read buffer)
+
 ---
 
 ## [0.76.0](https://github.com/SarthakJariwala/sqlsaber/compare/sqlsaber-v0.75.0...sqlsaber-v0.76.0) (2026-09-11)

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -10,6 +10,7 @@ All notable changes to SQLsaber will be documented here.
 ### Features
 
 * add xAI Grok as a first-class provider (`xai:grok-4.6`)
+* add `saber rpc` headless JSONL mode for embedding the SQL agent
 
 ---
 

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -41,6 +41,8 @@ saber --thread a1b2c3d4 "Now compare that with last quarter"
 - `--system-prompt` - Custom system prompt text or path to a file (overrides built-in prompt)
 - `--thread` - Continue a saved thread non-interactively. Requires a query; uses the stored configured database unless `-d` overrides it.
 
+Headless embedding uses [`saber rpc`](/reference/rpc), not a flag on this command. Piped stdin (`echo "show users" | saber`) is still a one-shot question.
+
 **Global Options:**
 
 - `--help, -h` - Display help message
@@ -75,6 +77,34 @@ no in-session toggle; launch with the desired flag.
 CSV often reduces token usage for multi-row data, but small results may be larger.
 The effect on model answer quality is not yet established, so this remains opt-in.
 For Python usage, see [SDK configuration](/sdk/configuration#experimental-csv-tool-results).
+
+---
+
+### `saber rpc`
+
+Headless JSONL over stdin/stdout so IDEs and other applications can embed SQLsaber. Full protocol: [RPC mode](/reference/rpc).
+
+**Usage:**
+
+```bash
+saber rpc
+saber rpc -d analytics
+saber rpc -d ./orders.csv --no-thread
+saber rpc --thread THREAD_ID
+echo '{"type":"prompt","message":"how many users?"}' | saber rpc -d analytics --no-thread
+```
+
+**Parameters:**
+
+- `-d, --database` - Same selectors as `saber` (repeatable).
+- `--thread` - Resume a saved thread. Mutually exclusive with `--no-thread`.
+- `--no-thread` - Do not persist the conversation.
+- `--thinking` / `--no-thinking` - Initial reasoning setting.
+- `--allow-dangerous` - Same write scope as interactive mode.
+- `--csv-tool-results` - Model-facing SQL results as CSV.
+- `--system-prompt` - Custom system prompt text or path.
+
+This command never starts onboarding or an update check. Missing database configuration yields one JSON `startup` error on stdout and exit 1. `echo "show users" | saber` is unchanged.
 
 ---
 

--- a/docs/src/content/docs/reference/rpc.md
+++ b/docs/src/content/docs/reference/rpc.md
@@ -1,0 +1,199 @@
+---
+title: RPC mode
+description: "Headless JSONL protocol for embedding SQLsaber in IDEs and other applications."
+---
+
+`saber rpc` is a headless JSONL protocol so IDEs and other applications can embed the SQL agent. It is the SQLsaber analogue of `pi --mode rpc`. One process owns one conversation. Commands arrive on stdin. Responses and events leave on stdout. Nothing else is written to stdout.
+
+The default `saber` command still treats non-TTY stdin as the natural-language question (`echo "show users" | saber`). RPC is a subcommand so that path stays unchanged.
+
+```bash
+saber rpc                                   # default database, conversation saved as a thread
+saber rpc -d analytics                      # a saved connection
+saber rpc -d sales -d analytics             # several databases in one session
+saber rpc -d ./orders.csv --no-thread       # ad-hoc file, nothing persisted
+saber rpc --thread 4f1c…                    # resume a saved thread
+saber rpc --allow-dangerous --thinking      # writes allowed, extended reasoning on
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `-d, --database` | Saved connection name, file (CSV/Parquet/SQLite/DuckDB), or DSN. Repeatable. Default connection if omitted. |
+| `--thread ID` | Resume a saved thread. History is loaded before `ready`. Mutually exclusive with `--no-thread`. |
+| `--no-thread` | Do not persist the conversation. `threadId` stays `null`. |
+| `--thinking` / `--no-thinking` | Initial reasoning setting. `set_thinking_level` changes it at runtime. |
+| `--allow-dangerous` | Allow INSERT/UPDATE/DELETE and restricted DDL, same scope as the interactive CLI. |
+| `--csv-tool-results` | Model-facing SQL results as CSV instead of JSON. |
+| `--system-prompt TEXT_OR_PATH` | Replace the built-in prompt. |
+
+Process rules:
+
+- stdout carries protocol lines only. Diagnostics go to stderr. Logs go to the usual log file (`SQLSABER_LOG_FILE`).
+- RPC never starts the onboarding TUI and never checks for updates. If no database is configured it emits one JSON line and exits 1.
+- Exit codes: `0` after `shutdown` or stdin EOF; `1` startup failure (one `startup` response line on stdout); `2` usage error (stderr, from the CLI parser before the protocol starts).
+
+## Framing
+
+- One JSON object per line, `\n` terminated. A trailing `\r` is stripped. Blank lines are ignored.
+- Split on `\n` only. `U+2028` / `U+2029` are legal inside JSON strings and are not record separators.
+- UTF-8 in both directions. Input lines longer than 1 MiB are rejected with one `parse` error; the rest of that line is discarded.
+- Every command may carry `"id"` (string or integer). The single response to that command echoes it. Events never carry `id`.
+- A line that is not a JSON object with a string `type` yields `{"type":"response","command":"parse","success":false,"error":"…"}`.
+
+## Lifecycle
+
+The first stdout line is the `ready` event, or a startup failure after which the process exits 1:
+
+```json
+{"type":"ready","protocolVersion":1,"state":"idle","database":{"name":"analytics","type":"PostgreSQL","names":["analytics"]},"model":{"name":"claude-sonnet-4-5","id":"anthropic:claude-sonnet-4-5"},"thinkingLevel":"off","thinkingLevels":["off","minimal","low","medium","high","maximum"],"dangerousMode":false,"csvToolResults":false,"threadId":null,"threadPersistence":true,"messageCount":0}
+```
+
+```json
+{"type":"response","command":"startup","success":false,"error":"No database connections configured. Use 'sqlsaber db add <name>' to add one."}
+```
+
+Each command produces exactly one `response`, in command order. `prompt` additionally streams events. The stream always ends with `agent_end`. Finish with `{"type":"shutdown"}` or close stdin. `SIGTERM` / `SIGINT` take the same graceful path.
+
+While `running`, these commands are accepted: `abort`, `get_state`, `get_messages`, `get_last_assistant_text`, `get_query_result`, `get_artifact`, `shutdown`. These are rejected because they would race the running query: `prompt`, `new_session`, `set_thinking_level`, `reload_model`, `get_tables`. There is no steer/follow-up queue. A `prompt` carrying Pi's `streamingBehavior` is rejected whether or not a query is running.
+
+`get_messages` returns committed turns only. A turn is committed when its `agent_end` has `status:"completed"`. Aborted or failed turns leave no trace in history or in the saved thread.
+
+## Commands
+
+### `prompt`
+
+Start one agent run. The response means "accepted". The answer arrives as events. Only one run at a time.
+
+```json
+{"id":"q1","type":"prompt","message":"Top 5 customers by revenue this quarter"}
+{"id":"q1","type":"response","command":"prompt","success":true}
+```
+
+Failures after acceptance (model API error, database error) are reported as `agent_end` with `status:"error"`, never as a second response.
+
+### `abort`
+
+Stop the running query. `agent_end` with `status:"aborted"` is emitted before the abort response. Idempotent: when idle it responds immediately with `aborted:false`. Stdin is still read while a run unwinds, so `get_state` can land between `abort` and `agent_end`.
+
+### `new_session`
+
+Clear history and start a fresh thread. Idle only.
+
+### `get_state`
+
+Same object as `ready` minus `protocolVersion`. Allowed while running (`state:"running"`).
+
+### `get_messages`
+
+Committed conversation as transcript messages. Not a pydantic-ai dump.
+
+### `get_last_assistant_text`
+
+`{"text": "…"}` or `{"text": null}` when there is no assistant message yet.
+
+### `set_thinking_level`
+
+Levels are `off`, `minimal`, `low`, `medium`, `high`, `maximum`. `off` disables reasoning. It is not an alias for medium. Idle only.
+
+### `reload_model`
+
+Re-read the saved model configuration and apply it to subsequent queries, keeping history. Idle only.
+
+### `get_tables`
+
+Tables across connected databases, for completion and schema panels. Idle only: listing tables hits live database connections.
+
+### `get_query_result`
+
+Fetch stored `execute_sql` rows by the `queryResult.id` seen on `tool_execution_end`, `agent_end`, or a `toolResult` message. Allowed while running. Page with `offset` and `limit` (default 500, max 5000) until `hasMore` is false.
+
+```json
+{"type":"get_query_result","resultId":"qr_01J9…","offset":0,"limit":500}
+{"type":"response","command":"get_query_result","success":true,"data":{"result":{"id":"qr_01J9…","rowCount":5,"columns":["customer","revenue"]},"offset":0,"limit":500,"rows":[{"customer":"Acme","revenue":120340.5}],"hasMore":false}}
+```
+
+### `get_artifact`
+
+Fetch an artifact descriptor by `artifact.id`. The payload includes `uri` so the client can read bytes itself. Allowed while running.
+
+### `shutdown`
+
+Abort any running query, end the session, respond, exit 0. Closing stdin without sending it does the same thing without a response.
+
+## Events
+
+| Event | When |
+| --- | --- |
+| `ready` | Once, first line, session accepting commands. |
+| `agent_start` | A `prompt` began. Carries `promptId` when the command had an `id`. |
+| `message_start` / `message_update` / `message_end` | One assistant message (one per model request in a tool loop). |
+| `sql_update` | Cumulative SQL recovered from a streaming `execute_sql` tool call. |
+| `tool_execution_start` / `tool_execution_end` | A tool ran. SQL tools include a `queryResult` handle, not the full grid. |
+| `agent_end` | The run finished: `completed`, `aborted`, or `error`. Always last. |
+
+`message_update.assistantMessageEvent.type` is one of `text_start`, `text_delta`, `text_end`, `thinking_start`, `thinking_delta`, `thinking_end`, `toolcall_start`, `toolcall_delta`, `toolcall_end`.
+
+`agent_end` on `completed` includes the new transcript messages, the final answer text, usage, query-result and artifact descriptors, and the thread id. On `aborted` and `error` any open message is implicitly closed and nothing was committed.
+
+## Types
+
+All RPC-defined field names are camelCase. Timestamps are epoch milliseconds.
+
+**State** (`ready`, `get_state`, mutating responses): `state`, `database` (`name`, `type`, `names`), `model` (`name`, `id`), `thinkingLevel`, `thinkingLevels`, `dangerousMode`, `csvToolResults`, `threadPersistence`, `threadId`, `messageCount`.
+
+**Transcript message**
+
+```
+{role:"user", content: string, timestamp}
+{role:"assistant", content: ContentBlock[], model, usage, stopReason, timestamp}
+{role:"toolResult", toolCallId, toolName, content, isError, queryResult?, timestamp}
+
+ContentBlock = {type:"text", text} | {type:"thinking", thinking}
+             | {type:"toolCall", id, name, arguments}
+```
+
+**QueryResult** — `id`, `file`, `rowCount`, `columns`, `size`, `sha256`, `mediaType`, `databaseName`, `createdAt`. Fetch rows with `get_query_result`.
+
+**Artifact** — `id`, `name`, `kind` (`image` \| `notebook` \| `file`), `mediaType`, `size`, `sha256`, `uri`.
+
+## Minimal client
+
+```python
+import json
+import subprocess
+
+proc = subprocess.Popen(
+    ["saber", "rpc", "-d", "analytics", "--no-thread"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, encoding="utf-8",
+)
+
+def send(command: dict) -> None:
+    proc.stdin.write(json.dumps(command) + "\n")
+    proc.stdin.flush()
+
+first = json.loads(proc.stdout.readline())
+if first["type"] != "ready":
+    raise SystemExit(first["error"])
+
+send({"id": 1, "type": "prompt", "message": "How many orders shipped late last month?"})
+for raw in proc.stdout:
+    event = json.loads(raw)
+    if event["type"] == "message_update":
+        delta = event.get("assistantMessageEvent", {})
+        if delta.get("type") == "text_delta":
+            print(delta["delta"], end="", flush=True)
+    elif event["type"] == "sql_update":
+        print(f"\n[sql] {event['sql']}")
+    elif event["type"] == "agent_end":
+        break
+
+send({"type": "shutdown"})
+proc.wait()
+```
+
+## What is not here
+
+- `steer`, `follow_up`, queues: `SQLSaber.query` rejects overlapping runs. Wait for `agent_end`.
+- `bash*`, extension UI, `compact*`, auto-retry, session trees (`fork` / `clone` / `get_tree`): threads are linear snapshots.
+- `set_model` / `cycle_model`: model selection is `saber models set`. `reload_model` applies it live.
+- Images on `prompt`: SQLSaber prompts are text.

--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -67,6 +67,7 @@ async def _create_cli_saber(
     thread: str | None,
     log,
     csv_tool_results: bool = False,
+    persist_thread: bool = True,
 ):
     """Construct SQLSaber and persistence handles for a CLI session."""
     from sqlsaber.cli.artifacts import cli_artifact_store
@@ -93,7 +94,11 @@ async def _create_cli_saber(
         allow_dangerous=allow_dangerous,
         csv_tool_results=csv_tool_results,
         system_prompt=system_prompt,
-        thread_manager=(ThreadManager(storage=storage) if thread is None else None),
+        thread_manager=(
+            ThreadManager(storage=storage)
+            if thread is None and persist_thread
+            else None
+        ),
         artifact_store=artifact_store,
         query_result_store=query_result_store,
     )
@@ -186,6 +191,11 @@ app.command(
     "sqlsaber.cli.threads:threads_app",
     name="threads",
     help="Manage SQLsaber threads",
+)
+app.command(
+    "sqlsaber.cli.rpc:rpc_app",
+    name="rpc",
+    help="Headless JSONL mode for embedding (IDEs, apps)",
 )
 
 

--- a/src/sqlsaber/cli/rpc.py
+++ b/src/sqlsaber/cli/rpc.py
@@ -1,0 +1,230 @@
+"""``saber rpc`` — headless JSONL mode over stdin/stdout."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from typing import Annotated, Any
+
+import cyclopts
+
+from sqlsaber.cli.commands import (
+    DANGEROUS_MODE_HELP,
+    DATABASE_OPTION_HELP,
+)
+
+rpc_app = cyclopts.App(
+    name="rpc",
+    help="Headless JSONL mode over stdin/stdout for embedding SQLsaber",
+    help_epilogue=(
+        "Examples:\n\n"
+        "saber rpc -d analytics\n\n"
+        "saber rpc -d sales -d analytics --thinking\n\n"
+        "saber rpc --thread THREAD_ID\n\n"
+        "saber rpc -d ./orders.csv --no-thread\n\n"
+        'echo \'{"type":"prompt","message":"how many users?"}\' | saber rpc'
+    ),
+)
+
+
+@rpc_app.default
+def rpc(
+    database: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(["--database", "-d"], help=DATABASE_OPTION_HELP),
+    ] = None,
+    thread: Annotated[
+        str | None,
+        cyclopts.Parameter(["--thread"], help="Resume a saved thread"),
+    ] = None,
+    no_thread: Annotated[
+        bool,
+        cyclopts.Parameter(
+            ["--no-thread"],
+            negative=(),
+            help="Do not persist the conversation",
+        ),
+    ] = False,
+    thinking: Annotated[
+        bool | None,
+        cyclopts.Parameter(
+            ["--thinking", "--no-thinking"],
+            help="Enable/disable extended thinking/reasoning mode",
+        ),
+    ] = None,
+    allow_dangerous: Annotated[
+        bool,
+        cyclopts.Parameter(["--allow-dangerous"], help=DANGEROUS_MODE_HELP),
+    ] = False,
+    csv_tool_results: Annotated[
+        bool,
+        cyclopts.Parameter(
+            ["--csv-tool-results"],
+            help="Opt in to experimental CSV tool results for the model (default: JSON)",
+        ),
+    ] = False,
+    system_prompt: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            ["--system-prompt"],
+            help="Custom system prompt text or path to a file (overrides built-in prompt)",
+        ),
+    ] = None,
+) -> None:
+    """Speak JSONL on stdin/stdout. See docs/reference/rpc.md for the protocol.
+
+    Exit 0 after shutdown/EOF, 1 on startup failure (one JSON line on stdout),
+    2 on usage errors (this parser, stderr).
+    """
+    from sqlsaber.cli.output import fail_usage
+
+    if thread and no_thread:
+        fail_usage("--thread and --no-thread are mutually exclusive")
+
+    write = claim_stdout()
+    from sqlsaber.cli.commands import _ensure_logging
+
+    log = _ensure_logging()
+    import asyncio
+
+    raise SystemExit(
+        asyncio.run(
+            _main(
+                write=write,
+                database=database,
+                thread=thread,
+                persist_thread=not no_thread,
+                thinking=thinking,
+                allow_dangerous=allow_dangerous,
+                csv_tool_results=csv_tool_results,
+                system_prompt=system_prompt,
+                log=log,
+            )
+        )
+    )
+
+
+def claim_stdout() -> Callable[[bytes], None]:
+    """Dup fd 1 as the protocol channel and point Python stdout at stderr.
+
+    Returns:
+        Write-and-flush callback for complete JSONL records on the dup'd fd.
+    """
+    from sqlsaber.render import reset_io
+
+    protocol_fd = os.dup(1)
+    try:
+        os.dup2(sys.stderr.fileno(), 1)
+    except OSError:
+        pass
+    sys.stdout = sys.stderr
+    reset_io(stdout=sys.stderr, stderr=sys.stderr, tty=False)
+
+    def write(record: bytes) -> None:
+        os.write(protocol_fd, record)
+
+    return write
+
+
+async def _main(
+    *,
+    write: Callable[[bytes], None],
+    database: list[str] | None,
+    thread: str | None,
+    persist_thread: bool,
+    thinking: bool | None,
+    allow_dangerous: bool,
+    csv_tool_results: bool,
+    system_prompt: str | None,
+    log: Any,
+) -> int:
+    """Build the SQLSaber with CLI option/store wiring, serve, close, retain.
+
+    Args:
+        write: Protocol stdout writer.
+        database: ``-d`` values, or ``None`` for the configured default.
+        thread: Thread id to resume, if any.
+        persist_thread: When false, do not attach a ``ThreadManager``.
+        thinking: Initial thinking flag.
+        allow_dangerous: Dangerous-mode flag.
+        csv_tool_results: Model-facing CSV results flag.
+        system_prompt: Optional prompt override.
+        log: Structured logger.
+
+    Returns:
+        Process exit code (0 success, 1 startup failure).
+    """
+    import getpass
+    from typing import TextIO
+
+    from sqlsaber.cli.commands import CLIError, _create_cli_saber
+    from sqlsaber.cli.onboarding import needs_onboarding
+    from sqlsaber.rpc.protocol import Err, encode
+    from sqlsaber.rpc.session import ThreadedLineReader, serve
+
+    def _no_prompt(prompt: str = "Password: ", stream: TextIO | None = None) -> str:
+        del prompt, stream
+        raise EOFError("API key prompt is not available in RPC mode")
+
+    setattr(getpass, "getpass", _no_prompt)
+
+    if thread is None and needs_onboarding(database):
+        write(
+            encode(
+                Err(
+                    "startup",
+                    None,
+                    "No database connections configured. Use 'sqlsaber db add <name>' to add one.",
+                )
+            )
+        )
+        return 1
+
+    import asyncio
+
+    from sqlsaber.cli.retention import run_cli_retention
+
+    saber = None
+    storage = None
+    artifact_store = None
+    query_result_store = None
+    try:
+        saber, storage, artifact_store, query_result_store = await _create_cli_saber(
+            selected_database=database,
+            thinking=thinking,
+            allow_dangerous=allow_dangerous,
+            system_prompt=system_prompt,
+            thread=thread,
+            csv_tool_results=csv_tool_results,
+            persist_thread=persist_thread,
+            log=log,
+        )
+        loop = asyncio.get_running_loop()
+        reader = ThreadedLineReader(sys.stdin.buffer, loop)
+        await serve(
+            saber,
+            reader=reader,
+            write=write,
+            persist_thread=persist_thread,
+        )
+        return 0
+    except CLIError as exc:
+        write(encode(Err("startup", None, str(exc))))
+        return 1
+    except Exception as exc:
+        write(encode(Err("startup", None, str(exc))))
+        return 1
+    finally:
+        if saber is not None:
+            try:
+                await saber.close()
+            finally:
+                if (
+                    storage is not None
+                    and artifact_store is not None
+                    and query_result_store is not None
+                ):
+                    await run_cli_retention(
+                        storage, artifact_store, query_result_store
+                    )

--- a/src/sqlsaber/cli/stream_presenter.py
+++ b/src/sqlsaber/cli/stream_presenter.py
@@ -21,8 +21,6 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolCallPartDelta,
 )
-from pydantic_core import from_json
-
 from sqlsaber.config.logging import get_logger
 from sqlsaber.query_result_resolution import (
     QueryResultReference,
@@ -40,6 +38,7 @@ from sqlsaber.tools.renderer import (
     ToolRenderer,
     core_display_registry,
 )
+from sqlsaber.utils.partial_json import partial_json_query
 from sqlsaber.utils.text_input import sanitize_terminal_text
 
 if TYPE_CHECKING:
@@ -356,7 +355,7 @@ class AgentStreamPresenter:
             return
         args = self._tool_call_args.get(index)
         if isinstance(args, str):
-            query = _partial_json_query(args)
+            query = partial_json_query(args)
         elif isinstance(args, dict):
             value = args.get("query")
             query = value if isinstance(value, str) else None
@@ -476,15 +475,3 @@ class AgentStreamPresenter:
             self._reset_tool_call_state(remove_previews=True)
             self._reset_response_stream_state()
             self._cancellation_token = None
-
-
-def _partial_json_query(args: str) -> str | None:
-    """Decode the complete portion of a query value from partial JSON arguments."""
-    try:
-        parsed = from_json(args, allow_partial="trailing-strings")
-    except ValueError:
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    query = parsed.get("query")
-    return query if isinstance(query, str) else None

--- a/src/sqlsaber/rpc/__init__.py
+++ b/src/sqlsaber/rpc/__init__.py
@@ -1,0 +1,20 @@
+"""Headless JSONL RPC mode for embedding SQLSaber."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .session import RpcSession, serve
+
+__all__ = [
+    "RpcSession",
+    "serve",
+]
+
+
+def __getattr__(name: str):
+    """Lazy import so ``saber --help`` never loads pydantic-ai via RPC."""
+    if name in {"RpcSession", "serve"}:
+        from . import session
+
+        return getattr(session, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/sqlsaber/rpc/protocol.py
+++ b/src/sqlsaber/rpc/protocol.py
@@ -1,0 +1,892 @@
+"""Wire vocabulary for ``saber rpc``.
+
+Stdlib JSON only. Nothing here starts a query; nothing outside this module
+builds or reads wire dicts.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlsaber.artifacts import StoredArtifact
+from sqlsaber.config.settings import ThinkingLevel
+from sqlsaber.query_results import LoadedQueryResult, StoredQueryResult
+from sqlsaber.utils.json_utils import EnhancedJSONEncoder
+
+PROTOCOL_VERSION = 1
+DEFAULT_RESULT_LIMIT = 500
+MAX_RESULT_LIMIT = 5000
+MAX_STDIN_LINE = 1_048_576
+OVERSIZE_LINE = b"\x00OVERSIZE\n"
+
+type RequestId = str | int
+type Json = dict[str, Any]
+
+THINKING_CHOICES: tuple[str, ...] = ("off", *(level.value for level in ThinkingLevel))
+
+_UNSUPPORTED_FIELDS: dict[str, str] = {
+    "streamingBehavior": (
+        "streamingBehavior is not supported: SQLSaber has no steer/follow-up "
+        "queue. Wait for agent_end, then send the prompt."
+    ),
+    "images": "images is not supported: SQLSaber prompts are text.",
+    "parentSession": (
+        "parentSession is not supported: SQLSaber threads are linear, "
+        "not a session tree."
+    ),
+}
+
+
+# --- commands (stdin) --------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Prompt:
+    message: str
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Abort:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NewSession:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetState:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetMessages:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetLastAssistantText:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SetThinkingLevel:
+    level: str
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReloadModel:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetTables:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetQueryResult:
+    result_id: str
+    offset: int = 0
+    limit: int = DEFAULT_RESULT_LIMIT
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GetArtifact:
+    artifact_id: str
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Shutdown:
+    id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Invalid:
+    """A line the boundary refused. Never reaches the SDK."""
+
+    error: str
+    command: str = "parse"
+    id: RequestId | None = None
+
+
+type ReadCommand = (
+    GetState | GetMessages | GetLastAssistantText | GetQueryResult | GetArtifact
+)
+"""Safe while a query runs: they only read SDK state or stores."""
+
+type MutateCommand = NewSession | SetThinkingLevel | ReloadModel
+"""Idle-only mutations. ``get_tables`` is idle-only too (live connections)."""
+
+type Command = (
+    Prompt | Abort | Shutdown | ReadCommand | MutateCommand | GetTables | Invalid
+)
+
+
+def parse_command(line: bytes) -> Command:
+    """Decode one stdin record into a command. Total: never raises.
+
+    Args:
+        line: One JSONL record, optionally ``\\n``/``\\r\\n`` terminated.
+
+    Returns:
+        A typed command, or ``Invalid`` for any framing/JSON/field problem.
+    """
+    try:
+        text = _decode_line(line)
+    except UnicodeDecodeError:
+        return Invalid("Command is not valid UTF-8")
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return Invalid(f"Failed to parse command: {exc}")
+    if not isinstance(obj, dict):
+        return Invalid('Command must be a JSON object with a string "type"')
+    raw_type = obj.get("type")
+    if not isinstance(raw_type, str) or not raw_type:
+        return Invalid('Command must be a JSON object with a string "type"')
+    rid, id_error = _parse_id(obj.get("id"), raw_type, "id" in obj)
+    if id_error is not None:
+        return id_error
+    for field, message in _UNSUPPORTED_FIELDS.items():
+        if field in obj:
+            return Invalid(message, command=raw_type, id=rid)
+    match raw_type:
+        case "prompt":
+            return _parse_prompt(obj, rid)
+        case "abort":
+            return Abort(id=rid)
+        case "new_session":
+            return NewSession(id=rid)
+        case "get_state":
+            return GetState(id=rid)
+        case "get_messages":
+            return GetMessages(id=rid)
+        case "get_last_assistant_text":
+            return GetLastAssistantText(id=rid)
+        case "set_thinking_level":
+            return _parse_set_thinking_level(obj, rid)
+        case "reload_model":
+            return ReloadModel(id=rid)
+        case "get_tables":
+            return GetTables(id=rid)
+        case "get_query_result":
+            return _parse_get_query_result(obj, rid)
+        case "get_artifact":
+            return _parse_get_artifact(obj, rid)
+        case "shutdown":
+            return Shutdown(id=rid)
+        case _:
+            return Invalid(f"Unknown command: {raw_type}", command=raw_type, id=rid)
+
+
+def _decode_line(line: bytes) -> str:
+    text = line.decode("utf-8")
+    if text.endswith("\n"):
+        text = text[:-1]
+    if text.endswith("\r"):
+        text = text[:-1]
+    return text
+
+
+def _parse_id(
+    value: object, command: str, present: bool
+) -> tuple[RequestId | None, Invalid | None]:
+    if not present or value is None:
+        return None, None
+    if isinstance(value, str):
+        return value, None
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value, None
+    return None, Invalid("id must be a string or integer", command=command, id=None)
+
+
+def _parse_prompt(obj: dict[str, Any], rid: RequestId | None) -> Command:
+    message = obj.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return Invalid("message must be a non-empty string", command="prompt", id=rid)
+    return Prompt(message=message, id=rid)
+
+
+def _parse_set_thinking_level(obj: dict[str, Any], rid: RequestId | None) -> Command:
+    level = obj.get("level")
+    if not isinstance(level, str) or level not in THINKING_CHOICES:
+        choices = ", ".join(THINKING_CHOICES)
+        return Invalid(
+            f"level must be one of: {choices}",
+            command="set_thinking_level",
+            id=rid,
+        )
+    return SetThinkingLevel(level=level, id=rid)
+
+
+def _parse_get_query_result(obj: dict[str, Any], rid: RequestId | None) -> Command:
+    result_id = obj.get("resultId")
+    if not isinstance(result_id, str) or not result_id:
+        return Invalid(
+            "resultId must be a non-empty string",
+            command="get_query_result",
+            id=rid,
+        )
+    offset = obj.get("offset", 0)
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        return Invalid(
+            "offset must be a non-negative integer",
+            command="get_query_result",
+            id=rid,
+        )
+    limit = obj.get("limit", DEFAULT_RESULT_LIMIT)
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or limit < 1
+        or limit > MAX_RESULT_LIMIT
+    ):
+        return Invalid(
+            f"limit must be an integer from 1 to {MAX_RESULT_LIMIT}",
+            command="get_query_result",
+            id=rid,
+        )
+    return GetQueryResult(result_id=result_id, offset=offset, limit=limit, id=rid)
+
+
+def _parse_get_artifact(obj: dict[str, Any], rid: RequestId | None) -> Command:
+    artifact_id = obj.get("artifactId")
+    if not isinstance(artifact_id, str) or not artifact_id:
+        return Invalid(
+            "artifactId must be a non-empty string",
+            command="get_artifact",
+            id=rid,
+        )
+    return GetArtifact(artifact_id=artifact_id, id=rid)
+
+
+# --- responses (stdout) ------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Ok:
+    command: str
+    id: RequestId | None
+    data: Json | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Err:
+    command: str
+    id: RequestId | None
+    error: str
+
+
+type Response = Ok | Err
+
+
+# --- transcript model --------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TextBlock:
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ThinkingBlock:
+    thinking: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallBlock:
+    id: str
+    name: str
+    arguments: Json
+
+
+type ContentBlock = TextBlock | ThinkingBlock | ToolCallBlock
+
+type StopReason = Literal["stop", "length", "toolUse", "contentFilter", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class Usage:
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class RunUsageSummary(Usage):
+    requests: int
+    tool_calls: int
+    context_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class UserMessage:
+    content: str
+    timestamp_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class AssistantMessage:
+    content: tuple[ContentBlock, ...]
+    model: str | None
+    usage: Usage | None
+    stop_reason: StopReason | None
+    timestamp_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResultMessage:
+    tool_call_id: str
+    tool_name: str
+    content: Any
+    is_error: bool
+    timestamp_ms: int
+    query_result: StoredQueryResult | None = None
+
+
+type TranscriptMessage = UserMessage | AssistantMessage | ToolResultMessage
+
+
+# --- state -------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class StateSnapshot:
+    """Payload of ``ready``, ``get_state`` and mutating responses."""
+
+    state: Literal["idle", "running"]
+    database_names: tuple[str, ...]
+    primary_database: str
+    database_type: str
+    model_name: str
+    model_id: str | None
+    thinking: str
+    dangerous_mode: bool
+    csv_tool_results: bool
+    thread_id: str | None
+    thread_persistence: bool
+    message_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class TableEntry:
+    database: str
+    schema: str
+    name: str
+    kind: str
+    qualified_name: str
+
+
+# --- events ------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Ready:
+    state: StateSnapshot
+    protocol_version: int = PROTOCOL_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class AgentStart:
+    prompt_id: RequestId | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MessageStart:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TextStart:
+    content_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class TextDelta:
+    content_index: int
+    delta: str
+
+
+@dataclass(frozen=True, slots=True)
+class TextEnd:
+    content_index: int
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class ThinkingStart:
+    content_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class ThinkingDelta:
+    content_index: int
+    delta: str
+
+
+@dataclass(frozen=True, slots=True)
+class ThinkingEnd:
+    content_index: int
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallStart:
+    content_index: int
+    id: str
+    tool_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallDelta:
+    content_index: int
+    delta: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallEnd:
+    content_index: int
+    tool_call: ToolCallBlock
+
+
+type ContentEvent = (
+    TextStart
+    | TextDelta
+    | TextEnd
+    | ThinkingStart
+    | ThinkingDelta
+    | ThinkingEnd
+    | ToolCallStart
+    | ToolCallDelta
+    | ToolCallEnd
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MessageUpdate:
+    event: ContentEvent
+
+
+@dataclass(frozen=True, slots=True)
+class MessageEnd:
+    message: AssistantMessage
+
+
+@dataclass(frozen=True, slots=True)
+class SqlUpdate:
+    sql: str
+    tool_call_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionStart:
+    tool_call_id: str
+    tool_name: str
+    args: Json
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionEnd:
+    tool_call_id: str
+    tool_name: str
+    result: Any
+    is_error: bool
+    query_result: StoredQueryResult | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Completed:
+    messages: tuple[TranscriptMessage, ...]
+    text: str
+    usage: RunUsageSummary | None
+    query_results: tuple[StoredQueryResult, ...]
+    artifacts: tuple[StoredArtifact, ...]
+    thread_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class Aborted:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class Failed:
+    error: str
+
+
+type RunOutcome = Completed | Aborted | Failed
+
+
+@dataclass(frozen=True, slots=True)
+class AgentEnd:
+    outcome: RunOutcome
+
+
+type Event = (
+    Ready
+    | AgentStart
+    | MessageStart
+    | MessageUpdate
+    | MessageEnd
+    | SqlUpdate
+    | ToolExecutionStart
+    | ToolExecutionEnd
+    | AgentEnd
+)
+
+
+def encode(message: Response | Event) -> bytes:
+    """One JSONL record (``\\n``-terminated, UTF-8, camelCase).
+
+    Args:
+        message: A response or event to serialize.
+
+    Returns:
+        UTF-8 bytes including a trailing newline.
+    """
+    return _dump(_wire_dict(message))
+
+
+def _wire_dict(message: Response | Event) -> Json:
+    match message:
+        case Ok(command=command, id=rid, data=data):
+            payload: Json = {
+                "type": "response",
+                "command": command,
+                "success": True,
+            }
+            if data is not None:
+                payload["data"] = data
+            _put_id(payload, rid)
+            return payload
+        case Err(command=command, id=rid, error=error):
+            payload = {
+                "type": "response",
+                "command": command,
+                "success": False,
+                "error": error,
+            }
+            _put_id(payload, rid)
+            return payload
+        case Ready(state=state, protocol_version=version):
+            return {"type": "ready", "protocolVersion": version, **state_json(state)}
+        case AgentStart(prompt_id=prompt_id):
+            payload = {"type": "agent_start"}
+            if prompt_id is not None:
+                payload["promptId"] = prompt_id
+            return payload
+        case MessageStart():
+            return {"type": "message_start"}
+        case MessageUpdate(event=event):
+            return {
+                "type": "message_update",
+                "assistantMessageEvent": _content_event_json(event),
+            }
+        case MessageEnd(message=transcript_message):
+            return {"type": "message_end", "message": message_json(transcript_message)}
+        case SqlUpdate(sql=sql, tool_call_id=tool_call_id):
+            payload = {"type": "sql_update", "sql": sql}
+            if tool_call_id:
+                payload["toolCallId"] = tool_call_id
+            return payload
+        case ToolExecutionStart(tool_call_id=call_id, tool_name=name, args=args):
+            return {
+                "type": "tool_execution_start",
+                "toolCallId": call_id,
+                "toolName": name,
+                "args": args,
+            }
+        case ToolExecutionEnd(
+            tool_call_id=call_id,
+            tool_name=name,
+            result=result,
+            is_error=is_error,
+            query_result=query_result,
+        ):
+            payload = {
+                "type": "tool_execution_end",
+                "toolCallId": call_id,
+                "toolName": name,
+                "result": result,
+                "isError": is_error,
+            }
+            if query_result is not None:
+                payload["queryResult"] = query_result_json(query_result)
+            return payload
+        case AgentEnd(outcome=Completed() as completed):
+            return {
+                "type": "agent_end",
+                "status": "completed",
+                "text": completed.text,
+                "messages": [message_json(item) for item in completed.messages],
+                "usage": (
+                    None
+                    if completed.usage is None
+                    else _run_usage_json(completed.usage)
+                ),
+                "queryResults": [
+                    query_result_json(item) for item in completed.query_results
+                ],
+                "artifacts": [artifact_json(item) for item in completed.artifacts],
+                "threadId": completed.thread_id,
+            }
+        case AgentEnd(outcome=Aborted()):
+            return {"type": "agent_end", "status": "aborted"}
+        case AgentEnd(outcome=Failed(error=error)):
+            return {"type": "agent_end", "status": "error", "error": error}
+    raise TypeError(f"unencodable RPC message: {type(message)!r}")
+
+
+def state_json(state: StateSnapshot) -> Json:
+    """Shared by ``Ready`` and every response carrying a snapshot.
+
+    Args:
+        state: Derived session snapshot.
+
+    Returns:
+        CamelCase wire object (without ``type`` / ``protocolVersion``).
+    """
+    return {
+        "state": state.state,
+        "database": {
+            "name": state.primary_database,
+            "type": state.database_type,
+            "names": list(state.database_names),
+        },
+        "model": {"name": state.model_name, "id": state.model_id},
+        "thinkingLevel": state.thinking,
+        "thinkingLevels": list(THINKING_CHOICES),
+        "dangerousMode": state.dangerous_mode,
+        "csvToolResults": state.csv_tool_results,
+        "threadId": state.thread_id,
+        "threadPersistence": state.thread_persistence,
+        "messageCount": state.message_count,
+    }
+
+
+def message_json(message: TranscriptMessage) -> Json:
+    """Project one transcript message onto the wire.
+
+    Args:
+        message: A user, assistant, or tool-result message.
+
+    Returns:
+        CamelCase wire object.
+    """
+    match message:
+        case UserMessage(content=content, timestamp_ms=timestamp_ms):
+            return {
+                "role": "user",
+                "content": content,
+                "timestamp": timestamp_ms,
+            }
+        case AssistantMessage(
+            content=content,
+            model=model,
+            usage=usage,
+            stop_reason=stop_reason,
+            timestamp_ms=timestamp_ms,
+        ):
+            return {
+                "role": "assistant",
+                "content": [_block_json(block) for block in content],
+                "model": model,
+                "usage": None if usage is None else _usage_json(usage),
+                "stopReason": stop_reason,
+                "timestamp": timestamp_ms,
+            }
+        case ToolResultMessage(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            content=content,
+            is_error=is_error,
+            timestamp_ms=timestamp_ms,
+            query_result=query_result,
+        ):
+            payload: Json = {
+                "role": "toolResult",
+                "toolCallId": tool_call_id,
+                "toolName": tool_name,
+                "content": content,
+                "isError": is_error,
+                "timestamp": timestamp_ms,
+            }
+            if query_result is not None:
+                payload["queryResult"] = query_result_json(query_result)
+            return payload
+    raise TypeError(f"unencodable transcript message: {type(message)!r}")
+
+
+def query_result_json(result: StoredQueryResult) -> Json:
+    """CamelCase projection of a stored query-result descriptor.
+
+    Args:
+        result: Durable result handle.
+
+    Returns:
+        Wire object for ``queryResult`` fields.
+    """
+    payload: Json = {
+        "id": result.id,
+        "file": result.file,
+        "rowCount": result.row_count,
+        "columns": list(result.columns),
+        "size": result.size,
+        "sha256": result.sha256,
+        "mediaType": result.media_type,
+    }
+    if result.database_name is not None:
+        payload["databaseName"] = result.database_name
+    if result.created_at is not None:
+        payload["createdAt"] = result.created_at
+    return payload
+
+
+def artifact_json(artifact: StoredArtifact) -> Json:
+    """CamelCase projection of a stored artifact descriptor.
+
+    Args:
+        artifact: Durable artifact handle.
+
+    Returns:
+        Wire object including ``uri`` (no inline bytes).
+    """
+    return {
+        "id": artifact.id,
+        "name": artifact.name,
+        "kind": artifact.kind,
+        "mediaType": artifact.media_type,
+        "size": artifact.size,
+        "sha256": artifact.sha256,
+        "uri": artifact.uri,
+    }
+
+
+def query_result_page(loaded: LoadedQueryResult, *, offset: int, limit: int) -> Json:
+    """Slice stored rows into a bounded wire page.
+
+    Args:
+        loaded: Complete stored result.
+        offset: Starting row index.
+        limit: Maximum rows to return.
+
+    Returns:
+        ``result``, ``offset``, ``limit``, ``rows``, ``hasMore``.
+    """
+    rows = loaded.rows()
+    page = rows[offset : offset + limit]
+    return {
+        "result": query_result_json(loaded.descriptor),
+        "offset": offset,
+        "limit": limit,
+        "rows": page,
+        "hasMore": offset + len(page) < len(rows),
+    }
+
+
+def _content_event_json(event: ContentEvent) -> Json:
+    match event:
+        case TextStart(content_index=index):
+            return {"type": "text_start", "contentIndex": index}
+        case TextDelta(content_index=index, delta=delta):
+            return {"type": "text_delta", "contentIndex": index, "delta": delta}
+        case TextEnd(content_index=index, content=content):
+            return {"type": "text_end", "contentIndex": index, "content": content}
+        case ThinkingStart(content_index=index):
+            return {"type": "thinking_start", "contentIndex": index}
+        case ThinkingDelta(content_index=index, delta=delta):
+            return {
+                "type": "thinking_delta",
+                "contentIndex": index,
+                "delta": delta,
+            }
+        case ThinkingEnd(content_index=index, content=content):
+            return {
+                "type": "thinking_end",
+                "contentIndex": index,
+                "content": content,
+            }
+        case ToolCallStart(content_index=index, id=call_id, tool_name=name):
+            return {
+                "type": "toolcall_start",
+                "contentIndex": index,
+                "id": call_id,
+                "toolName": name,
+            }
+        case ToolCallDelta(content_index=index, delta=delta):
+            return {"type": "toolcall_delta", "contentIndex": index, "delta": delta}
+        case ToolCallEnd(content_index=index, tool_call=tool_call):
+            return {
+                "type": "toolcall_end",
+                "contentIndex": index,
+                "toolCall": _block_json(tool_call),
+            }
+    raise TypeError(f"unencodable content event: {type(event)!r}")
+
+
+def _block_json(block: ContentBlock) -> Json:
+    match block:
+        case TextBlock(text=text):
+            return {"type": "text", "text": text}
+        case ThinkingBlock(thinking=thinking):
+            return {"type": "thinking", "thinking": thinking}
+        case ToolCallBlock(id=call_id, name=name, arguments=arguments):
+            return {
+                "type": "toolCall",
+                "id": call_id,
+                "name": name,
+                "arguments": arguments,
+            }
+    raise TypeError(f"unencodable content block: {type(block)!r}")
+
+
+def _usage_json(usage: Usage) -> Json:
+    return {
+        "inputTokens": usage.input_tokens,
+        "outputTokens": usage.output_tokens,
+        "cacheReadTokens": usage.cache_read_tokens,
+        "cacheWriteTokens": usage.cache_write_tokens,
+    }
+
+
+def _run_usage_json(usage: RunUsageSummary) -> Json:
+    payload = _usage_json(usage)
+    payload["requests"] = usage.requests
+    payload["toolCalls"] = usage.tool_calls
+    payload["contextTokens"] = usage.context_tokens
+    return payload
+
+
+def _put_id(payload: Json, rid: RequestId | None) -> None:
+    if rid is not None:
+        payload["id"] = rid
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _sanitize(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize(item) for item in value]
+    return value
+
+
+def _dump(payload: Json) -> bytes:
+    text = json.dumps(
+        _sanitize(payload),
+        ensure_ascii=False,
+        allow_nan=False,
+        cls=EnhancedJSONEncoder,
+    )
+    return (text + "\n").encode("utf-8")

--- a/src/sqlsaber/rpc/session.py
+++ b/src/sqlsaber/rpc/session.py
@@ -102,8 +102,32 @@ class LineReader(Protocol):
         ...
 
 
+def _read_available(stream: Any) -> bytes:
+    """Read whatever is ready without waiting to fill a buffer.
+
+    ``BufferedReader.read(n)`` keeps pulling from the raw stream until it
+    has ``n`` bytes or hits EOF. On a pipe that deadlocks an interactive
+    JSONL client: the first command is shorter than the buffer, the client
+    waits for a response, and this side waits for more input.
+
+    ``read1`` issues at most one raw read, so a complete line unblocks.
+
+    Args:
+        stream: Binary stdin, typically ``sys.stdin.buffer``.
+
+    Returns:
+        Available bytes, or empty at EOF.
+    """
+    read1 = getattr(stream, "read1", None)
+    try:
+        chunk = read1(8192) if callable(read1) else stream.read(8192)
+    except Exception:
+        return b""
+    return b"" if chunk is None else chunk
+
+
 class ThreadedLineReader:
-    """Portable stdin source: a daemon thread blocks on ``stream.read``.
+    """Portable stdin source: a daemon thread blocks on one raw read at a time.
 
     Enforces the 1 MiB line cap: an oversized line is discarded through the
     next ``\\n`` and surfaced as ``OVERSIZE_LINE``.
@@ -122,10 +146,7 @@ class ThreadedLineReader:
         buf = bytearray()
         oversized = False
         while True:
-            try:
-                chunk = self._stream.read(8192)
-            except Exception:
-                chunk = b""
+            chunk = _read_available(self._stream)
             if not chunk:
                 if buf and not oversized:
                     self._put(loop, bytes(buf))

--- a/src/sqlsaber/rpc/session.py
+++ b/src/sqlsaber/rpc/session.py
@@ -1,0 +1,660 @@
+"""RPC session: one SQLSaber, one JSONL conversation, ordered stdout."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+import threading
+from collections.abc import AsyncIterable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import AgentStreamEvent
+
+from sqlsaber import SQLSaber, SQLSaberResult
+from sqlsaber.artifacts import ArtifactUnavailable
+from sqlsaber.config.settings import ThinkingLevel
+from sqlsaber.query_results import QueryResultUnavailable
+from sqlsaber.sdk.errors import (
+    RunInProgressError,
+    SQLSaberClosedError,
+    ThreadResumeError,
+)
+
+from .protocol import (
+    MAX_STDIN_LINE,
+    OVERSIZE_LINE,
+    Abort,
+    Aborted,
+    AgentEnd,
+    AgentStart,
+    Command,
+    Completed,
+    Err,
+    Event,
+    Failed,
+    GetArtifact,
+    GetLastAssistantText,
+    GetMessages,
+    GetQueryResult,
+    GetState,
+    GetTables,
+    Invalid,
+    NewSession,
+    Ok,
+    Prompt,
+    ReadCommand,
+    Ready,
+    ReloadModel,
+    Response,
+    RunOutcome,
+    RunUsageSummary,
+    SetThinkingLevel,
+    Shutdown,
+    StateSnapshot,
+    encode,
+    parse_command,
+    query_result_page,
+    state_json,
+    artifact_json,
+    message_json,
+)
+from .transcript import StreamTranslator, last_assistant_text, transcript
+
+BUSY_ERROR = 'A query is already running. Send {"type":"abort"} or wait for agent_end.'
+IDLE_ONLY_ERROR = 'A query is running. Send {"type":"abort"} or wait for agent_end.'
+HARD_CANCEL_TIMEOUT = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class Idle:
+    pass
+
+
+@dataclass(slots=True)
+class Running:
+    task: asyncio.Task[None]
+    abort: asyncio.Event
+    prompt: str
+    prompt_id: str | int | None
+    abort_waiters: list[Abort] = field(default_factory=list)
+    shutdown_waiters: list[Shutdown] = field(default_factory=list)
+    watch: asyncio.Task[None] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Closed:
+    pass
+
+
+type SessionState = Idle | Running | Closed
+
+
+class _RunAborted(Exception):
+    """Raised inside the event handler when the abort token is set."""
+
+
+class LineReader(Protocol):
+    async def readline(self) -> bytes:
+        """One record including its terminator; ``b""`` at EOF."""
+        ...
+
+
+class ThreadedLineReader:
+    """Portable stdin source: a daemon thread blocks on ``stream.read``.
+
+    Enforces the 1 MiB line cap: an oversized line is discarded through the
+    next ``\\n`` and surfaced as ``OVERSIZE_LINE``.
+    """
+
+    def __init__(self, stream: Any, loop: asyncio.AbstractEventLoop) -> None:
+        self._stream = stream
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._thread = threading.Thread(target=self._pump, args=(loop,), daemon=True)
+        self._thread.start()
+
+    def _put(self, loop: asyncio.AbstractEventLoop, line: bytes) -> None:
+        loop.call_soon_threadsafe(self._queue.put_nowait, line)
+
+    def _pump(self, loop: asyncio.AbstractEventLoop) -> None:
+        buf = bytearray()
+        oversized = False
+        while True:
+            try:
+                chunk = self._stream.read(8192)
+            except Exception:
+                chunk = b""
+            if not chunk:
+                if buf and not oversized:
+                    self._put(loop, bytes(buf))
+                elif oversized:
+                    self._put(loop, OVERSIZE_LINE)
+                self._put(loop, b"")
+                return
+            start = 0
+            while start < len(chunk):
+                newline = chunk.find(b"\n", start)
+                if newline < 0:
+                    piece = chunk[start:]
+                    if oversized:
+                        break
+                    if len(buf) + len(piece) > MAX_STDIN_LINE:
+                        oversized = True
+                        buf.clear()
+                    else:
+                        buf.extend(piece)
+                    break
+                piece = chunk[start : newline + 1]
+                if oversized or len(buf) + len(piece.rstrip(b"\r\n")) > MAX_STDIN_LINE:
+                    self._put(loop, OVERSIZE_LINE)
+                    oversized = False
+                    buf.clear()
+                else:
+                    buf.extend(piece)
+                    self._put(loop, bytes(buf))
+                    buf.clear()
+                start = newline + 1
+
+    async def readline(self) -> bytes:
+        return await self._queue.get()
+
+
+class RpcSession:
+    """One conversation over one SQLSaber, driven by parsed commands."""
+
+    def __init__(
+        self,
+        saber: SQLSaber,
+        *,
+        write: Callable[[bytes], None],
+        persist_thread: bool,
+        abort_grace: float = 0.5,
+    ) -> None:
+        self._saber = saber
+        self._write = write
+        self._persist_thread = persist_thread
+        self._abort_grace = abort_grace
+        self._state: SessionState = Idle()
+        self.closed = asyncio.Event()
+
+    def emit_ready(self) -> None:
+        self._emit(Ready(state=self._snapshot()))
+
+    async def handle(self, command: Command) -> Response | None:
+        """Exactly one response per command, or ``None`` when the reply is held.
+
+        Abort/shutdown during a run return ``None`` so ``serve`` keeps reading
+        stdin. Held replies are written after ``agent_end``.
+        """
+        match self._state, command:
+            case _, Invalid(error=error, command=name, id=rid):
+                return Err(name, rid, error)
+            case Closed(), _:
+                return Err(_command_name(command), command.id, "Session is closed")
+            case _, Prompt() as prompt:
+                return self._start_prompt(prompt)
+            case _, Abort() as abort:
+                return await self._abort(abort)
+            case _, Shutdown() as shutdown:
+                return await self._shutdown(shutdown)
+            case Running(), GetTables() as tables:
+                return Err("get_tables", tables.id, IDLE_ONLY_ERROR)
+            case Running(), (
+                NewSession() | SetThinkingLevel() | ReloadModel()
+            ) as mutate:
+                return Err(_command_name(mutate), mutate.id, IDLE_ONLY_ERROR)
+            case Idle(), (NewSession() | SetThinkingLevel() | ReloadModel()) as mutate:
+                return await self._mutate(mutate)
+            case Idle(), GetTables() as tables:
+                return await self._read(tables)
+            case _, (
+                GetState()
+                | GetMessages()
+                | GetLastAssistantText()
+                | GetQueryResult()
+                | GetArtifact()
+            ) as read:
+                return await self._read(read)
+        return Err(
+            _command_name(command),
+            command.id,
+            "Internal error: unhandled command",
+        )
+
+    async def close(self) -> None:
+        """Idempotent. Aborts a running query, then enters Closed."""
+        match self._state:
+            case Closed():
+                return
+            case Running() as running:
+                running.abort.set()
+                self._ensure_watch(running)
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(running.task),
+                        timeout=self._abort_grace + HARD_CANCEL_TIMEOUT + 0.25,
+                    )
+                except TimeoutError:
+                    running.task.cancel()
+                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(running.task, timeout=1.0)
+                if isinstance(self._state, Closed):
+                    return
+                self._state = Closed()
+                self.closed.set()
+            case Idle():
+                self._state = Closed()
+                self.closed.set()
+
+    def send(self, response: Response) -> None:
+        self._write_bytes(encode(response))
+
+    def _start_prompt(self, command: Prompt) -> Response:
+        match self._state:
+            case Running():
+                return Err("prompt", command.id, BUSY_ERROR)
+            case Idle():
+                abort = asyncio.Event()
+                task = asyncio.create_task(
+                    self._run(command.message, abort, command.id)
+                )
+                self._state = Running(
+                    task=task,
+                    abort=abort,
+                    prompt=command.message,
+                    prompt_id=command.id,
+                )
+                return Ok("prompt", command.id)
+        return Err("prompt", command.id, "Session is closed")
+
+    async def _run(
+        self,
+        prompt: str,
+        abort: asyncio.Event,
+        prompt_id: str | int | None,
+    ) -> None:
+        outcome: RunOutcome = Failed("internal error")
+        try:
+            self._emit(AgentStart(prompt_id=prompt_id))
+            result = await self._saber.query(
+                prompt, event_stream_handler=self._translate
+            )
+            outcome = Completed(
+                messages=tuple(transcript(result.new_messages)),
+                text=result.text,
+                usage=_run_usage(result),
+                query_results=tuple(result.query_results),
+                artifacts=tuple(result.artifacts),
+                thread_id=self._saber.info.thread_id,
+            )
+        except _RunAborted:
+            outcome = Aborted()
+        except asyncio.CancelledError:
+            outcome = Aborted()
+        except Exception as exc:
+            outcome = Failed(str(exc))
+        finally:
+            abort_waiters: list[Abort] = []
+            shutdown_waiters: list[Shutdown] = []
+            match self._state:
+                case Running() as running:
+                    abort_waiters = list(running.abort_waiters)
+                    shutdown_waiters = list(running.shutdown_waiters)
+                    running.abort_waiters.clear()
+                    running.shutdown_waiters.clear()
+            self._state = Idle()
+            self._emit(AgentEnd(outcome))
+            for waiter in abort_waiters:
+                self.send(Ok("abort", waiter.id, {"aborted": True}))
+            if shutdown_waiters:
+                self._state = Closed()
+                self.closed.set()
+                for waiter in shutdown_waiters:
+                    self.send(Ok("shutdown", waiter.id))
+
+    async def _translate(
+        self, ctx: RunContext[Any], events: AsyncIterable[AgentStreamEvent]
+    ) -> None:
+        model = getattr(ctx, "model", None)
+        model_name = getattr(model, "model_name", None)
+        translator = StreamTranslator(
+            model_name=str(model_name) if model_name is not None else None
+        )
+        self._raise_if_aborted()
+        async for event in events:
+            self._raise_if_aborted()
+            for wire in translator.translate(event):
+                self._emit(wire)
+        self._raise_if_aborted()
+        for wire in translator.finish():
+            self._emit(wire)
+
+    def _raise_if_aborted(self) -> None:
+        match self._state:
+            case Running(abort=token) if token.is_set():
+                raise _RunAborted
+
+    async def _abort(self, command: Abort) -> Response | None:
+        match self._state:
+            case Idle():
+                return Ok("abort", command.id, {"aborted": False})
+            case Running() as running:
+                running.abort.set()
+                running.abort_waiters.append(command)
+                self._ensure_watch(running)
+                return None
+        return Err("abort", command.id, "Session is closed")
+
+    async def _shutdown(self, command: Shutdown) -> Response | None:
+        match self._state:
+            case Idle():
+                self._state = Closed()
+                self.closed.set()
+                return Ok("shutdown", command.id)
+            case Running() as running:
+                running.abort.set()
+                running.shutdown_waiters.append(command)
+                self._ensure_watch(running)
+                return None
+        return Ok("shutdown", command.id)
+
+    def _ensure_watch(self, running: Running) -> None:
+        if running.watch is not None and not running.watch.done():
+            return
+        running.watch = asyncio.create_task(self._watch_cancel(running))
+
+    async def _watch_cancel(self, running: Running) -> None:
+        task = running.task
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=self._abort_grace)
+            return
+        except TimeoutError:
+            task.cancel()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=HARD_CANCEL_TIMEOUT
+                )
+            except TimeoutError:
+                waiters: list[Abort] = []
+                match self._state:
+                    case Running() as current if current is running:
+                        waiters = list(current.abort_waiters)
+                        current.abort_waiters.clear()
+                for waiter in waiters:
+                    self.send(
+                        Err(
+                            "abort",
+                            waiter.id,
+                            "Run did not stop; it is still running",
+                        )
+                    )
+
+    async def _read(self, command: ReadCommand | GetTables) -> Response:
+        name = _command_name(command)
+        try:
+            match command:
+                case GetState():
+                    return Ok(name, command.id, state_json(self._snapshot()))
+                case GetMessages():
+                    messages = [
+                        message_json(item) for item in transcript(self._saber.messages)
+                    ]
+                    return Ok(name, command.id, {"messages": messages})
+                case GetLastAssistantText():
+                    return Ok(
+                        name,
+                        command.id,
+                        {"text": last_assistant_text(self._saber.messages)},
+                    )
+                case GetTables():
+                    tables = [
+                        {
+                            "database": table.database_name,
+                            "schema": table.schema_name,
+                            "name": table.name,
+                            "kind": table.kind,
+                            "qualifiedName": table.qualified_name,
+                        }
+                        for table in await self._saber.list_tables()
+                    ]
+                    return Ok(name, command.id, {"tables": tables})
+                case GetQueryResult(result_id=result_id, offset=offset, limit=limit):
+                    loaded = await self._saber.get_query_result(result_id)
+                    return Ok(
+                        name,
+                        command.id,
+                        query_result_page(loaded, offset=offset, limit=limit),
+                    )
+                case GetArtifact(artifact_id=artifact_id):
+                    loaded = await self._saber.get_artifact(artifact_id)
+                    return Ok(
+                        name,
+                        command.id,
+                        {"artifact": artifact_json(loaded.descriptor)},
+                    )
+        except Exception as exc:
+            return Err(name, command.id, map_sdk_error(exc))
+        return Err(name, command.id, "Internal error: unhandled read")
+
+    async def _mutate(
+        self, command: NewSession | SetThinkingLevel | ReloadModel
+    ) -> Response:
+        name = _command_name(command)
+        try:
+            match command:
+                case NewSession():
+                    await self._saber.new_thread()
+                case SetThinkingLevel(level="off"):
+                    self._saber.set_thinking(enabled=False)
+                case SetThinkingLevel(level=level):
+                    self._saber.set_thinking(enabled=True, level=ThinkingLevel(level))
+                case ReloadModel():
+                    self._saber.reload_model_settings()
+            return Ok(name, command.id, state_json(self._snapshot()))
+        except Exception as exc:
+            return Err(name, command.id, map_sdk_error(exc))
+
+    def _snapshot(self) -> StateSnapshot:
+        info = self._saber.info
+        thinking = "off" if not info.thinking.enabled else info.thinking.level.value
+        phase: str = "running" if isinstance(self._state, Running) else "idle"
+        return StateSnapshot(
+            state="running" if phase == "running" else "idle",
+            database_names=info.database_names,
+            primary_database=info.primary_database_name,
+            database_type=info.primary_database_type,
+            model_name=info.model_name,
+            model_id=info.model_id,
+            thinking=thinking,
+            dangerous_mode=info.dangerous_mode,
+            csv_tool_results=info.csv_tool_results,
+            thread_id=info.thread_id,
+            thread_persistence=self._persist_thread,
+            message_count=len(transcript(self._saber.messages)),
+        )
+
+    def _emit(self, event: Event) -> None:
+        self._write_bytes(encode(event))
+
+    def _write_bytes(self, record: bytes) -> None:
+        try:
+            self._write(record)
+        except BrokenPipeError:
+            if not self.closed.is_set():
+                with contextlib.suppress(RuntimeError):
+                    asyncio.get_running_loop().create_task(self.close())
+
+
+def map_sdk_error(exc: BaseException) -> str:
+    """Map an SDK/store exception onto a protocol error string.
+
+    Args:
+        exc: Raised error.
+
+    Returns:
+        Client-facing error text. ``error`` stays a string (Pi-shaped).
+    """
+    if isinstance(exc, RunInProgressError):
+        return BUSY_ERROR
+    if isinstance(exc, SQLSaberClosedError):
+        return "SQLSaber is closed"
+    if isinstance(exc, QueryResultUnavailable):
+        return str(exc)
+    if isinstance(exc, ArtifactUnavailable):
+        return str(exc)
+    if isinstance(exc, ThreadResumeError):
+        return str(exc)
+    if isinstance(exc, ValueError):
+        return str(exc)
+    return f"Internal error: {exc}"
+
+
+def _command_name(command: Command) -> str:
+    match command:
+        case Prompt():
+            return "prompt"
+        case Abort():
+            return "abort"
+        case NewSession():
+            return "new_session"
+        case GetState():
+            return "get_state"
+        case GetMessages():
+            return "get_messages"
+        case GetLastAssistantText():
+            return "get_last_assistant_text"
+        case SetThinkingLevel():
+            return "set_thinking_level"
+        case ReloadModel():
+            return "reload_model"
+        case GetTables():
+            return "get_tables"
+        case GetQueryResult():
+            return "get_query_result"
+        case GetArtifact():
+            return "get_artifact"
+        case Shutdown():
+            return "shutdown"
+        case Invalid(command=name):
+            return name
+    return "parse"
+
+
+def _run_usage(result: SQLSaberResult) -> RunUsageSummary | None:
+    usage = result.usage
+    if usage is None:
+        return None
+    return RunUsageSummary(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_write_tokens=usage.cache_write_tokens,
+        requests=usage.requests,
+        tool_calls=usage.tool_calls,
+        context_tokens=result.final_context_tokens,
+    )
+
+
+async def _next_line_or_closed(
+    reader: LineReader, closed: asyncio.Event
+) -> bytes | None:
+    """Race one ``readline`` against the closed flag.
+
+    Args:
+        reader: Stdin source.
+        closed: Set when the session enters Closed.
+
+    Returns:
+        The next line, ``b""`` at EOF, or ``None`` when closed won.
+    """
+    read_task = asyncio.create_task(reader.readline())
+    closed_task = asyncio.create_task(closed.wait())
+    try:
+        _done, pending = await asyncio.wait(
+            {read_task, closed_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        for task in pending:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        if closed.is_set():
+            return None
+        return read_task.result()
+    except asyncio.CancelledError:
+        read_task.cancel()
+        closed_task.cancel()
+        raise
+
+
+def _install_signals(session: RpcSession) -> Callable[[], None]:
+    loop = asyncio.get_running_loop()
+    signals = [
+        sig
+        for sig in (getattr(signal, "SIGTERM", None), getattr(signal, "SIGINT", None))
+        if sig is not None
+    ]
+
+    def _close() -> None:
+        loop.create_task(session.close())
+
+    installed: list[signal.Signals] = []
+    for sig in signals:
+        try:
+            loop.add_signal_handler(sig, _close)
+            installed.append(sig)
+        except (NotImplementedError, RuntimeError, OSError):
+            break
+
+    def _uninstall() -> None:
+        for sig in installed:
+            with contextlib.suppress(NotImplementedError, RuntimeError, OSError):
+                loop.remove_signal_handler(sig)
+
+    return _uninstall
+
+
+async def serve(
+    saber: SQLSaber,
+    *,
+    reader: LineReader,
+    write: Callable[[bytes], None],
+    persist_thread: bool,
+    abort_grace: float = 0.5,
+) -> None:
+    """Run one session to completion (shutdown, EOF, signal, or client gone).
+
+    Args:
+        saber: Conversation owner. Not closed by this function.
+        reader: Stdin source.
+        write: Sink for complete JSONL records.
+        persist_thread: Whether this session saves a thread.
+        abort_grace: Seconds to wait for cooperative abort before hard cancel.
+    """
+    session = RpcSession(
+        saber, write=write, persist_thread=persist_thread, abort_grace=abort_grace
+    )
+    uninstall = _install_signals(session)
+    session.emit_ready()
+    try:
+        while not session.closed.is_set():
+            line = await _next_line_or_closed(reader, session.closed)
+            if line is None:
+                break
+            if line == b"":
+                await session.close()
+                break
+            if line.strip(b"\r\n") == b"":
+                continue
+            payload = line.rstrip(b"\r\n")
+            if line == OVERSIZE_LINE or len(payload) > MAX_STDIN_LINE:
+                session.send(Err("parse", None, "Input line exceeds 1 MiB"))
+                continue
+            response = await session.handle(parse_command(line))
+            if response is not None:
+                session.send(response)
+    finally:
+        uninstall()
+        await session.close()

--- a/src/sqlsaber/rpc/transcript.py
+++ b/src/sqlsaber/rpc/transcript.py
@@ -1,0 +1,524 @@
+"""Project pydantic-ai history and stream events onto the RPC wire model."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic_ai.messages import (
+    AgentStreamEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    ModelResponsePart,
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    RetryPromptPart,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from sqlsaber.query_result_resolution import query_result_from_metadata
+from sqlsaber.utils.partial_json import partial_json_query
+
+from .protocol import (
+    AssistantMessage,
+    ContentBlock,
+    Event,
+    MessageEnd,
+    MessageStart,
+    MessageUpdate,
+    SqlUpdate,
+    StopReason,
+    TextBlock,
+    TextDelta,
+    TextEnd,
+    TextStart,
+    ThinkingBlock,
+    ThinkingDelta,
+    ThinkingEnd,
+    ThinkingStart,
+    ToolCallBlock,
+    ToolCallDelta,
+    ToolCallEnd,
+    ToolCallStart,
+    ToolExecutionEnd,
+    ToolExecutionStart,
+    ToolResultMessage,
+    TranscriptMessage,
+    Usage,
+    UserMessage,
+)
+
+_STOP_REASONS: dict[str, StopReason] = {
+    "stop": "stop",
+    "length": "length",
+    "tool_call": "toolUse",
+    "content_filter": "contentFilter",
+    "error": "error",
+}
+
+
+def transcript(messages: Sequence[ModelMessage]) -> list[TranscriptMessage]:
+    """Project committed pydantic-ai history onto the RPC transcript.
+
+    Args:
+        messages: SDK-owned ``ModelMessage`` history.
+
+    Returns:
+        Wire transcript messages in order. System-prompt parts are dropped.
+    """
+    projected: list[TranscriptMessage] = []
+    for message in messages:
+        if isinstance(message, ModelRequest):
+            for part in message.parts:
+                if isinstance(part, UserPromptPart):
+                    projected.append(user_message(part))
+                elif isinstance(part, (ToolReturnPart, RetryPromptPart)):
+                    projected.append(tool_result_message(part))
+        elif isinstance(message, ModelResponse):
+            projected.append(assistant_message(message))
+    return projected
+
+
+def last_assistant_text(messages: Sequence[ModelMessage]) -> str | None:
+    """Return concatenated text of the latest assistant message, if any.
+
+    Args:
+        messages: SDK-owned history.
+
+    Returns:
+        Joined text blocks, an empty string when the last assistant message
+        has no text, or ``None`` when there is no assistant message.
+    """
+    for message in reversed(transcript(messages)):
+        if isinstance(message, AssistantMessage):
+            return "".join(
+                block.text for block in message.content if isinstance(block, TextBlock)
+            )
+    return None
+
+
+def user_message(part: UserPromptPart) -> UserMessage:
+    """Project a user-prompt part.
+
+    Args:
+        part: pydantic-ai user prompt.
+
+    Returns:
+        Wire user message.
+    """
+    return UserMessage(
+        content=_user_text(part.content),
+        timestamp_ms=_timestamp_ms(part.timestamp),
+    )
+
+
+def assistant_message(response: ModelResponse) -> AssistantMessage:
+    """Project a model response.
+
+    Args:
+        response: pydantic-ai model response.
+
+    Returns:
+        Wire assistant message.
+    """
+    usage = response.usage
+    return AssistantMessage(
+        content=content_blocks(response.parts),
+        model=response.model_name,
+        usage=Usage(
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+        ),
+        stop_reason=_STOP_REASONS.get(response.finish_reason or "", None),
+        timestamp_ms=_timestamp_ms(response.timestamp),
+    )
+
+
+def tool_result_message(part: ToolReturnPart | RetryPromptPart) -> ToolResultMessage:
+    """Project a tool return or retry prompt.
+
+    Args:
+        part: Tool result or retry feedback.
+
+    Returns:
+        Wire tool-result message.
+    """
+    if isinstance(part, RetryPromptPart):
+        return ToolResultMessage(
+            tool_call_id=part.tool_call_id,
+            tool_name=part.tool_name or "",
+            content=part.model_response(),
+            is_error=True,
+            timestamp_ms=_timestamp_ms(part.timestamp),
+        )
+    return ToolResultMessage(
+        tool_call_id=part.tool_call_id,
+        tool_name=part.tool_name,
+        content=part.content,
+        is_error=part.outcome != "success",
+        timestamp_ms=_timestamp_ms(part.timestamp),
+        query_result=query_result_from_metadata(part.metadata),
+    )
+
+
+def content_blocks(parts: Sequence[ModelResponsePart]) -> tuple[ContentBlock, ...]:
+    """Map response parts onto transcript content blocks.
+
+    Args:
+        parts: Model response parts.
+
+    Returns:
+        Text, thinking, and tool-call blocks. File and builtin parts are dropped.
+    """
+    blocks: list[ContentBlock] = []
+    for part in parts:
+        if isinstance(part, TextPart):
+            blocks.append(TextBlock(text=part.content))
+        elif isinstance(part, ThinkingPart):
+            blocks.append(ThinkingBlock(thinking=part.content))
+        elif isinstance(part, ToolCallPart):
+            blocks.append(
+                ToolCallBlock(
+                    id=part.tool_call_id,
+                    name=part.tool_name,
+                    arguments=part.args_as_dict(),
+                )
+            )
+    return tuple(blocks)
+
+
+def _user_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray)):
+        pieces: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                pieces.append(item)
+            else:
+                text = getattr(item, "content", None)
+                if isinstance(text, str):
+                    pieces.append(text)
+        return "".join(pieces)
+    return str(content)
+
+
+def _timestamp_ms(value: datetime | None) -> int:
+    if value is None:
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return int(value.timestamp() * 1000)
+
+
+@dataclass(slots=True)
+class _OpenBlock:
+    kind: Literal["text", "thinking", "tool_call"]
+    text: str = ""
+    tool_call_id: str = ""
+    tool_name: str = ""
+    args: str | dict[str, Any] = ""
+    last_sql: str = ""
+
+
+class StreamTranslator:
+    """Translate one ``event_stream_handler`` invocation into wire events.
+
+    pydantic-ai calls the handler once per graph node, so one translator
+    instance is at most one assistant message.
+    """
+
+    def __init__(self, *, model_name: str | None) -> None:
+        self._model_name = model_name
+        self._blocks: dict[int, _OpenBlock] = {}
+        self._completed: dict[int, ContentBlock] = {}
+        self._started = False
+
+    def translate(self, event: AgentStreamEvent) -> list[Event]:
+        """Return zero or more wire events for one pydantic-ai stream event.
+
+        Args:
+            event: A part-start/delta/end or function-tool event.
+
+        Returns:
+            Wire events in the order a client should observe them.
+        """
+        if isinstance(event, PartStartEvent):
+            return self._on_part_start(event)
+        if isinstance(event, PartDeltaEvent):
+            return self._on_part_delta(event)
+        if isinstance(event, PartEndEvent):
+            return self._on_part_end(event)
+        if isinstance(event, FunctionToolCallEvent):
+            return [
+                ToolExecutionStart(
+                    tool_call_id=event.part.tool_call_id,
+                    tool_name=event.part.tool_name,
+                    args=event.part.args_as_dict(),
+                )
+            ]
+        if isinstance(event, FunctionToolResultEvent):
+            return [self._tool_result(event)]
+        return []
+
+    def finish(self) -> list[Event]:
+        """Close any open message with ``message_end``.
+
+        Returns:
+            End events for unfinished blocks plus ``MessageEnd`` when a
+            message was opened; otherwise an empty list.
+        """
+        events: list[Event] = []
+        for index in sorted(self._blocks):
+            events.extend(self._close_index(index))
+        if self._started:
+            events.append(
+                MessageEnd(
+                    message=AssistantMessage(
+                        content=tuple(
+                            self._completed[index] for index in sorted(self._completed)
+                        ),
+                        model=self._model_name,
+                        usage=None,
+                        stop_reason=None,
+                        timestamp_ms=_timestamp_ms(None),
+                    )
+                )
+            )
+        return events
+
+    def _ensure_message_start(self) -> list[Event]:
+        if self._started:
+            return []
+        self._started = True
+        return [MessageStart()]
+
+    def _on_part_start(self, event: PartStartEvent) -> list[Event]:
+        events = self._ensure_message_start()
+        if event.index in self._blocks:
+            events.extend(self._close_index(event.index))
+        part = event.part
+        if isinstance(part, TextPart):
+            self._blocks[event.index] = _OpenBlock(kind="text", text=part.content)
+            events.append(MessageUpdate(TextStart(event.index)))
+            if part.content:
+                events.append(MessageUpdate(TextDelta(event.index, part.content)))
+            return events
+        if isinstance(part, ThinkingPart):
+            self._blocks[event.index] = _OpenBlock(kind="thinking", text=part.content)
+            events.append(MessageUpdate(ThinkingStart(event.index)))
+            if part.content:
+                events.append(MessageUpdate(ThinkingDelta(event.index, part.content)))
+            return events
+        if isinstance(part, ToolCallPart):
+            args: str | dict[str, Any]
+            if isinstance(part.args, dict):
+                args = dict(part.args)
+            else:
+                args = part.args or ""
+            self._blocks[event.index] = _OpenBlock(
+                kind="tool_call",
+                tool_call_id=part.tool_call_id,
+                tool_name=part.tool_name,
+                args=args,
+            )
+            events.append(
+                MessageUpdate(
+                    ToolCallStart(event.index, part.tool_call_id, part.tool_name)
+                )
+            )
+            delta = _args_delta(args)
+            if delta:
+                events.append(MessageUpdate(ToolCallDelta(event.index, delta)))
+            events.extend(self._maybe_sql_update(event.index))
+            return events
+        return events
+
+    def _on_part_delta(self, event: PartDeltaEvent) -> list[Event]:
+        delta = event.delta
+        block = self._blocks.get(event.index)
+        if isinstance(delta, TextPartDelta):
+            text = delta.content_delta or ""
+            if block is None or block.kind != "text":
+                events = self._ensure_message_start()
+                if block is not None:
+                    events.extend(self._close_index(event.index))
+                self._blocks[event.index] = _OpenBlock(kind="text")
+                events.append(MessageUpdate(TextStart(event.index)))
+                block = self._blocks[event.index]
+            else:
+                events = []
+            block.text += text
+            if text:
+                events.append(MessageUpdate(TextDelta(event.index, text)))
+            return events
+        if isinstance(delta, ThinkingPartDelta):
+            text = delta.content_delta or ""
+            if block is None or block.kind != "thinking":
+                events = self._ensure_message_start()
+                if block is not None:
+                    events.extend(self._close_index(event.index))
+                self._blocks[event.index] = _OpenBlock(kind="thinking")
+                events.append(MessageUpdate(ThinkingStart(event.index)))
+                block = self._blocks[event.index]
+            else:
+                events = []
+            block.text += text
+            if text:
+                events.append(MessageUpdate(ThinkingDelta(event.index, text)))
+            return events
+        if isinstance(delta, ToolCallPartDelta):
+            events = []
+            if block is None or block.kind != "tool_call":
+                events.extend(self._ensure_message_start())
+                if block is not None:
+                    events.extend(self._close_index(event.index))
+                self._blocks[event.index] = _OpenBlock(kind="tool_call")
+                block = self._blocks[event.index]
+                events.append(
+                    MessageUpdate(ToolCallStart(event.index, block.tool_call_id, ""))
+                )
+            if delta.tool_name_delta:
+                block.tool_name = f"{block.tool_name}{delta.tool_name_delta}"
+            if delta.tool_call_id:
+                block.tool_call_id = delta.tool_call_id
+            args_delta = delta.args_delta
+            emitted = ""
+            if isinstance(args_delta, str):
+                if isinstance(block.args, str):
+                    block.args = block.args + args_delta
+                else:
+                    block.args = json.dumps(block.args, ensure_ascii=False) + args_delta
+                emitted = args_delta
+            elif isinstance(args_delta, dict):
+                if isinstance(block.args, dict):
+                    block.args = {**block.args, **args_delta}
+                else:
+                    parsed = _parse_args_object(block.args)
+                    block.args = {**parsed, **args_delta}
+                emitted = json.dumps(args_delta, ensure_ascii=False)
+            if emitted:
+                events.append(MessageUpdate(ToolCallDelta(event.index, emitted)))
+            events.extend(self._maybe_sql_update(event.index))
+            return events
+        return []
+
+    def _on_part_end(self, event: PartEndEvent) -> list[Event]:
+        part = event.part
+        if isinstance(part, TextPart):
+            self._blocks.pop(event.index, None)
+            self._completed[event.index] = TextBlock(text=part.content)
+            return [MessageUpdate(TextEnd(event.index, part.content))]
+        if isinstance(part, ThinkingPart):
+            self._blocks.pop(event.index, None)
+            self._completed[event.index] = ThinkingBlock(thinking=part.content)
+            return [MessageUpdate(ThinkingEnd(event.index, part.content))]
+        if isinstance(part, ToolCallPart):
+            self._blocks.pop(event.index, None)
+            tool_call = ToolCallBlock(
+                id=part.tool_call_id,
+                name=part.tool_name,
+                arguments=part.args_as_dict(),
+            )
+            self._completed[event.index] = tool_call
+            events: list[Event] = [MessageUpdate(ToolCallEnd(event.index, tool_call))]
+            query = tool_call.arguments.get("query")
+            if part.tool_name == "execute_sql" and isinstance(query, str) and query:
+                events.append(SqlUpdate(sql=query, tool_call_id=part.tool_call_id))
+            return events
+        return []
+
+    def _close_index(self, index: int) -> list[Event]:
+        block = self._blocks.pop(index, None)
+        if block is None:
+            return []
+        if block.kind == "text":
+            self._completed[index] = TextBlock(text=block.text)
+            return [MessageUpdate(TextEnd(index, block.text))]
+        if block.kind == "thinking":
+            self._completed[index] = ThinkingBlock(thinking=block.text)
+            return [MessageUpdate(ThinkingEnd(index, block.text))]
+        arguments = _args_as_dict(block.args)
+        tool_call = ToolCallBlock(
+            id=block.tool_call_id,
+            name=block.tool_name,
+            arguments=arguments,
+        )
+        self._completed[index] = tool_call
+        return [MessageUpdate(ToolCallEnd(index, tool_call))]
+
+    def _maybe_sql_update(self, index: int) -> list[Event]:
+        block = self._blocks.get(index)
+        if (
+            block is None
+            or block.kind != "tool_call"
+            or block.tool_name != "execute_sql"
+        ):
+            return []
+        query: str | None
+        if isinstance(block.args, str):
+            query = partial_json_query(block.args)
+        else:
+            value = block.args.get("query")
+            query = value if isinstance(value, str) else None
+        if not query or query == block.last_sql:
+            return []
+        block.last_sql = query
+        return [SqlUpdate(sql=query, tool_call_id=block.tool_call_id or None)]
+
+    def _tool_result(self, event: FunctionToolResultEvent) -> ToolExecutionEnd:
+        part = event.part
+        if isinstance(part, RetryPromptPart):
+            return ToolExecutionEnd(
+                tool_call_id=part.tool_call_id,
+                tool_name=part.tool_name or "",
+                result=part.model_response(),
+                is_error=True,
+            )
+        return ToolExecutionEnd(
+            tool_call_id=part.tool_call_id,
+            tool_name=part.tool_name,
+            result=part.content,
+            is_error=part.outcome != "success",
+            query_result=query_result_from_metadata(getattr(part, "metadata", None)),
+        )
+
+
+def _args_delta(args: str | dict[str, Any]) -> str:
+    if isinstance(args, str):
+        return args
+    if not args:
+        return ""
+    return json.dumps(args, ensure_ascii=False)
+
+
+def _parse_args_object(raw: str) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _args_as_dict(args: str | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(args, dict):
+        return args
+    return _parse_args_object(args)

--- a/src/sqlsaber/sdk/client.py
+++ b/src/sqlsaber/sdk/client.py
@@ -273,6 +273,15 @@ class SQLSaber:
         )
 
     @property
+    def messages(self) -> list[ModelMessage]:
+        """Committed conversation history (copy).
+
+        Aborted or failed queries leave this unchanged. The list is a snapshot;
+        mutating it does not affect the SDK-owned history.
+        """
+        return list(self._message_history)
+
+    @property
     def display_registry(self) -> Mapping[str, Tool]:
         """Read-only display adapters for streaming renderers."""
         return MappingProxyType(dict(self._runtime.agent.display_registry))

--- a/src/sqlsaber/utils/partial_json.py
+++ b/src/sqlsaber/utils/partial_json.py
@@ -1,0 +1,25 @@
+"""Partial JSON helpers shared by the CLI stream presenter and RPC."""
+
+from __future__ import annotations
+
+from pydantic_core import from_json
+
+
+def partial_json_query(args: str) -> str | None:
+    """Decode the complete portion of a query value from partial JSON arguments.
+
+    Args:
+        args: A possibly incomplete JSON object string, typically streamed
+            ``execute_sql`` tool-call arguments.
+
+    Returns:
+        The ``query`` string when it can be recovered, otherwise ``None``.
+    """
+    try:
+        parsed = from_json(args, allow_partial="trailing-strings")
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    query = parsed.get("query")
+    return query if isinstance(query, str) else None

--- a/tests/test_api/test_sdk_conversation.py
+++ b/tests/test_api/test_sdk_conversation.py
@@ -176,6 +176,34 @@ async def test_query_owns_history_and_preserves_explicit_history_compatibility(
 
 
 @pytest.mark.asyncio
+async def test_messages_is_a_copy_of_committed_history(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+
+    async def fake_run(prompt: str, **kwargs: Any) -> _RunResult:
+        history = list(kwargs["message_history"])
+        created = _turn(prompt, "answer")
+        return _RunResult(
+            output="answer",
+            created_messages=created,
+            history=[*history, *created],
+        )
+
+    monkeypatch.setattr(saber.agent, "run", fake_run)
+    try:
+        assert saber.messages == []
+        result = await saber.query("first")
+        snapshot = saber.messages
+        assert snapshot == result.all_messages
+        snapshot.clear()
+        assert saber.messages == result.all_messages
+        saber._query_in_progress = True
+        assert saber.messages == result.all_messages
+        saber._query_in_progress = False
+    finally:
+        await saber.close()
+
+
+@pytest.mark.asyncio
 async def test_result_exposes_complete_run_data(monkeypatch) -> None:
     saber = SQLSaber(options=_options())
     first_response = ModelResponse(

--- a/tests/test_cli/test_agent_friendly_cli.py
+++ b/tests/test_cli/test_agent_friendly_cli.py
@@ -28,6 +28,7 @@ from sqlsaber.config.settings import ThinkingLevel
         ["theme", "set"],
         ["theme", "reset"],
         ["threads", "prune"],
+        ["rpc"],
     ],
 )
 def test_affected_help_includes_examples(command, capsys):

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -158,6 +158,7 @@ class TestCLICommands:
         assert "knowledge" in captured.out
         assert "models" in captured.out
         assert "auth" in captured.out
+        assert "rpc" in captured.out
 
     @staticmethod
     def _help_text(capsys, args: list[str]) -> str:

--- a/tests/test_cli/test_interactive_boot.py
+++ b/tests/test_cli/test_interactive_boot.py
@@ -28,6 +28,7 @@ loaded = [
         "pydantic_ai",
         "sqlsaber.cli.auth",
         "sqlsaber.cli.models",
+        "sqlsaber.cli.rpc",
         "sqlsaber.cli.update_check",
         "sqlsaber.config.logging",
     )

--- a/tests/test_cli/test_rpc_command.py
+++ b/tests/test_cli/test_rpc_command.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from sqlsaber.cli.commands import app
+from sqlsaber.cli.rpc import rpc
+
+
+def test_root_help_lists_rpc(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        app(["--help"])
+    assert exc_info.value.code == 0
+    assert "rpc" in capsys.readouterr().out
+
+
+def test_rpc_help_includes_examples_and_is_fast(capsys) -> None:
+    started = time.perf_counter()
+    with pytest.raises(SystemExit) as exc_info:
+        app(["rpc", "--help"])
+    elapsed = time.perf_counter() - started
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Example" in output
+    assert "--no-thread" in output
+    assert elapsed < 0.5
+
+
+def test_thread_and_no_thread_are_exclusive(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        rpc(thread="abc", no_thread=True)
+    assert exc_info.value.code == 2
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+def test_rpc_startup_without_database_is_one_json_line(monkeypatch) -> None:
+    writes: list[bytes] = []
+    monkeypatch.setattr("sqlsaber.cli.rpc.claim_stdout", lambda: writes.append)
+    monkeypatch.setattr(
+        "sqlsaber.cli.onboarding.needs_onboarding", lambda _database=None: True
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        rpc()
+    assert exc_info.value.code == 1
+    assert len(writes) == 1
+    record = json.loads(writes[0])
+    assert record["type"] == "response"
+    assert record["command"] == "startup"
+    assert record["success"] is False
+    assert "sqlsaber db add" in record["error"]
+
+
+def test_rpc_passes_persist_thread(monkeypatch) -> None:
+    from sqlsaber.cli.commands import CLIError
+
+    captured: dict[str, object] = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        raise CLIError("stopped")
+
+    writes: list[bytes] = []
+    monkeypatch.setattr("sqlsaber.cli.rpc.claim_stdout", lambda: writes.append)
+    monkeypatch.setattr(
+        "sqlsaber.cli.onboarding.needs_onboarding", lambda _database=None: False
+    )
+    monkeypatch.setattr("sqlsaber.cli.commands._create_cli_saber", create)
+    with pytest.raises(SystemExit) as exc_info:
+        rpc(no_thread=True, database=["analytics"])
+    assert exc_info.value.code == 1
+    assert captured["persist_thread"] is False
+    assert json.loads(writes[0])["command"] == "startup"
+
+    captured.clear()
+    writes.clear()
+    with pytest.raises(SystemExit):
+        rpc(database=["analytics"])
+    assert captured["persist_thread"] is True
+
+
+def test_subprocess_rpc_empty_config_writes_startup_json(tmp_path) -> None:
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "XDG_DATA_HOME": str(tmp_path / "data"),
+        "XDG_STATE_HOME": str(tmp_path / "state"),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", "sqlsaber", "rpc"],
+        check=False,
+        capture_output=True,
+        input=b"",
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["command"] == "startup"
+    assert record["success"] is False
+    assert result.stdout.decode("utf-8").endswith("\n")

--- a/tests/test_rpc/test_protocol.py
+++ b/tests/test_rpc/test_protocol.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+
+from sqlsaber.rpc.protocol import (
+    MAX_STDIN_LINE,
+    Aborted,
+    AgentEnd,
+    AgentStart,
+    Completed,
+    Err,
+    Failed,
+    GetQueryResult,
+    Invalid,
+    MessageUpdate,
+    Ok,
+    Prompt,
+    TextDelta,
+    encode,
+    parse_command,
+)
+
+
+def _load(record: bytes) -> dict:
+    assert record.endswith(b"\n")
+    assert b"\n" not in record[:-1]
+    return json.loads(record.decode("utf-8"))
+
+
+def test_parse_strips_crlf_and_echoes_id() -> None:
+    command = parse_command(b'{"id":"q1","type":"abort"}\r\n')
+    assert command == parse_command(b'{"id":"q1","type":"abort"}')
+    encoded = _load(encode(Ok("abort", "q1", {"aborted": False})))
+    assert encoded["id"] == "q1"
+    assert encoded["success"] is True
+    assert encoded["command"] == "abort"
+
+
+def test_parse_ignores_blank_payload_as_invalid_object() -> None:
+    command = parse_command(b"\n")
+    assert isinstance(command, Invalid)
+    assert command.command == "parse"
+
+
+def test_parse_keeps_line_separator_inside_json_strings() -> None:
+    raw = '{"type":"prompt","message":"a\u2028b"}'
+    command = parse_command(raw.encode("utf-8"))
+    assert isinstance(command, Prompt)
+    assert command.message == "a\u2028b"
+
+
+def test_parse_rejects_non_utf8() -> None:
+    command = parse_command(b"\xff\xfe")
+    assert isinstance(command, Invalid)
+    assert command.command == "parse"
+    assert "UTF-8" in command.error
+
+
+def test_parse_rejects_invalid_json() -> None:
+    command = parse_command(b"{not json}\n")
+    assert isinstance(command, Invalid)
+    assert command.error.startswith("Failed to parse command:")
+
+
+def test_parse_rejects_non_object() -> None:
+    command = parse_command(b'"prompt"\n')
+    assert isinstance(command, Invalid)
+    assert "JSON object" in command.error
+
+
+def test_parse_rejects_bool_id() -> None:
+    command = parse_command(b'{"type":"abort","id":true}')
+    assert isinstance(command, Invalid)
+    assert "id must be" in command.error
+
+
+def test_parse_integer_id() -> None:
+    parsed = parse_command(b'{"type":"get_state","id":7}')
+    assert parsed.id == 7
+
+
+def test_parse_unknown_command() -> None:
+    command = parse_command(b'{"type":"compact"}')
+    assert isinstance(command, Invalid)
+    assert command.command == "compact"
+    assert command.error == "Unknown command: compact"
+
+
+def test_parse_rejects_streaming_behavior() -> None:
+    command = parse_command(
+        b'{"type":"prompt","message":"hi","streamingBehavior":"steer"}'
+    )
+    assert isinstance(command, Invalid)
+    assert command.command == "prompt"
+    assert "streamingBehavior" in command.error
+
+
+def test_parse_rejects_images_and_parent_session() -> None:
+    images = parse_command(b'{"type":"prompt","message":"hi","images":[]}')
+    parent = parse_command(b'{"type":"prompt","message":"hi","parentSession":"x"}')
+    assert isinstance(images, Invalid)
+    assert "images" in images.error
+    assert isinstance(parent, Invalid)
+    assert "parentSession" in parent.error
+
+
+def test_parse_rejects_empty_prompt() -> None:
+    command = parse_command(b'{"type":"prompt","message":"   "}')
+    assert isinstance(command, Invalid)
+    assert command.error == "message must be a non-empty string"
+
+
+def test_parse_ignores_unknown_fields() -> None:
+    command = parse_command(b'{"type":"abort","extra":1}')
+    assert command.__class__.__name__ == "Abort"
+
+
+def test_parse_thinking_level() -> None:
+    ok = parse_command(b'{"type":"set_thinking_level","level":"off"}')
+    bad = parse_command(b'{"type":"set_thinking_level","level":"xhigh"}')
+    assert ok.__class__.__name__ == "SetThinkingLevel"
+    assert isinstance(bad, Invalid)
+    assert "off, minimal" in bad.error
+
+
+def test_parse_get_query_result_paging() -> None:
+    command = parse_command(
+        b'{"type":"get_query_result","resultId":"qr_abc","offset":10,"limit":2}'
+    )
+    assert isinstance(command, GetQueryResult)
+    assert command.result_id == "qr_abc"
+    assert command.offset == 10
+    assert command.limit == 2
+    default = parse_command(b'{"type":"get_query_result","resultId":"qr_abc"}')
+    assert isinstance(default, GetQueryResult)
+    assert default.offset == 0
+    assert default.limit == 500
+    too_big = parse_command(
+        b'{"type":"get_query_result","resultId":"qr_abc","limit":5001}'
+    )
+    assert isinstance(too_big, Invalid)
+
+
+def test_encode_ok_omits_data_and_err_has_string_error() -> None:
+    ok = _load(encode(Ok("shutdown", None)))
+    assert ok == {"type": "response", "command": "shutdown", "success": True}
+    err = _load(encode(Err("parse", None, "nope")))
+    assert err == {
+        "type": "response",
+        "command": "parse",
+        "success": False,
+        "error": "nope",
+    }
+
+
+def test_encode_agent_end_is_a_sum() -> None:
+    completed = _load(
+        encode(
+            AgentEnd(
+                Completed(
+                    messages=(),
+                    text="done",
+                    usage=None,
+                    query_results=(),
+                    artifacts=(),
+                    thread_id=None,
+                )
+            )
+        )
+    )
+    assert completed["status"] == "completed"
+    assert "error" not in completed
+    aborted = _load(encode(AgentEnd(Aborted())))
+    assert aborted == {"type": "agent_end", "status": "aborted"}
+    failed = _load(encode(AgentEnd(Failed("boom"))))
+    assert failed == {"type": "agent_end", "status": "error", "error": "boom"}
+
+
+def test_encode_message_update_uses_pi_envelope() -> None:
+    record = _load(encode(MessageUpdate(TextDelta(content_index=0, delta="Hello"))))
+    assert record["type"] == "message_update"
+    assert record["assistantMessageEvent"] == {
+        "type": "text_delta",
+        "contentIndex": 0,
+        "delta": "Hello",
+    }
+    start = _load(encode(AgentStart(prompt_id="q1")))
+    assert start == {"type": "agent_start", "promptId": "q1"}
+
+
+def test_encode_sanitizes_non_finite_floats() -> None:
+    record = _load(encode(Ok("get_state", None, {"n": float("nan")})))
+    assert record["data"]["n"] == "nan"
+
+
+def test_max_stdin_line_constant() -> None:
+    assert MAX_STDIN_LINE == 1_048_576

--- a/tests/test_rpc/test_session.py
+++ b/tests/test_rpc/test_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -29,7 +30,7 @@ from sqlsaber.query_results import (
     new_query_result_id,
 )
 from sqlsaber.rpc.protocol import OVERSIZE_LINE, parse_command
-from sqlsaber.rpc.session import RpcSession, map_sdk_error, serve
+from sqlsaber.rpc.session import RpcSession, ThreadedLineReader, map_sdk_error, serve
 from sqlsaber.sdk.errors import RunInProgressError, SQLSaberClosedError
 
 
@@ -552,3 +553,39 @@ def test_map_sdk_error_is_a_string_table() -> None:
     assert map_sdk_error(SQLSaberClosedError("closed")) == "SQLSaber is closed"
     assert map_sdk_error(ValueError("bad")) == "bad"
     assert map_sdk_error(RuntimeError("x")).startswith("Internal error:")
+
+
+@pytest.mark.asyncio
+async def test_serve_answers_while_stdin_stays_open() -> None:
+    """BufferedReader.read(n) would deadlock here; read1 must not."""
+    saber = SQLSaber(options=_options())
+    buf: list[bytes] = []
+    read_fd, write_fd = os.pipe()
+    reader_file = os.fdopen(read_fd, "rb")
+    writer_file = os.fdopen(write_fd, "wb")
+    loop = asyncio.get_running_loop()
+    reader = ThreadedLineReader(reader_file, loop)
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        writer_file.write(b'{"id":"s1","type":"get_state"}\n')
+        writer_file.flush()
+        records = await _wait_for(
+            buf,
+            lambda rows: any(row.get("command") == "get_state" for row in rows),
+        )
+        reply = next(row for row in records if row.get("command") == "get_state")
+        assert reply["success"] is True
+        assert reply["id"] == "s1"
+        assert reply["data"]["state"] == "idle"
+        writer_file.write(b'{"id":"z1","type":"shutdown"}\n')
+        writer_file.flush()
+        await asyncio.wait_for(task, timeout=2)
+    finally:
+        writer_file.close()
+        reader_file.close()
+        if not task.done():
+            task.cancel()
+        await saber.close()

--- a/tests/test_rpc/test_session.py
+++ b/tests/test_rpc/test_session.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    PartEndEvent,
+    PartStartEvent,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.usage import RequestUsage, RunUsage
+
+from sqlsaber import SQLSaber, SQLSaberOptions
+from sqlsaber.config.settings import Config
+from sqlsaber.query_results import (
+    InMemoryQueryResultStore,
+    QueryResultContext,
+    QueryResultData,
+    descriptor_for_data,
+    new_query_result_id,
+)
+from sqlsaber.rpc.protocol import OVERSIZE_LINE, parse_command
+from sqlsaber.rpc.session import RpcSession, map_sdk_error, serve
+from sqlsaber.sdk.errors import RunInProgressError, SQLSaberClosedError
+
+
+def _options(**overrides: Any) -> SQLSaberOptions:
+    values: dict[str, Any] = {
+        "database": "sqlite:///:memory:",
+        "settings": Config.in_memory(
+            model_name="anthropic:claude-3-5-sonnet",
+            api_keys={"anthropic": "test-key"},
+        ),
+        "query_result_store": InMemoryQueryResultStore(),
+    }
+    values.update(overrides)
+    return SQLSaberOptions(**values)
+
+
+def _turn(prompt: str, answer: str) -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart(prompt)]),
+        ModelResponse(
+            parts=[TextPart(answer)],
+            usage=RequestUsage(input_tokens=10, output_tokens=2),
+        ),
+    ]
+
+
+@dataclass
+class _RunResult:
+    output: str
+    created_messages: list[ModelMessage]
+    history: list[ModelMessage]
+
+    def usage(self) -> RunUsage:
+        return RunUsage(input_tokens=20, output_tokens=4, requests=1)
+
+    def new_messages(self) -> list[ModelMessage]:
+        return list(self.created_messages)
+
+    def all_messages(self) -> list[ModelMessage]:
+        return list(self.history)
+
+    def all_messages_json(self) -> bytes:
+        return ModelMessagesTypeAdapter.dump_json(self.history)
+
+
+class QueueReader:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+    def push(self, obj: dict[str, Any] | bytes) -> None:
+        if isinstance(obj, bytes):
+            self._queue.put_nowait(obj)
+        else:
+            self._queue.put_nowait((json.dumps(obj) + "\n").encode())
+
+    def eof(self) -> None:
+        self._queue.put_nowait(b"")
+
+    async def readline(self) -> bytes:
+        return await self._queue.get()
+
+
+def _load(buf: list[bytes]) -> list[dict[str, Any]]:
+    return [json.loads(item) for item in buf]
+
+
+async def _wait_for(
+    buf: list[bytes],
+    predicate,
+    *,
+    timeout: float = 3.0,
+) -> list[dict[str, Any]]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        records = _load(buf)
+        if predicate(records):
+            return records
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for records: {_load(buf)}")
+
+
+def _patch_answer(monkeypatch, saber: SQLSaber, *, hang: asyncio.Event | None = None):
+    async def fake_run(prompt: str, **kwargs: Any) -> _RunResult:
+        handler = kwargs.get("event_stream_handler")
+        if handler is not None:
+            ctx = SimpleNamespace(model=SimpleNamespace(model_name="claude-3-5-sonnet"))
+
+            async def events():
+                yield PartStartEvent(index=0, part=TextPart("Hello"))
+                if hang is not None:
+                    await hang.wait()
+                yield PartEndEvent(index=0, part=TextPart("Hello"))
+
+            await handler(ctx, events())
+        created = _turn(prompt, "Hello")
+        return _RunResult(
+            output="Hello",
+            created_messages=created,
+            history=[*list(saber.messages), *created],
+        )
+
+    monkeypatch.setattr(saber.agent, "run", fake_run)
+
+
+@pytest.mark.asyncio
+async def test_prompt_streams_then_agent_end(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    _patch_answer(monkeypatch, saber)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        assert _load(buf)[0]["thinkingLevel"] == "off"
+        reader.push({"id": "q1", "type": "prompt", "message": "hi"})
+        records = await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_end" for row in rows)
+        )
+        types = [row["type"] for row in records]
+        assert types[:3] == ["ready", "response", "agent_start"]
+        assert records[1]["command"] == "prompt" and records[1]["success"] is True
+        assert records[2].get("promptId") == "q1"
+        assert "message_start" in types
+        assert any(
+            row.get("type") == "message_update"
+            and row.get("assistantMessageEvent", {}).get("type") == "text_delta"
+            for row in records
+        )
+        end = next(row for row in records if row["type"] == "agent_end")
+        assert end["status"] == "completed"
+        assert end["text"] == "Hello"
+        reader.push({"type": "get_messages"})
+        records = await _wait_for(
+            buf, lambda rows: any(row.get("command") == "get_messages" for row in rows)
+        )
+        messages = next(row for row in records if row.get("command") == "get_messages")[
+            "data"
+        ]["messages"]
+        assert messages[0]["role"] == "user"
+        assert messages[-1]["role"] == "assistant"
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_overlapping_prompt_is_rejected(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    hang = asyncio.Event()
+    _patch_answer(monkeypatch, saber, hang=hang)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push({"id": 1, "type": "prompt", "message": "first"})
+        await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_start" for row in rows)
+        )
+        reader.push({"id": 2, "type": "prompt", "message": "second"})
+        records = await _wait_for(
+            buf,
+            lambda rows: any(
+                row.get("command") == "prompt" and row.get("id") == 2 for row in rows
+            ),
+        )
+        rejected = next(row for row in records if row.get("id") == 2)
+        assert rejected["success"] is False
+        assert "already running" in rejected["error"]
+        hang.set()
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        hang.set()
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_abort_idle_is_idempotent(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    _patch_answer(monkeypatch, saber)
+    buf: list[bytes] = []
+    session = RpcSession(saber, write=buf.append, persist_thread=False)
+    first = await session.handle(parse_command(b'{"id":"a","type":"abort"}'))
+    second = await session.handle(parse_command(b'{"id":"b","type":"abort"}'))
+    session.send(first)
+    session.send(second)
+    records = _load(buf)
+    assert records[0]["data"] == {"aborted": False}
+    assert records[1]["data"] == {"aborted": False}
+    await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_abort_mid_run_keeps_reading_stdin(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    hang = asyncio.Event()
+    _patch_answer(monkeypatch, saber, hang=hang)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(
+            saber,
+            reader=reader,
+            write=buf.append,
+            persist_thread=False,
+            abort_grace=0.05,
+        )
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push({"id": "q", "type": "prompt", "message": "slow"})
+        await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_start" for row in rows)
+        )
+        reader.push({"id": "a", "type": "abort"})
+        reader.push({"id": "s", "type": "get_state"})
+        records = await _wait_for(
+            buf,
+            lambda rows: (
+                any(row.get("command") == "abort" for row in rows)
+                and any(row.get("type") == "agent_end" for row in rows)
+            ),
+        )
+        state = next(row for row in records if row.get("command") == "get_state")
+        abort = next(row for row in records if row.get("command") == "abort")
+        end = next(row for row in records if row.get("type") == "agent_end")
+        assert state["success"] is True
+        assert records.index(state) < records.index(end)
+        assert records.index(end) < records.index(abort)
+        assert end["status"] == "aborted"
+        assert abort["data"] == {"aborted": True}
+        assert saber.messages == []
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        hang.set()
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_error_after_accept_is_agent_end(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+
+    async def boom(prompt: str, **kwargs: Any) -> _RunResult:
+        del prompt, kwargs
+        raise RuntimeError("anthropic: 529 overloaded_error")
+
+    monkeypatch.setattr(saber.agent, "run", boom)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push({"id": "q", "type": "prompt", "message": "hi"})
+        records = await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_end" for row in rows)
+        )
+        accepted = next(
+            row
+            for row in records
+            if row.get("command") == "prompt" and row.get("id") == "q"
+        )
+        assert accepted["success"] is True
+        end = next(row for row in records if row["type"] == "agent_end")
+        assert end["status"] == "error"
+        assert "529" in end["error"]
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_new_session_twice_and_mid_run_reads(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    hang = asyncio.Event()
+    _patch_answer(monkeypatch, saber, hang=hang)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=True)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push({"type": "new_session"})
+        reader.push({"id": "n2", "type": "new_session"})
+        await _wait_for(
+            buf,
+            lambda rows: (
+                sum(1 for row in rows if row.get("command") == "new_session") == 2
+            ),
+        )
+        reader.push({"id": "q", "type": "prompt", "message": "hi"})
+        await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_start" for row in rows)
+        )
+        reader.push({"type": "get_state"})
+        reader.push({"type": "get_messages"})
+        reader.push({"type": "new_session"})
+        reader.push({"type": "get_tables"})
+        records = await _wait_for(
+            buf,
+            lambda rows: (
+                any(
+                    row.get("command") == "new_session" and row.get("success") is False
+                    for row in rows
+                )
+                and any(row.get("command") == "get_tables" for row in rows)
+            ),
+        )
+        running_state = next(
+            row
+            for row in records
+            if row.get("command") == "get_state" and row.get("success")
+        )
+        assert running_state["data"]["state"] == "running"
+        assert running_state["data"]["threadPersistence"] is True
+        rejected_session = next(
+            row
+            for row in records
+            if row.get("command") == "new_session" and row.get("success") is False
+        )
+        rejected_tables = next(
+            row
+            for row in records
+            if row.get("command") == "get_tables" and row.get("success") is False
+        )
+        assert rejected_session["success"] is False
+        assert rejected_tables["success"] is False
+        hang.set()
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        hang.set()
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_while_running_aborts_first(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    hang = asyncio.Event()
+    _patch_answer(monkeypatch, saber, hang=hang)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(
+            saber,
+            reader=reader,
+            write=buf.append,
+            persist_thread=False,
+            abort_grace=0.05,
+        )
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push({"type": "prompt", "message": "hi"})
+        await _wait_for(
+            buf, lambda rows: any(row.get("type") == "agent_start" for row in rows)
+        )
+        reader.push({"id": "x", "type": "shutdown"})
+        records = await _wait_for(
+            buf,
+            lambda rows: (
+                any(row.get("command") == "shutdown" for row in rows)
+                and any(row.get("type") == "agent_end" for row in rows)
+            ),
+        )
+        end = next(row for row in records if row["type"] == "agent_end")
+        shutdown = next(row for row in records if row.get("command") == "shutdown")
+        assert records.index(end) < records.index(shutdown)
+        assert end["status"] == "aborted"
+        assert shutdown["success"] is True
+        await task
+        assert all(json.loads(item) for item in buf)
+    finally:
+        hang.set()
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_eof_closes_without_shutdown_response(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    _patch_answer(monkeypatch, saber)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+    reader.eof()
+    await task
+    records = _load(buf)
+    assert records[0]["type"] == "ready"
+    assert all(row.get("command") != "shutdown" for row in records)
+    await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_oversize_line_is_a_parse_error(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    _patch_answer(monkeypatch, saber)
+    buf: list[bytes] = []
+    reader = QueueReader()
+    task = asyncio.create_task(
+        serve(saber, reader=reader, write=buf.append, persist_thread=False)
+    )
+    try:
+        await _wait_for(buf, lambda rows: rows and rows[0]["type"] == "ready")
+        reader.push(OVERSIZE_LINE)
+        records = await _wait_for(
+            buf, lambda rows: any(row.get("command") == "parse" for row in rows)
+        )
+        error = next(row for row in records if row.get("command") == "parse")
+        assert error["success"] is False
+        assert "1 MiB" in error["error"]
+        reader.push({"type": "shutdown"})
+        await task
+    finally:
+        if not task.done():
+            reader.eof()
+            await task
+        await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_get_query_result_pages(monkeypatch) -> None:
+    store = InMemoryQueryResultStore()
+    saber = SQLSaber(options=_options(query_result_store=store))
+    _patch_answer(monkeypatch, saber)
+    rows = [{"n": index} for index in range(5)]
+    payload = json.dumps({"columns": ["n"], "results": rows}).encode()
+    descriptor = descriptor_for_data(
+        payload,
+        result_id=new_query_result_id(),
+        file="result_call.json",
+        row_count=5,
+        columns=("n",),
+    )
+    stored = await store.put(
+        QueryResultData(payload),
+        descriptor=descriptor,
+        context=QueryResultContext(),
+    )
+    buf: list[bytes] = []
+    session = RpcSession(saber, write=buf.append, persist_thread=False)
+    response = await session.handle(
+        parse_command(
+            json.dumps(
+                {
+                    "type": "get_query_result",
+                    "resultId": stored.id,
+                    "offset": 2,
+                    "limit": 2,
+                }
+            ).encode()
+        )
+    )
+    session.send(response)
+    page = _load(buf)[0]["data"]
+    assert page["offset"] == 2
+    assert page["limit"] == 2
+    assert page["rows"] == [{"n": 2}, {"n": 3}]
+    assert page["hasMore"] is True
+    missing = await session.handle(
+        parse_command(
+            b'{"type":"get_query_result","resultId":"qr_ffffffffffffffffffffffffffffffff"}'
+        )
+    )
+    session.send(missing)
+    error = _load(buf)[1]
+    assert error["success"] is False
+    assert "unavailable" in error["error"].lower()
+    await saber.close()
+
+
+@pytest.mark.asyncio
+async def test_set_thinking_off_is_real_off(monkeypatch) -> None:
+    saber = SQLSaber(options=_options())
+    buf: list[bytes] = []
+    session = RpcSession(saber, write=buf.append, persist_thread=False)
+    await session.handle(parse_command(b'{"type":"set_thinking_level","level":"high"}'))
+    off = await session.handle(
+        parse_command(b'{"type":"set_thinking_level","level":"off"}')
+    )
+    session.send(off)
+    assert _load(buf)[0]["data"]["thinkingLevel"] == "off"
+    assert saber.info.thinking.enabled is False
+    await saber.close()
+
+
+def test_map_sdk_error_is_a_string_table() -> None:
+    assert "already running" in map_sdk_error(RunInProgressError("busy"))
+    assert map_sdk_error(SQLSaberClosedError("closed")) == "SQLSaber is closed"
+    assert map_sdk_error(ValueError("bad")) == "bad"
+    assert map_sdk_error(RuntimeError("x")).startswith("Internal error:")

--- a/tests/test_rpc/test_transcript.py
+++ b/tests/test_rpc/test_transcript.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic_ai.messages import (
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    ModelRequest,
+    ModelResponse,
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    RetryPromptPart,
+    SystemPromptPart,
+    TextPart,
+    TextPartDelta,
+    ThinkingPart,
+    ThinkingPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.usage import RequestUsage
+
+from sqlsaber.query_results import QUERY_RESULT_MEDIA_TYPE, StoredQueryResult
+from sqlsaber.rpc.protocol import (
+    AssistantMessage,
+    MessageEnd,
+    MessageStart,
+    MessageUpdate,
+    SqlUpdate,
+    TextBlock,
+    TextDelta,
+    TextEnd,
+    ThinkingBlock,
+    ThinkingDelta,
+    ThinkingStart,
+    ToolExecutionEnd,
+    ToolExecutionStart,
+    ToolResultMessage,
+    UserMessage,
+)
+from sqlsaber.rpc.transcript import StreamTranslator, last_assistant_text, transcript
+from sqlsaber.utils.partial_json import partial_json_query
+
+_TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def test_partial_json_query_recovers_trailing_string() -> None:
+    assert partial_json_query('{"query": "SELECT id FROM') == "SELECT id FROM"
+    assert partial_json_query("not json") is None
+
+
+def test_transcript_projects_user_assistant_and_tool_result() -> None:
+    descriptor = StoredQueryResult(
+        id="qr_" + "a" * 32,
+        file="result_call_1.json",
+        media_type=QUERY_RESULT_MEDIA_TYPE,
+        size=10,
+        sha256="b" * 64,
+        row_count=1,
+        columns=("n",),
+    )
+    messages = [
+        ModelRequest(
+            parts=[
+                SystemPromptPart("hidden"),
+                UserPromptPart("count them", timestamp=_TS),
+            ]
+        ),
+        ModelResponse(
+            parts=[
+                ThinkingPart("plan"),
+                ToolCallPart("execute_sql", {"query": "SELECT 1"}, "call_1"),
+            ],
+            model_name="claude-3-5-sonnet",
+            timestamp=_TS,
+            finish_reason="tool_call",
+            usage=RequestUsage(input_tokens=3, output_tokens=2),
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    "execute_sql",
+                    {"n": 1},
+                    "call_1",
+                    timestamp=_TS,
+                    metadata={"query_result": descriptor.to_dict()},
+                )
+            ]
+        ),
+        ModelResponse(
+            parts=[TextPart("one row")],
+            model_name="claude-3-5-sonnet",
+            timestamp=_TS,
+            finish_reason="stop",
+        ),
+    ]
+    projected = transcript(messages)
+    assert isinstance(projected[0], UserMessage)
+    assert projected[0].content == "count them"
+    assert isinstance(projected[1], AssistantMessage)
+    assert projected[1].stop_reason == "toolUse"
+    assert projected[1].content[0] == ThinkingBlock("plan")
+    assert isinstance(projected[2], ToolResultMessage)
+    assert projected[2].query_result is not None
+    assert projected[2].query_result.id == descriptor.id
+    assert last_assistant_text(messages) == "one row"
+
+
+def test_transcript_retry_prompt_is_an_error_tool_result() -> None:
+    messages = [
+        ModelRequest(
+            parts=[
+                RetryPromptPart("bad args", tool_name="execute_sql", tool_call_id="c1")
+            ]
+        )
+    ]
+    projected = transcript(messages)
+    assert isinstance(projected[0], ToolResultMessage)
+    assert projected[0].is_error is True
+    assert "Fix the errors" in projected[0].content
+
+
+def test_stream_translator_text_and_thinking_and_tool_sql() -> None:
+    translator = StreamTranslator(model_name="claude-3-5-sonnet")
+    events = []
+    events.extend(
+        translator.translate(PartStartEvent(index=0, part=ThinkingPart(content="Need")))
+    )
+    events.extend(
+        translator.translate(
+            PartDeltaEvent(index=0, delta=ThinkingPartDelta(content_delta=" joins"))
+        )
+    )
+    events.extend(
+        translator.translate(
+            PartEndEvent(index=0, part=ThinkingPart(content="Need joins"))
+        )
+    )
+    events.extend(
+        translator.translate(
+            PartStartEvent(
+                index=1,
+                part=ToolCallPart("execute_sql", '{"query": "SEL', "call_1"),
+            )
+        )
+    )
+    events.extend(
+        translator.translate(
+            PartDeltaEvent(
+                index=1,
+                delta=ToolCallPartDelta(args_delta='ECT 1"}'),
+            )
+        )
+    )
+    events.extend(
+        translator.translate(
+            PartEndEvent(
+                index=1,
+                part=ToolCallPart("execute_sql", {"query": "SELECT 1"}, "call_1"),
+            )
+        )
+    )
+    events.extend(translator.finish())
+
+    assert isinstance(events[0], MessageStart)
+    assert isinstance(events[1], MessageUpdate)
+    assert isinstance(events[1].event, ThinkingStart)
+    thinking_deltas = [
+        event.event
+        for event in events
+        if isinstance(event, MessageUpdate) and isinstance(event.event, ThinkingDelta)
+    ]
+    assert thinking_deltas[0].delta == "Need"
+    sql_updates = [event for event in events if isinstance(event, SqlUpdate)]
+    assert sql_updates
+    assert sql_updates[-1].sql == "SELECT 1"
+    assert isinstance(events[-1], MessageEnd)
+    assert events[-1].message.usage is None
+    assert events[-1].message.stop_reason is None
+
+
+def test_stream_translator_function_tool_events() -> None:
+    translator = StreamTranslator(model_name=None)
+    start = translator.translate(
+        FunctionToolCallEvent(
+            part=ToolCallPart("execute_sql", {"query": "SELECT 1"}, "c1")
+        )
+    )
+    end = translator.translate(
+        FunctionToolResultEvent(
+            part=ToolReturnPart("execute_sql", {"ok": True}, "c1"),
+        )
+    )
+    assert start == [
+        ToolExecutionStart(
+            tool_call_id="c1",
+            tool_name="execute_sql",
+            args={"query": "SELECT 1"},
+        )
+    ]
+    assert isinstance(end[0], ToolExecutionEnd)
+    assert end[0].is_error is False
+    assert translator.finish() == []
+
+
+def test_stream_translator_text_deltas() -> None:
+    translator = StreamTranslator(model_name="m")
+    events = []
+    events.extend(translator.translate(PartStartEvent(index=0, part=TextPart("He"))))
+    events.extend(
+        translator.translate(
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta="llo"))
+        )
+    )
+    events.extend(translator.translate(PartEndEvent(index=0, part=TextPart("Hello"))))
+    events.extend(translator.finish())
+    kinds = []
+    for event in events:
+        if isinstance(event, MessageStart):
+            kinds.append("start")
+        elif isinstance(event, MessageUpdate):
+            kinds.append(type(event.event).__name__)
+        elif isinstance(event, MessageEnd):
+            kinds.append("end")
+    assert kinds == [
+        "start",
+        "TextStart",
+        "TextDelta",
+        "TextDelta",
+        "TextEnd",
+        "end",
+    ]
+    text_deltas = [
+        event.event.delta
+        for event in events
+        if isinstance(event, MessageUpdate) and isinstance(event.event, TextDelta)
+    ]
+    assert text_deltas == ["He", "llo"]
+    end_event = [
+        event.event
+        for event in events
+        if isinstance(event, MessageUpdate) and isinstance(event.event, TextEnd)
+    ][0]
+    assert end_event.content == "Hello"
+    assert isinstance(events[-1].message.content[0], TextBlock)
+    assert events[-1].message.content[0].text == "Hello"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

IDEs and other apps need a headless way to drive SQLsaber. Pi coding agent already has `pi --mode rpc` (JSONL on stdin/stdout). SQLsaber had no equivalent, and hanging RPC on the default command would steal `echo "show users" | saber`.

## Scope

- New `saber rpc` subcommand. Lazy-registered like `auth`/`db`/`threads`, so `saber --help` stays fast.
- Core package `sqlsaber.rpc` owns the protocol, transcript projection, and session loop. The CLI shell claims stdout, builds one `SQLSaber` via `_create_cli_saber`, and never writes human text to stdout.
- Pi-like camelCase JSONL: `prompt`, `abort`, `new_session`, `get_state`, `get_messages`, `get_last_assistant_text`, `set_thinking_level`, `reload_model`, `get_tables`, paged `get_query_result`, `get_artifact`, `shutdown`. Events include `ready`, `agent_start` (`promptId`), `message_*` with `assistantMessageEvent`, `sql_update`, `tool_execution_*`, and `agent_end` as a sum (`completed` / `aborted` / `error`).
- Abort uses the TUI two-stage ladder (token, grace, `task.cancel()`, hard timeout) and keeps reading stdin while a run unwinds.
- SDK delta: read-only `SQLSaber.messages` copy. CLI delta: `persist_thread` on `_create_cli_saber` for `--no-thread`. Shared `partial_json_query` for live SQL.

Out of scope: steer/follow-up queues, bash, compaction, session trees, `set_model`, images on prompt.

## Tradeoffs

- Subcommand instead of `--mode rpc`, so piped one-shot queries keep working.
- `get_tables` is idle-only because it hits live connections. `get_query_result` / `get_artifact` stay legal mid-run.
- `get_query_result` pages (default 500, max 5000). Artifact bytes are not inlined; clients use `uri`.
- `"off"` thinking calls `set_thinking(enabled=False)`. `ThinkingLevel.from_string("off")` still means MEDIUM and is not used here.

## Blast Radius

- Default `query()` path is unchanged aside from a defaulted `persist_thread=True` kwarg.
- Architecture rules hold: `sqlsaber.cli` does not import `sqlsaber.sdk`; `sqlsaber.rpc` may.
- Command discovery now lists seven families.

## Verification

Automated:

- `uvx ty check src/`
- `env -u FORCE_COLOR uv run python -m pytest` (1685 passed, 6 skipped on the feature commit; RPC-related 57 passed after the stdin fix)
- After merging `origin/main`: 118 merge-affected tests passed (`test_rpc`, `test_rpc_command`, `test_quiet_cli_logs`, `test_commands`, `test_interactive_boot`, `test_agent_friendly_cli`, `test_logging`)
- `test_serve_answers_while_stdin_stays_open` covers the keep-open path that `BufferedReader.read(n)` deadlocked

CLI (`verify-sqlsaber`, isolated home):

- `saber --help` lists `rpc`; `saber rpc --help` includes Examples (`0.19s` / `0.18s`)
- No database: one stdout `startup` JSON line, exit 1, empty stderr
- `--thread` with `--no-thread`: exit 2, stderr only
- `saber rpc -d verification.db --no-thread`: `ready`, then `get_state` / `get_tables` (departments, employees, orders) / `get_messages` / `shutdown`
- Keep-open stdin: `get_state` returns in ~1ms while the pipe stays open
- `prompt` then immediate `shutdown`: `agent_start` with `promptId`, `agent_end` aborted
- Completed model-backed `prompt` not claimed: the provider did not stream within 90s; abort path is the proof for `prompt`

Docs: `docs/src/content/docs/reference/rpc.md`. Recipe: `.agents/skills/verify-sqlsaber/features/rpc-mode.md`.

Merged `origin/main` (`be73e52`) on 2026-09-14. Conflicts were additive (docs rewrite + `_LAZY_SUBCOMMANDS` + RPC). No remaining conflicted intents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09170-40e5-7188-ab8e-06cbd2192e7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09170-40e5-7188-ab8e-06cbd2192e7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

