### PR TITLE
fix(cli): keep structlog off management command terminals

### DIFF
--- a/src/sqlsaber/cli/commands.py
+++ b/src/sqlsaber/cli/commands.py
@@ -157,36 +157,23 @@ app = cyclopts.App(
     ),
 )
 
-app.command(
-    "sqlsaber.cli.auth:auth_app",
-    name="auth",
-    help="Manage authentication configuration",
+_LAZY_SUBCOMMANDS: tuple[tuple[str, str, str], ...] = (
+    ("sqlsaber.cli.auth:auth_app", "auth", "Manage authentication configuration"),
+    ("sqlsaber.cli.database:db_app", "db", "Manage database connections"),
+    (
+        "sqlsaber.cli.knowledge:knowledge_app",
+        "knowledge",
+        "Manage database-specific knowledge entries",
+    ),
+    ("sqlsaber.cli.models:models_app", "models", "Select and manage models"),
+    ("sqlsaber.cli.theme:theme_app", "theme", "Manage theme settings"),
+    ("sqlsaber.cli.threads:threads_app", "threads", "Manage SQLsaber threads"),
 )
-app.command(
-    "sqlsaber.cli.database:db_app",
-    name="db",
-    help="Manage database connections",
-)
-app.command(
-    "sqlsaber.cli.knowledge:knowledge_app",
-    name="knowledge",
-    help="Manage database-specific knowledge entries",
-)
-app.command(
-    "sqlsaber.cli.models:models_app",
-    name="models",
-    help="Select and manage models",
-)
-app.command(
-    "sqlsaber.cli.theme:theme_app",
-    name="theme",
-    help="Manage theme settings",
-)
-app.command(
-    "sqlsaber.cli.threads:threads_app",
-    name="threads",
-    help="Manage SQLsaber threads",
-)
+
+for _target, _name, _help in _LAZY_SUBCOMMANDS:
+    app.command(_target, name=_name, help=_help)
+
+_LAZY_SUBCOMMAND_NAMES = frozenset(name for _, name, _ in _LAZY_SUBCOMMANDS)
 
 
 @app.meta.default
@@ -481,4 +468,9 @@ def query(
 
 def main():
     """Entry point for the CLI application."""
+    argv = sys.argv[1:]
+    if argv and argv[0] in _LAZY_SUBCOMMAND_NAMES:
+        from sqlsaber.config.logging import setup_logging
+
+        setup_logging()
     app()

--- a/src/sqlsaber/config/logging.py
+++ b/src/sqlsaber/config/logging.py
@@ -8,6 +8,8 @@ Defaults:
 - JSON logs to a rotating file under the user log directory.
 - Optional pretty console logs when `SQLSABER_DEBUG=1` or
   `SQLSABER_LOG_TO_STDERR=1`.
+- Until `setup_logging()` runs, events are discarded. Unconfigured
+  structlog would otherwise print to stdout.
 
 Environment variables:
 - `SQLSABER_LOG_LEVEL` (default: INFO)
@@ -33,6 +35,7 @@ import platformdirs
 import structlog
 
 _CONFIGURED = False
+_SILENCED = False
 
 
 def _to_bool(value: str | None, default: bool = False) -> bool:
@@ -49,11 +52,35 @@ def default_log_file() -> Path:
     return default_log_dir() / "sqlsaber.log"
 
 
+def _silence_unconfigured_logging() -> None:
+    """Discard events until ``setup_logging()`` attaches handlers.
+
+    structlog's default PrintLogger writes to stdout. CLI modules log
+    before the TUI path calls ``setup_logging()``, so that default leaks
+    operational events onto the terminal.
+    """
+    global _SILENCED
+    if _CONFIGURED or _SILENCED:
+        return
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.format_exc_info,
+        ],
+        logger_factory=structlog.ReturnLoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+    _SILENCED = True
+
+
 def get_logger(name: Optional[str] = None) -> structlog.BoundLogger:
     """Return a structlog logger bound to `name`.
 
     Prefer using this over the stdlib `logging.getLogger` in new code.
     """
+    if not _CONFIGURED:
+        _silence_unconfigured_logging()
     return structlog.get_logger(name)
 
 

--- a/src/sqlsaber/config/logging.py
+++ b/src/sqlsaber/config/logging.py
@@ -8,8 +8,7 @@ Defaults:
 - JSON logs to a rotating file under the user log directory.
 - Optional pretty console logs when `SQLSABER_DEBUG=1` or
   `SQLSABER_LOG_TO_STDERR=1`.
-- Until `setup_logging()` runs, events are discarded. Unconfigured
-  structlog would otherwise print to stdout.
+- Until `setup_logging()` runs, events are discarded.
 
 Environment variables:
 - `SQLSABER_LOG_LEVEL` (default: INFO)
@@ -53,12 +52,6 @@ def default_log_file() -> Path:
 
 
 def _silence_unconfigured_logging() -> None:
-    """Discard events until ``setup_logging()`` attaches handlers.
-
-    structlog's default PrintLogger writes to stdout. CLI modules log
-    before the TUI path calls ``setup_logging()``, so that default leaks
-    operational events onto the terminal.
-    """
     global _SILENCED
     if _CONFIGURED or _SILENCED:
         return
@@ -79,8 +72,6 @@ def get_logger(name: Optional[str] = None) -> structlog.BoundLogger:
 
     Prefer using this over the stdlib `logging.getLogger` in new code.
     """
-    if not _CONFIGURED:
-        _silence_unconfigured_logging()
     return structlog.get_logger(name)
 
 
@@ -226,3 +217,5 @@ __all__ = [
     "default_log_dir",
     "default_log_file",
 ]
+
+_silence_unconfigured_logging()

--- a/tests/test_cli/test_quiet_cli_logs.py
+++ b/tests/test_cli/test_quiet_cli_logs.py
@@ -1,0 +1,57 @@
+"""Management commands must not print structured logs to the terminal."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _saber_env(tmp_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    home = tmp_path / "home"
+    home.mkdir()
+    env["HOME"] = str(home)
+    env["XDG_CONFIG_HOME"] = str(tmp_path / "config")
+    env["XDG_DATA_HOME"] = str(tmp_path / "data")
+    env["XDG_STATE_HOME"] = str(tmp_path / "state")
+    env["SQLSABER_LOG_FILE"] = str(tmp_path / "sqlsaber.log")
+    env.pop("SQLSABER_DEBUG", None)
+    env.pop("SQLSABER_LOG_TO_STDERR", None)
+    return env
+
+
+def _run_saber(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "sqlsaber", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_saber_env(tmp_path),
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "event", "visible"),
+    [
+        (("db", "list"), "db.list.start", "No database connections configured"),
+        (("auth", "status"), "auth.status.start", "Authentication Status"),
+        (("threads", "list"), "threads.cli.list.start", "No threads found"),
+    ],
+)
+def test_management_commands_keep_structlog_off_the_terminal(
+    tmp_path: Path, args: tuple[str, ...], event: str, visible: str
+) -> None:
+    result = _run_saber(tmp_path, *args)
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert visible in output
+    assert event not in result.stdout
+    assert event not in result.stderr
+    assert "[info" not in result.stdout
+    assert "[info" not in result.stderr
+    logged = (tmp_path / "sqlsaber.log").read_text(encoding="utf-8")
+    assert f'"event": "{event}"' in logged

--- a/tests/test_cli/test_quiet_cli_logs.py
+++ b/tests/test_cli/test_quiet_cli_logs.py
@@ -1,5 +1,3 @@
-"""Management commands must not print structured logs to the terminal."""
-
 from __future__ import annotations
 
 import os

--- a/tests/test_config/test_logging.py
+++ b/tests/test_config/test_logging.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 
 
-def _run_isolated(code: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+def _run_isolated(
+    code: str, *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     merged = os.environ.copy()
     if env:
         merged.update(env)

--- a/tests/test_config/test_logging.py
+++ b/tests/test_config/test_logging.py
@@ -1,0 +1,83 @@
+"""Logging must stay off the terminal unless the user opts into console output."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_isolated(code: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    if not env or "SQLSABER_DEBUG" not in env:
+        merged.pop("SQLSABER_DEBUG", None)
+    if not env or "SQLSABER_LOG_TO_STDERR" not in env:
+        merged.pop("SQLSABER_LOG_TO_STDERR", None)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=merged,
+    )
+
+
+def test_unconfigured_logger_does_not_print_to_stdout_or_stderr() -> None:
+    result = _run_isolated(
+        """
+from sqlsaber.config.logging import get_logger, is_configured
+
+assert is_configured() is False
+get_logger("probe").info("probe.must_not_print", count=1)
+print("OK")
+"""
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "probe.must_not_print" not in result.stdout
+    assert "probe.must_not_print" not in result.stderr
+    assert "OK" in result.stdout
+
+
+def test_setup_logging_writes_json_to_file_not_the_terminal(tmp_path: Path) -> None:
+    log_file = tmp_path / "sqlsaber.log"
+    result = _run_isolated(
+        """
+from sqlsaber.config.logging import get_logger, setup_logging
+
+setup_logging(force=True)
+get_logger("probe").info("probe.file_only", count=2)
+print("OK")
+""",
+        env={"SQLSABER_LOG_FILE": str(log_file)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "probe.file_only" not in result.stdout
+    assert "probe.file_only" not in result.stderr
+    assert "OK" in result.stdout
+    logged = log_file.read_text(encoding="utf-8")
+    assert '"event": "probe.file_only"' in logged
+    assert '"count": 2' in logged
+
+
+def test_debug_flag_prints_console_logs_to_stderr(tmp_path: Path) -> None:
+    log_file = tmp_path / "sqlsaber.log"
+    result = _run_isolated(
+        """
+from sqlsaber.config.logging import get_logger, setup_logging
+
+setup_logging(force=True)
+get_logger("probe").info("probe.debug_console")
+print("OK")
+""",
+        env={
+            "SQLSABER_LOG_FILE": str(log_file),
+            "SQLSABER_DEBUG": "1",
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "probe.debug_console" not in result.stdout
+    assert "probe.debug_console" in result.stderr
+    assert "OK" in result.stdout

--- a/tests/test_config/test_logging.py
+++ b/tests/test_config/test_logging.py
@@ -1,5 +1,3 @@
-"""Logging must stay off the terminal unless the user opts into console output."""
-
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`saber db list` and the other management commands print structlog lines such as `db.list.start` on stdout. Those events belong in the JSON log file, not on the terminal.

PR #249 moved `setup_logging()` off process start so the TUI can paint before structlog loads. Management commands never call it, so unconfigured structlog uses PrintLogger and writes to stdout.

## Scope

- Importing `sqlsaber.config.logging` discards events until `setup_logging()` attaches handlers. `get_logger()` does not configure structlog.
- `main()` calls `setup_logging()` when argv selects a lazy subcommand (`auth`, `db`, `knowledge`, `models`, `theme`, `threads`).
- Tests cover the unconfigured logger, file-only vs `SQLSABER_DEBUG` console, and `db list` / `auth status` / `threads list`.

Out of scope: TUI first-paint timing, and changing which events the commands emit.

## Tradeoffs

A per-command `setup_logging()` call would restore file logs only at the sites we remember. Discarding unconfigured events in the logging module covers SDK, thread storage, and any new command that logs before setup.

`saber --help` still does not open the log file. Interactive first paint still delays `setup_logging()` so structlog stays off that path.

## Blast Radius

CLI management commands, `get_logger()` callers that never call `setup_logging()`, and the TUI path that already delays setup until after first paint. Console output still requires `SQLSABER_DEBUG=1` or `SQLSABER_LOG_TO_STDERR=1`.

## Verification

- Reproduced `saber db list` printing `db.list.start` / `db.list.complete` on stdout. Same leak on `db add`, `auth status`, `threads list`, `knowledge list`, and `models list`.
- After the fix, those commands print only the user table or status text. The same events land in the JSON log file.
- `env -u FORCE_COLOR uv run python -m pytest -q`: 1645 passed, 6 skipped.
- Targeted re-run after the import-time discard: 28 passed.
- `time uv run saber --help`: 0.187s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f2e502a-703c-4637-bb50-5142a6cd7d64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f2e502a-703c-4637-bb50-5142a6cd7d64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

